### PR TITLE
Restrict mapping helpers to internal scope

### DIFF
--- a/docs/diff_log/diff_internal_access_20250824.md
+++ b/docs/diff_log/diff_internal_access_20250824.md
@@ -1,0 +1,3 @@
+# diff_internal_access_20250824
+- MappingRegistry and KeyValueTypeMapping classes were restricted to `internal` to reduce public surface.
+- ModelValidationResult class was likewise made `internal` for encapsulation.

--- a/docs/diff_log/diff_internal_access_20250825.md
+++ b/docs/diff_log/diff_internal_access_20250825.md
@@ -1,0 +1,6 @@
+# diff_internal_access_20250825
+
+## Summary
+- SpecificRecordGenerator restricted to internal visibility
+- KeyValueSchemaInfo limited to internal scope
+- TableCacheOptions and TableCacheEntry hidden behind internal

--- a/src/Cache/Configuration/TableCacheOptions.cs
+++ b/src/Cache/Configuration/TableCacheOptions.cs
@@ -2,12 +2,12 @@ namespace Kafka.Ksql.Linq.Cache.Configuration;
 
 using System.Collections.Generic;
 
-public class TableCacheOptions
+internal class TableCacheOptions
 {
     public List<TableCacheEntry> Entries { get; set; } = new();
 }
 
-public class TableCacheEntry
+internal class TableCacheEntry
 {
     public string Entity { get; set; } = string.Empty;
     public string SourceTopic { get; set; } = string.Empty;

--- a/src/Core/Modeling/ModelValidationResult.cs
+++ b/src/Core/Modeling/ModelValidationResult.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 namespace Kafka.Ksql.Linq.Core.Modeling;
-public class ModelValidationResult
+internal class ModelValidationResult
 {
     public bool HasErrors { get; set; }
     public Dictionary<Type, List<string>> EntityErrors { get; set; } = new();

--- a/src/Mapping/KeyValueTypeMapping.cs
+++ b/src/Mapping/KeyValueTypeMapping.cs
@@ -15,7 +15,7 @@ using System.Globalization;
 /// <summary>
 /// Holds generated key/value types and their associated PropertyMeta information.
 /// </summary>
-public class KeyValueTypeMapping
+internal class KeyValueTypeMapping
 {
     public const char KeySep = '\u0000';
     public Type KeyType { get; set; } = default!;

--- a/src/Mapping/MappingRegistry.cs
+++ b/src/Mapping/MappingRegistry.cs
@@ -19,7 +19,7 @@ namespace Kafka.Ksql.Linq.Mapping;
 /// Provides registration and lookup of dynamically generated key/value types
 /// based on PropertyMeta information.
 /// </summary>
-public class MappingRegistry
+internal class MappingRegistry
 {
     private readonly ConcurrentDictionary<Type, KeyValueTypeMapping> _mappings = new();
     private readonly ModuleBuilder _moduleBuilder;

--- a/src/Mapping/SpecificRecordGenerator.cs
+++ b/src/Mapping/SpecificRecordGenerator.cs
@@ -14,7 +14,7 @@ namespace Kafka.Ksql.Linq.Mapping;
 /// <summary>
 /// Generate ISpecificRecord implementations from POCO types at runtime.
 /// </summary>
-public static class SpecificRecordGenerator
+internal static class SpecificRecordGenerator
 {
     private static readonly ConcurrentDictionary<string, Lazy<Type>> _cache = new();
     private static readonly ModuleBuilder _moduleBuilder;

--- a/src/Query/Schema/KeyValueSchemaInfo.cs
+++ b/src/Query/Schema/KeyValueSchemaInfo.cs
@@ -6,7 +6,7 @@ namespace Kafka.Ksql.Linq.Query.Schema;
 /// <summary>
 /// クエリによって生成されるKey/Value構造の定義
 /// </summary>
-public class KeyValueSchemaInfo
+internal class KeyValueSchemaInfo
 {
     public string ClassName { get; set; } = string.Empty;
     public string Namespace { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
- limit SpecificRecordGenerator to internal
- hide unused KeyValueSchemaInfo
- conceal TableCacheOptions and TableCacheEntry

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68ab2141a3a48327bb79032245df914b