### PR TITLE
docs: streamline API reference

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -10,9 +10,7 @@
 - [エラーハンドリング](#%E3%82%A8%E3%83%A9%E3%83%BC%E3%83%8F%E3%83%B3%E3%83%89%E3%83%AA%E3%83%B3%E3%82%B0)
 - [コアインタフェース](#%E3%82%B3%E3%82%A2%E3%82%A4%E3%83%B3%E3%82%BF%E3%83%95%E3%82%A7%E3%83%BC%E3%82%B9)
 - [構成オプションとビルダー](#%E6%A7%8B%E6%88%90%E3%82%AA%E3%83%97%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%A8%E3%83%93%E3%83%AB%E3%83%80%E3%83%BC)
-- [状態監視・内部機構](#%E7%8A%B6%E6%85%8B%E7%9B%A3%E8%A6%96%E3%83%BB%E5%86%85%E9%83%A8%E6%A9%9F%E6%A7%8B)
 - [既定値の参照](#%E6%97%A2%E5%AE%9A%E5%80%A4%E3%81%AE%E5%8F%82%E7%85%A7)
-- [各 API の備考](#%E5%90%84-api-%E3%81%AE%E5%82%99%E8%80%83)
 
 ## 属性 (Attributes)
 
@@ -65,42 +63,6 @@ public class Order
 1. POCO へ `[KsqlTopic]` と `[KsqlKey]` を付与。
 2. `OnModelCreating` では `Entity<T>()` の登録のみ行う。
 3. テストでキー順序やトピック設定を確認。
-
-#### MappingManager との連携
-
-`MappingManager` を利用して key/value を抽出する例です。
-
-```csharp
-var ctx = new MyKsqlContext(options);
-var mapping = ctx.MappingManager;
-var entity = new Order { Id = 1, Amount = 100 };
-var (key, value) = mapping.ExtractKeyValue(entity);
-await ctx.AddAsync(entity, headers: new Dictionary<string, string> { ["is_dummy"] = "true" });
-```
-
-##### ベストプラクティス
-
-- エンティティ登録は `OnModelCreating` 内で一括定義。
-- `MappingManager` は DI コンテナで共有し、新規生成を避ける。
-
-##### 追加検討事項
-
-- `[KsqlTopic]` で指定できない詳細設定の扱いを検討中。
-- キャッシュ戦略の確定が必要。
-
-##### サンプル実装での気づき
-
-- `AddSampleModels` 拡張で登録漏れ防止。
-- 複合キーは `Dictionary<string, object>` として抽出。
-- `Dictionary<string,string>` は Avro の `map` で文字列のみサポート、`null` 不可。
-- `decimal` プロパティは `DecimalPrecisionConfig` に従う Avro `bytes` (logicalType: decimal) へ変換。
-- 複数エンティティ登録ヘルパーで `OnModelCreating` の記述量を削減。
-
-##### AddAsync 統一に伴うポイント
-
-- メッセージ送信 API は `AddAsync` に一本化。旧 `ProduceAsync` は廃止予定。
-- LINQ クエリ解析から `MappingManager.ExtractKeyValue()` を経由し `AddAsync` を呼び出す流れをサンプル化。
-- 詳細は [architecture/query_to_addasync_sample.md](architecture/query_to_addasync_sample.md) を参照。
 
 ### ToQuery チェーン
 
@@ -209,23 +171,6 @@ await foreach (var rec in ctx.Dlq.ReadAsync())
 
 `KsqlDslOptions.DlqTopicName` は既定で `"dead-letter-queue"` です。
 
-## 状態監視・内部機構
-
-| API | 説明 | 実装状態 |
-|-----|------|---------|
-| `ReadyStateMonitor` | トピック同期状態の監視 | ✅ |
-| `CacheBinding` | Kafka トピックと Cache の双方向バインディング | ✅ |
-| `SchemaRegistryClient` | スキーマ管理クライアント | ✅ |
-| `ResilientAvroSerializerManager` | Avro 操作のリトライ管理 | ✅ |
-
 ## 既定値の参照
 
 - 既定値一覧は [docs_configuration_reference.md](docs_configuration_reference.md) を参照してください。
-
-## 各 API の備考
-
-- `IEventSet<T>.WithRetry()` の実装例は `EventSet.cs` にあります。
-- `OnError` の拡張は `EventSetErrorHandlingExtensions.cs` で提供。
-- 手動コミットの利用例は [manual_commit.md](old/manual_commit.md) を参照。
-- `StartErrorHandling()` → `.Map()` → `.WithRetry()` の流れで細かいエラー処理を構築できます。
-- `AvroOperationRetrySettings` で Schema Registry 操作のリトライ方針を制御します。

--- a/docs/diff_log/diff_api_reference_cleanup_20250824.md
+++ b/docs/diff_log/diff_api_reference_cleanup_20250824.md
@@ -1,0 +1,8 @@
+# diff_api_reference_cleanup_20250824
+
+## Summary
+- Removed MappingManager sample and related internal notes from API Reference.
+- Dropped sections on internal monitoring and API implementation remarks to keep user-focused content.
+
+## Testing
+- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`


### PR DESCRIPTION
## Summary
- remove MappingManager sample and internal notes from API reference
- drop internal monitoring and implementation remark sections

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68ab90fabaa083278375d43fc66b3273