### PR TITLE
Add chart DSL checklist tests

### DIFF
--- a/docs/diff_log/diff_chart_rollup_checks_20250826.md
+++ b/docs/diff_log/diff_chart_rollup_checks_20250826.md
@@ -1,0 +1,3 @@
+- add tests verifying 5m live derives from 1m live and 5m final composes with bar_prev_1m
+- ensure week anchor metadata propagates through derivation planner
+- confirm month windows use `1mo` topic suffix

--- a/docs/diff_log/diff_chart_ut_tests_20250826.md
+++ b/docs/diff_log/diff_chart_ut_tests_20250826.md
@@ -1,0 +1,3 @@
+# chart UT tests 2025-08-26
+- add ChartChecklistTests covering tumbling windows across minute/hour/day/week/month with proper TimeFrame→Tumbling order and multi-granularity arrays.
+- add QueryAdapter tests via DerivationPlanner verifying hb/prev generation, live/final separation, and roll-up naming as `bar_<tf>_*`.

--- a/src/Query/Adapters/QueryAdapter.cs
+++ b/src/Query/Adapters/QueryAdapter.cs
@@ -20,7 +20,7 @@ internal static class QueryAdapter
             {
                 Role.AggFinal => $"Window(TUMBLING,{e.Timeframe.Value}{e.Timeframe.Unit})+Emit(FINAL+GRACE)",
                 Role.Live => $"Window(TUMBLING,{e.Timeframe.Value}{e.Timeframe.Unit})+Emit(CHANGES)",
-                Role.Final => "Compose(AggFinal⟂Prev1m)",
+                Role.Final => "Compose(AggFinal⟂BarPrev1m)",
                 _ => string.Empty
             };
             var projector = e.Role == Role.AggFinal ? "BucketStartFromWindowStart" : null;

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -34,7 +34,8 @@ internal static class DerivationPlanner
                 Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
-                BasedOnSpec = qao.BasedOn
+                BasedOnSpec = qao.BasedOn,
+                WeekAnchor = qao.WeekAnchor
             };
             entities.Add(agg); dag.AddNode(aggId);
 
@@ -47,7 +48,8 @@ internal static class DerivationPlanner
                 ValueShape = valueShapes,
                 InputHint = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? "bar_1m_final" : "bar_1m_live",
                 SyncHint = tf.Unit == "m" && tf.Value == 1 ? "HB_1m" : null,
-                BasedOnSpec = qao.BasedOn
+                BasedOnSpec = qao.BasedOn,
+                WeekAnchor = qao.WeekAnchor
             };
             entities.Add(live); dag.AddNode(liveId);
 
@@ -60,7 +62,8 @@ internal static class DerivationPlanner
                 ValueShape = valueShapes,
                 InputHint = tf.Unit == "m" && tf.Value == 1 ? "bar_1m_agg_final ⟂ bar_prev_1m" : $"bar_{tfStr}_agg_final ⟂ bar_prev_1m",
                 SyncHint = tf.Unit == "m" && tf.Value == 1 ? "HB_1m" : null,
-                BasedOnSpec = qao.BasedOn
+                BasedOnSpec = qao.BasedOn,
+                WeekAnchor = qao.WeekAnchor
             };
             entities.Add(final); dag.AddNode(finalId);
 
@@ -80,7 +83,8 @@ internal static class DerivationPlanner
                     Timeframe = tf,
                     KeyShape = keyShapes,
                     ValueShape = valueShapes,
-                    BasedOnSpec = qao.BasedOn
+                    BasedOnSpec = qao.BasedOn,
+                    WeekAnchor = qao.WeekAnchor
                 };
                 entities.Add(prev); dag.AddNode(prev.Id);
 
@@ -92,7 +96,8 @@ internal static class DerivationPlanner
                     KeyShape = keyShapes,
                     ValueShape = Array.Empty<ColumnShape>(),
                     MaterializationHint = MaterializationHint.Stream,
-                    BasedOnSpec = qao.BasedOn
+                    BasedOnSpec = qao.BasedOn,
+                    WeekAnchor = qao.WeekAnchor
                 };
                 entities.Add(hb); dag.AddNode(hb.Id);
             }

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -23,9 +23,9 @@ internal static class DerivationPlanner
         foreach (var tf in qao.Windows)
         {
             var tfStr = $"{tf.Value}{tf.Unit}";
-            var aggId = $"agg_final_{tfStr}";
-            var liveId = $"live_{tfStr}";
-            var finalId = $"final_{tfStr}";
+            var aggId = $"bar_{tfStr}_agg_final";
+            var liveId = $"bar_{tfStr}_live";
+            var finalId = $"bar_{tfStr}_final";
 
             var agg = new DerivedEntity
             {
@@ -45,7 +45,7 @@ internal static class DerivationPlanner
                 Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
-                InputHint = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? "1mFinal" : "1mLive",
+                InputHint = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? "bar_1m_final" : "bar_1m_live",
                 SyncHint = tf.Unit == "m" && tf.Value == 1 ? "HB_1m" : null,
                 BasedOnSpec = qao.BasedOn
             };
@@ -58,24 +58,24 @@ internal static class DerivationPlanner
                 Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
-                InputHint = tf.Unit == "m" && tf.Value == 1 ? "1mAggFinal ⟂ prev_1m" : $"{tfStr}AggFinal ⟂ prev_1m",
+                InputHint = tf.Unit == "m" && tf.Value == 1 ? "bar_1m_agg_final ⟂ bar_prev_1m" : $"bar_{tfStr}_agg_final ⟂ bar_prev_1m",
                 SyncHint = tf.Unit == "m" && tf.Value == 1 ? "HB_1m" : null,
                 BasedOnSpec = qao.BasedOn
             };
             entities.Add(final); dag.AddNode(finalId);
 
             dag.AddEdge(aggId, finalId);
-            dag.AddEdge("prev_1m", finalId);
+            dag.AddEdge("bar_prev_1m", finalId);
             if (tf.Unit == "wk")
-                dag.AddEdge("final_1m", liveId);
+                dag.AddEdge("bar_1m_final", liveId);
             else if (!(tf.Unit == "m" && tf.Value == 1))
-                dag.AddEdge("live_1m", liveId);
+                dag.AddEdge("bar_1m_live", liveId);
 
             if (tf.Unit == "m" && tf.Value == 1 && prev == null)
             {
                 prev = new DerivedEntity
                 {
-                    Id = "prev_1m",
+                    Id = "bar_prev_1m",
                     Role = Role.Prev1m,
                     Timeframe = tf,
                     KeyShape = keyShapes,

--- a/src/Query/Analysis/DerivedEntity.cs
+++ b/src/Query/Analysis/DerivedEntity.cs
@@ -32,4 +32,5 @@ internal class DerivedEntity
     public string? InputHint { get; init; }
     public string? SyncHint { get; init; }
     public BasedOnSpec BasedOnSpec { get; init; } = new(new List<string>(), string.Empty, string.Empty, string.Empty);
+    public DayOfWeek WeekAnchor { get; init; } = DayOfWeek.Monday;
 }

--- a/src/Query/Analysis/TumblingAnalyzer.cs
+++ b/src/Query/Analysis/TumblingAnalyzer.cs
@@ -45,7 +45,8 @@ internal static class TumblingAnalyzer
             Keys = keys,
             Projection = projection,
             PocoShape = pocoShape,
-            BasedOn = basedOn
+            BasedOn = basedOn,
+            WeekAnchor = res.WeekAnchor
         };
     }
 

--- a/src/Query/Analysis/TumblingQao.cs
+++ b/src/Query/Analysis/TumblingQao.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Kafka.Ksql.Linq.Query.Analysis;
@@ -20,4 +21,5 @@ internal class TumblingQao
     public IReadOnlyList<string> Projection { get; init; } = new List<string>();
     public IReadOnlyList<ColumnShape> PocoShape { get; init; } = new List<ColumnShape>();
     public BasedOnSpec BasedOn { get; init; } = new(new List<string>(), string.Empty, string.Empty, string.Empty);
+    public DayOfWeek WeekAnchor { get; init; } = DayOfWeek.Monday;
 }

--- a/src/Query/Pipeline/ExpressionAnalysisResult.cs
+++ b/src/Query/Pipeline/ExpressionAnalysisResult.cs
@@ -55,11 +55,11 @@ internal class ExpressionAnalysisResult
             var liveInput = tf switch
             {
                 "1m" => "10sAgg",
-                "1wk" => "1mFinal",
-                _ => "1mLive"
+                "1wk" => "bar_1m_final",
+                _ => "bar_1m_live"
             };
             md = md.WithProperty($"input/{tf}Live", liveInput);
-            md = md.WithProperty($"input/{tf}Final", $"{tf}AggFinal ⟂ prev_1m");
+            md = md.WithProperty($"input/{tf}Final", $"bar_{tf}_agg_final ⟂ bar_prev_1m");
         }
         return md;
     }

--- a/tests/Query/Analysis/ChartChecklistTests.cs
+++ b/tests/Query/Analysis/ChartChecklistTests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Core.Modeling;
+using Kafka.Ksql.Linq.Query.Adapters;
+using Kafka.Ksql.Linq.Query.Analysis;
+using Kafka.Ksql.Linq.Query.Dsl;
+using Kafka.Ksql.Linq.Query.Pipeline;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Analysis;
+
+public class ChartChecklistTests
+{
+    private class Rate
+    {
+        public string Broker { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
+        public DateTime Timestamp { get; set; }
+        public decimal Open { get; set; }
+        public decimal High { get; set; }
+        public decimal Low { get; set; }
+        public decimal Close { get; set; }
+    }
+
+    private class MarketSchedule
+    {
+        public string Broker { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
+        public DateTime Open { get; set; }
+        public DateTime Close { get; set; }
+        public DateTime MarketDate { get; set; }
+    }
+
+    [Fact]
+    public void Expression_Collects_Windows_TimeFrame_And_GroupByKeys()
+    {
+        Expression expr = ((Expression<Func<KsqlQueryable<Rate>, object>>)(q => q
+            .TimeFrame<MarketSchedule>(
+                (r, s) =>
+                    r.Broker == s.Broker &&
+                    r.Symbol == s.Symbol &&
+                    s.Open <= r.Timestamp &&
+                    r.Timestamp < s.Close,
+                s => s.MarketDate)
+            .Tumbling(r => r.Timestamp,
+                new[] { 1, 5, 15, 30 },
+                new[] { 1, 4, 8 },
+                new[] { 1, 7 },
+                new[] { 1, 12 },
+                null,
+                null)
+            .GroupBy(r => new { r.Broker, r.Symbol, BucketStart = r.Timestamp })
+            .Select(g => g))).Body;
+
+        var visitor = new MethodCallCollectorVisitor();
+        visitor.Visit(expr);
+        var res = visitor.Result;
+
+        Assert.Equal(new[] { "1m", "5m", "15m", "30m", "1h", "4h", "8h", "1d", "7d", "1mo", "12mo" }, res.Windows.ToArray());
+        Assert.Equal(new[] { "Broker", "Symbol" }, res.BasedOnJoinKeys.ToArray());
+        Assert.Equal(res.TimeKey, res.BasedOnOpen);
+        Assert.Equal("Close", res.BasedOnClose);
+        Assert.Equal("MarketDate", res.BasedOnDayKey);
+        Assert.Equal(new[] { "Broker", "Symbol", "BucketStart" }, res.GroupByKeys.ToArray());
+    }
+
+    [Fact]
+    public void Expression_Collects_Month_And_Week_Windows()
+    {
+        var q = Expression.Parameter(typeof(KsqlQueryable<Rate>), "q");
+        var r = Expression.Parameter(typeof(Rate), "r");
+        var s = Expression.Parameter(typeof(MarketSchedule), "s");
+        var tfMethod = typeof(KsqlQueryable<Rate>).GetMethods()
+            .First(m => m.Name == "TimeFrame").MakeGenericMethod(typeof(MarketSchedule));
+        var tfCall = Expression.Call(q, tfMethod,
+            Expression.Lambda(
+                Expression.AndAlso(
+                    Expression.AndAlso(
+                        Expression.Equal(Expression.Property(r, nameof(Rate.Broker)), Expression.Property(s, nameof(MarketSchedule.Broker))),
+                        Expression.Equal(Expression.Property(r, nameof(Rate.Symbol)), Expression.Property(s, nameof(MarketSchedule.Symbol)))),
+                    Expression.AndAlso(
+                        Expression.LessThanOrEqual(Expression.Property(s, nameof(MarketSchedule.Open)), Expression.Property(r, nameof(Rate.Timestamp))),
+                        Expression.LessThan(Expression.Property(r, nameof(Rate.Timestamp)), Expression.Property(s, nameof(MarketSchedule.Close))))
+                ), r, s),
+            Expression.Lambda(Expression.Convert(Expression.Property(s, nameof(MarketSchedule.MarketDate)), typeof(object)), s));
+        var tumbling = typeof(IScheduledScope<Rate>).GetMethods()
+            .First(m => m.Name == "Tumbling" && m.GetParameters().Length == 7);
+        var call = Expression.Call(tfCall, tumbling,
+            Expression.Lambda(Expression.Property(r, nameof(Rate.Timestamp)), r),
+            Expression.Constant(null, typeof(int[])),
+            Expression.Constant(null, typeof(int[])),
+            Expression.Constant(null, typeof(int[])),
+            Expression.Constant(new[] { 1 }),
+            Expression.Constant(DayOfWeek.Monday, typeof(DayOfWeek?)),
+            Expression.Constant(null, typeof(TimeSpan?))
+        );
+        var visitor = new MethodCallCollectorVisitor();
+        visitor.Visit(call);
+        var res = visitor.Result;
+
+        Assert.Contains("1mo", res.Windows);
+        Assert.Contains("1wk", res.Windows);
+        Assert.Equal(DayOfWeek.Monday, res.WeekAnchor);
+    }
+
+    private static T ExecuteInScope<T>(Func<T> func)
+    {
+        using (ModelCreatingScope.Enter())
+            return func();
+    }
+
+    [Fact]
+    public void DmlGenerator_Translates_Ohlc_Aggregates()
+    {
+        Expression<Func<IGrouping<int, Rate>, object>> expr = g => new
+        {
+            Open  = g.EarliestByOffset(x => x.Open),
+            High  = g.Max(x => x.High),
+            Low   = g.Min(x => x.Low),
+            Close = g.LatestByOffset(x => x.Close)
+        };
+
+        var generator = new DMLQueryGenerator();
+        var sql = ExecuteInScope(() => generator.GenerateAggregateQuery("rates", expr.Body));
+
+        Assert.Contains("EARLIEST_BY_OFFSET(Open) AS Open", sql);
+        Assert.Contains("MAX(High) AS High", sql);
+        Assert.Contains("MIN(Low) AS Low", sql);
+        Assert.Contains("LATEST_BY_OFFSET(Close) AS Close", sql);
+    }
+
+    [Fact]
+    public void QueryAdapter_Emits_Final_And_Live_Modes()
+    {
+        var qao = new TumblingQao
+        {
+            TimeKey = "Timestamp",
+            Windows = new List<Timeframe> { new(1, "m") },
+            Keys = new[] { "Broker", "Symbol", "BucketStart" },
+            Projection = new[] { "Broker", "Symbol", "BucketStart" },
+            PocoShape = new[]
+            {
+                new ColumnShape("Broker", typeof(string), false),
+                new ColumnShape("Symbol", typeof(string), false),
+                new ColumnShape("Timestamp", typeof(DateTime), false),
+                new ColumnShape("BucketStart", typeof(DateTime), false)
+            },
+            BasedOn = new BasedOnSpec(new[] { "Broker" }, "Open", "Close", "MarketDate")
+        };
+        var (entities, dag) = DerivationPlanner.Plan(qao);
+        var specs = QueryAdapter.Build(entities, dag);
+        Assert.Contains(entities, e => e.Id == "hb_1m" && e.Role == Role.Hb);
+        Assert.Contains(entities, e => e.Id == "bar_prev_1m" && e.Role == Role.Prev1m);
+        Assert.Equal("Window(TUMBLING,1m)+Emit(FINAL+GRACE)", specs.First(s => s.TargetId == "bar_1m_agg_final").Operation);
+        Assert.Equal("Window(TUMBLING,1m)+Emit(CHANGES)", specs.First(s => s.TargetId == "bar_1m_live").Operation);
+        var final = specs.First(s => s.TargetId == "bar_1m_final");
+        Assert.Contains("bar_prev_1m", final.Sources);
+        Assert.Equal("Compose(AggFinal⟂BarPrev1m)", final.Operation);
+    }
+
+    [Fact]
+    public void QueryAdapter_Rolls_Up_1m_To_1h()
+    {
+        var qao = new TumblingQao
+        {
+            TimeKey = "Timestamp",
+            Windows = new List<Timeframe> { new(1, "m"), new(1, "h") },
+            Keys = new[] { "Broker", "Symbol", "BucketStart" },
+            Projection = new[] { "Broker", "Symbol", "BucketStart" },
+            PocoShape = new[]
+            {
+                new ColumnShape("Broker", typeof(string), false),
+                new ColumnShape("Symbol", typeof(string), false),
+                new ColumnShape("Timestamp", typeof(DateTime), false),
+                new ColumnShape("BucketStart", typeof(DateTime), false)
+            },
+            BasedOn = new BasedOnSpec(new[] { "Broker" }, "Open", "Close", "MarketDate")
+        };
+        var (entities, dag) = DerivationPlanner.Plan(qao);
+        var specs = QueryAdapter.Build(entities, dag);
+        var liveHour = specs.First(s => s.TargetId == "bar_1h_live");
+        Assert.Contains("bar_1m_live", liveHour.Sources);
+        Assert.Equal("Window(TUMBLING,1h)+Emit(CHANGES)", liveHour.Operation);
+    }
+}
+

--- a/tests/Query/Builders/RollupBuilderTests.cs
+++ b/tests/Query/Builders/RollupBuilderTests.cs
@@ -87,7 +87,7 @@ public class RollupBuilderTests
     {
         var md = BuildMetadata();
         var sql = LiveBuilder.Build(md, "5m");
-        Assert.Contains("TABLE 1mLive WINDOW TUMBLING(5m)", sql);
+        Assert.Contains("TABLE bar_1m_live WINDOW TUMBLING(5m)", sql);
         Assert.DoesNotContain("HB_1m", sql);
     }
 
@@ -96,7 +96,7 @@ public class RollupBuilderTests
     {
         var md = BuildMetadata();
         var sql = FinalBuilder.Build(md, "5m");
-        Assert.Contains("COMPOSE(5mAggFinal ⟂ prev_1m)", sql);
+        Assert.Contains("COMPOSE(bar_5m_agg_final ⟂ bar_prev_1m)", sql);
         Assert.DoesNotContain("HB_1m", sql);
         var sql1 = FinalBuilder.Build(md, "1m");
         Assert.Contains("SYNC HB_1m", sql1);


### PR DESCRIPTION
## Summary
- expand tumbling DSL tests with multi-granularity windows and verified TimeFrame→Tumbling ordering
- adapt derivation planning and query adapter to emit `bar_<tf>_*` entities with heartbeat and prev links
- update roll-up and planner tests to align with new naming and week/month coverage

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68ad8e55fd448327b8c49afb1c546fa4