### PR TITLE
Handle optional key schema metadata in ksql DDL

### DIFF
--- a/docs/diff_log/diff_ksql_key_schema_optional_20250903.md
+++ b/docs/diff_log/diff_ksql_key_schema_optional_20250903.md
@@ -1,0 +1,3 @@
+# diff: key schema optional metadata (2025-09-03)
+- omit KEY_AVRO_SCHEMA_FULL_NAME when key schema is not supplied
+- still emit KEY_FORMAT='AVRO' and VALUE_AVRO_SCHEMA_FULL_NAME

--- a/src/Query/Builders/KsqlCreateStatementBuilder.cs
+++ b/src/Query/Builders/KsqlCreateStatementBuilder.cs
@@ -55,12 +55,9 @@ public static class KsqlCreateStatementBuilder
         sb.Append($"{createType} {streamName}");
         if (!string.IsNullOrWhiteSpace(keySchemaFullName) || !string.IsNullOrWhiteSpace(valueSchemaFullName))
         {
-            var withParts = new List<string> { $"KAFKA_TOPIC='{streamName}'" };
+            var withParts = new List<string> { $"KAFKA_TOPIC='{streamName}'", "KEY_FORMAT='AVRO'" };
             if (!string.IsNullOrWhiteSpace(keySchemaFullName))
-            {
-                withParts.Add("KEY_FORMAT='AVRO'");
                 withParts.Add($"KEY_AVRO_SCHEMA_FULL_NAME='{keySchemaFullName}'");
-            }
             withParts.Add("VALUE_FORMAT='AVRO'");
             if (!string.IsNullOrWhiteSpace(valueSchemaFullName))
                 withParts.Add($"VALUE_AVRO_SCHEMA_FULL_NAME='{valueSchemaFullName}'");

--- a/src/Query/Pipeline/DDLQueryGenerator.cs
+++ b/src/Query/Pipeline/DDLQueryGenerator.cs
@@ -65,10 +65,11 @@ internal class DDLQueryGenerator : GeneratorBase, IDDLQueryGenerator
             var replicas = schema.Replicas;
 
             var withParts = new List<string> { $"KAFKA_TOPIC='{topicName}'" };
-            if (hasKey && !string.IsNullOrWhiteSpace(schema.KeySchemaFullName))
+            if (hasKey)
             {
                 withParts.Add("KEY_FORMAT='AVRO'");
-                withParts.Add($"KEY_AVRO_SCHEMA_FULL_NAME='{schema.KeySchemaFullName}'");
+                if (!string.IsNullOrWhiteSpace(schema.KeySchemaFullName))
+                    withParts.Add($"KEY_AVRO_SCHEMA_FULL_NAME='{schema.KeySchemaFullName}'");
             }
             withParts.Add("VALUE_FORMAT='AVRO'");
             if (!string.IsNullOrWhiteSpace(schema.ValueSchemaFullName))
@@ -105,10 +106,11 @@ internal class DDLQueryGenerator : GeneratorBase, IDDLQueryGenerator
             var replicas = schema.Replicas;
 
             var withParts = new List<string> { $"KAFKA_TOPIC='{topicName}'" };
-            if (hasKey && !string.IsNullOrWhiteSpace(schema.KeySchemaFullName))
+            if (hasKey)
             {
                 withParts.Add("KEY_FORMAT='AVRO'");
-                withParts.Add($"KEY_AVRO_SCHEMA_FULL_NAME='{schema.KeySchemaFullName}'");
+                if (!string.IsNullOrWhiteSpace(schema.KeySchemaFullName))
+                    withParts.Add($"KEY_AVRO_SCHEMA_FULL_NAME='{schema.KeySchemaFullName}'");
             }
             withParts.Add("VALUE_FORMAT='AVRO'");
             if (!string.IsNullOrWhiteSpace(schema.ValueSchemaFullName))

--- a/tests/Query/Dsl/KsqlCreateStatementBuilderDslTests.cs
+++ b/tests/Query/Dsl/KsqlCreateStatementBuilderDslTests.cs
@@ -55,7 +55,7 @@ public class KsqlCreateStatementBuilderDslTests
             .Build();
 
         var sql = KsqlCreateStatementBuilder.Build("orders", model, null, "com.acme.Value");
-        Assert.DoesNotContain("KEY_FORMAT", sql);
+        Assert.Contains("KEY_FORMAT='AVRO'", sql);
         Assert.DoesNotContain("KEY_AVRO_SCHEMA_FULL_NAME", sql);
         Assert.Contains("VALUE_AVRO_SCHEMA_FULL_NAME='com.acme.Value'", sql);
         Assert.DoesNotContain("PARTITION BY", sql);

--- a/tests/Query/Pipeline/DDLQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/DDLQueryGeneratorTests.cs
@@ -92,7 +92,21 @@ public class DDLQueryGeneratorTests
         model.ValueSchemaFullName = "com.acme.Value";
         var generator = new DDLQueryGenerator();
         var query = ExecuteInScope(() => generator.GenerateCreateTable(new EntityModelDdlAdapter(model)));
+        Assert.Contains("KEY_FORMAT='AVRO'", query);
+        Assert.DoesNotContain("KEY_AVRO_SCHEMA_FULL_NAME", query);
         Assert.Contains("VALUE_FORMAT='AVRO'", query);
+        Assert.Contains("VALUE_AVRO_SCHEMA_FULL_NAME='com.acme.Value'", query);
+    }
+
+    [Fact]
+    public void GenerateCreateStream_EmitsKeyFormatWithoutKeySchema()
+    {
+        var model = CreateEntityModel();
+        model.ValueSchemaFullName = "com.acme.Value";
+        var generator = new DDLQueryGenerator();
+        var query = ExecuteInScope(() => generator.GenerateCreateStream(new EntityModelDdlAdapter(model)));
+        Assert.Contains("KEY_FORMAT='AVRO'", query);
+        Assert.DoesNotContain("KEY_AVRO_SCHEMA_FULL_NAME", query);
         Assert.Contains("VALUE_AVRO_SCHEMA_FULL_NAME='com.acme.Value'", query);
     }
 


### PR DESCRIPTION
## Summary
- omit KEY_AVRO_SCHEMA_FULL_NAME when no key schema is provided
- keep KEY_FORMAT='AVRO' and VALUE_AVRO_SCHEMA_FULL_NAME in generated DDL
- cover key schema absence in unit tests

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` *(fails: 16, passed: 460, skipped: 22)*

------
https://chatgpt.com/codex/tasks/task_e_68b82686833c83279cafafd28c97b7e6