### PR TITLE
feat: support generic key mappings

### DIFF
--- a/src/Mapping/MappingRegistry.cs
+++ b/src/Mapping/MappingRegistry.cs
@@ -46,7 +46,8 @@ internal class MappingRegistry
         Type pocoType,
         PropertyMeta[] keyProperties,
         PropertyMeta[] valueProperties,
-        string? topicName = null)
+        string? topicName = null,
+        bool genericKey = false)
     {
         if (_mappings.TryGetValue(pocoType, out var existing))
         {
@@ -61,11 +62,15 @@ internal class MappingRegistry
         var valueType = CreateType(ns, $"{baseName}-value", valueProperties);
 
         // Generate ISpecificRecord types for Avro deserialization
-        var avroKeyType = SpecificRecordGenerator.Generate(keyType);
+        Type? avroKeyType = null;
+        string? avroKeySchema = null;
+        if (!genericKey && keyProperties.Length > 0)
+        {
+            avroKeyType = SpecificRecordGenerator.Generate(keyType);
+            avroKeySchema = ((Avro.Specific.ISpecificRecord)Activator.CreateInstance(avroKeyType)!).Schema.ToString();
+        }
+
         var avroValueType = SpecificRecordGenerator.Generate(valueType);
-        var avroKeySchema = avroKeyType != null
-            ? ((Avro.Specific.ISpecificRecord)Activator.CreateInstance(avroKeyType)!).Schema.ToString()
-            : null;
         var avroValueSchema = ((Avro.Specific.ISpecificRecord)Activator.CreateInstance(avroValueType)!).Schema.ToString();
 
         var keyTypeProps = keyProperties
@@ -99,9 +104,10 @@ internal class MappingRegistry
     public KeyValueTypeMapping RegisterMeta(
         Type pocoType,
         (PropertyMeta[] KeyProperties, PropertyMeta[] ValueProperties) meta,
-        string? topicName = null)
+        string? topicName = null,
+        bool genericKey = false)
     {
-        return Register(pocoType, meta.KeyProperties, meta.ValueProperties, topicName);
+        return Register(pocoType, meta.KeyProperties, meta.ValueProperties, topicName, genericKey);
     }
 
     /// <summary>
@@ -109,7 +115,7 @@ internal class MappingRegistry
     /// Convenience wrapper so callers don't need to manually convert
     /// PropertyInfo to <see cref="PropertyMeta"/> arrays.
     /// </summary>
-    public KeyValueTypeMapping RegisterEntityModel(EntityModel model)
+    public KeyValueTypeMapping RegisterEntityModel(EntityModel model, bool genericKey = false)
     {
         if (model == null) throw new ArgumentNullException(nameof(model));
 
@@ -120,7 +126,7 @@ internal class MappingRegistry
             .Select(p => PropertyMeta.FromProperty(p))
             .ToArray();
 
-        return Register(model.EntityType, keyMeta, valueMeta, model.GetTopicName());
+        return Register(model.EntityType, keyMeta, valueMeta, model.GetTopicName(), genericKey);
     }
 
     /// <summary>
@@ -132,7 +138,8 @@ internal class MappingRegistry
         Type resultType,
         KsqlQueryModel model,
         PropertyInfo[] keyProperties,
-        string? topicName = null)
+        string? topicName = null,
+        bool genericKey = false)
     {
         if (resultType == null) throw new ArgumentNullException(nameof(resultType));
         if (model == null) throw new ArgumentNullException(nameof(model));
@@ -151,7 +158,7 @@ internal class MappingRegistry
             .ToArray();
         var keyMeta = keyProperties.Select(p => PropertyMeta.FromProperty(p)).ToArray();
 
-        return Register(resultType, keyMeta, valueProps, topicName ?? resultType.Name.ToLowerInvariant());
+        return Register(resultType, keyMeta, valueProps, topicName ?? resultType.Name.ToLowerInvariant(), genericKey);
     }
 
     private static List<PropertyInfo> ExtractProjectionProperties(LambdaExpression? projection, Type resultType)

--- a/tests/Mapping/MappingRegistryTests.cs
+++ b/tests/Mapping/MappingRegistryTests.cs
@@ -47,5 +47,27 @@ public class MappingRegistryTests
             System.Array.Empty<PropertyMeta>());
         Assert.Empty(mapping.KeyProperties);
         Assert.Empty(mapping.ValueProperties);
+        Assert.Null(mapping.AvroKeyType);
+        Assert.Null(mapping.AvroKeySchema);
+    }
+
+    [Fact]
+    public void Register_GenericKey_SkipsAvroGeneration()
+    {
+        var registry = new MappingRegistry();
+        var keyProps = new[] { PropertyMeta.FromProperty(typeof(Sample).GetProperty(nameof(Sample.Id))!) };
+        var valueProps = typeof(Sample).GetProperties()
+            .Select(p => PropertyMeta.FromProperty(p))
+            .ToArray();
+
+        var mapping = registry.Register(
+            typeof(Sample),
+            keyProps,
+            valueProps,
+            genericKey: true);
+
+        Assert.Null(mapping.AvroKeyType);
+        Assert.Null(mapping.AvroKeySchema);
+        Assert.NotNull(mapping.AvroValueType);
     }
 }


### PR DESCRIPTION
## Summary
- allow registering mappings without Avro key generation
- handle generic keys via optional flag or empty key schema
- cover generic key behavior with tests

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` *(fails: Assert.Equal() failure)*
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b82684bd408327b849be3cbba69279