### PR TITLE
Expose WindowStart pseudo column in query DSL

### DIFF
--- a/docs/diff_log/diff_windowstart_extension_20250906.md
+++ b/docs/diff_log/diff_windowstart_extension_20250906.md
@@ -1,0 +1,3 @@
+# WindowStart extension
+- Added `WindowStart` method for grouping to select window start time.
+- Mapped `WindowStart` to KSQL `WINDOWSTART` pseudo column.

--- a/src/Extensions/WindowExtensions.cs
+++ b/src/Extensions/WindowExtensions.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Linq;
+
+namespace Kafka.Ksql.Linq
+{
+    public static class WindowExtensions
+    {
+        public static DateTime WindowStart<TSource, TKey>(this IGrouping<TKey, TSource> source)
+        {
+            throw new NotSupportedException("WindowStart is for expression translation only.");
+        }
+    }
+}

--- a/src/Query/Builders/Functions/KsqlFunctionRegistry.cs
+++ b/src/Query/Builders/Functions/KsqlFunctionRegistry.cs
@@ -125,6 +125,7 @@ internal static class KsqlFunctionRegistry
         ["Sha1"] = new("SHA1", 1),
         ["Sha256"] = new("SHA256", 1),
 
+        ["WindowStart"] = new("WINDOWSTART", 0, "WINDOWSTART"),
         ["RowTime"] = new("ROWTIME", 0),
         ["RowKey"] = new("ROWKEY", 0)
     };
@@ -171,7 +172,7 @@ internal static class KsqlFunctionRegistry
             ["URL"] = ["UrlExtractHost", "UrlExtractPath", "UrlExtractQuery", "UrlExtractProtocol"],
             ["GEO"] = ["GeoDistance", "AsGeoJson"],
             ["Crypto"] = ["Md5", "Sha1", "Sha256"],
-            ["Window"] = ["RowTime", "RowKey"]
+            ["Window"] = ["WindowStart", "RowTime", "RowKey"]
         };
     }
 

--- a/tests/Query/Pipeline/DMLQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/DMLQueryGeneratorTests.cs
@@ -99,6 +99,16 @@ public class DMLQueryGeneratorTests
     }
 
     [Fact]
+    public void GenerateAggregateQuery_WindowStart()
+    {
+        Expression<Func<IGrouping<int, TestEntity>, object>> expr = g => new { Start = g.WindowStart() };
+        var generator = new DMLQueryGenerator();
+        var query = ExecuteInScope(() => generator.GenerateAggregateQuery("t1", expr.Body));
+        Assert.Equal("SELECT WINDOWSTART AS Start FROM t1;", query);
+        File.AppendAllText("generated_queries.txt", query + Environment.NewLine);
+    }
+
+    [Fact]
     public void GenerateLinqQuery_FullClauseCombination()
     {
         IQueryable<TestEntity> src = new List<TestEntity>().AsQueryable();


### PR DESCRIPTION
## Summary
- allow LINQ group projections to call `WindowStart()`
- translate `WindowStart` to KSQL `WINDOWSTART`
- add regression test and diff log entry

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` *(fails: Duplicate 'TargetFrameworkAttribute')*
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj` *(fails: 'TableCache<T>' is inaccessible due to its protection level)*

------
https://chatgpt.com/codex/tasks/task_e_68bbba6f037483278409d99688cc2cc3