### PR TITLE
Fix alias for window start in select visitor

### DIFF
--- a/docs/diff_log/diff_select_expression_memberinit_alias_20250906.md
+++ b/docs/diff_log/diff_select_expression_memberinit_alias_20250906.md
@@ -1,0 +1,4 @@
+# diff: SelectExpressionVisitor MemberInit alias (2025-09-06)
+
+- Handle MemberInit expressions in SelectExpressionVisitor to apply property aliases.
+- Prevents reserved column name `WINDOWSTART` from appearing without alias in generated KSQL.

--- a/src/Query/Builders/SelectExpressionVisitor.cs
+++ b/src/Query/Builders/SelectExpressionVisitor.cs
@@ -71,7 +71,25 @@ internal class SelectExpressionVisitor : ExpressionVisitor
     protected override Expression VisitMemberInit(MemberInitExpression node)
     {
         ValidateGroupKeyDtoOrder(node);
-        return base.VisitMemberInit(node);
+        foreach (var binding in node.Bindings.OfType<MemberAssignment>())
+        {
+            var memberName = binding.Member.Name;
+            var expr = binding.Expression;
+            if (IsGroupKeyAccess(expr))
+            {
+                AddGroupKeyColumns();
+            }
+            else
+            {
+                var columnExpression = ProcessProjectionArgument(expr);
+                var alias = GenerateUniqueAlias(memberName);
+                if (columnExpression != alias)
+                    _columns.Add($"{columnExpression} AS {alias}");
+                else
+                    _columns.Add(columnExpression);
+            }
+        }
+        return node;
     }
 
     protected override Expression VisitMember(MemberExpression node)

--- a/tests/Query/Builders/SelectClauseBuilderTests.cs
+++ b/tests/Query/Builders/SelectClauseBuilderTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Linq.Expressions;
+using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Query.Builders;
 using Kafka.Ksql.Linq.Tests;
 using Xunit;
@@ -51,5 +52,19 @@ public class SelectClauseBuilderTests
         var sql = builder.Build(expr.Body);
 
         Assert.Equal("COUNT(*) AS OrderCount, SUM(Amount) AS TotalAmount", sql);
+    }
+
+    private class Bar
+    {
+        public DateTime BucketStart { get; set; }
+    }
+
+    [Fact]
+    public void Build_MemberInit_WindowStart_AliasesProperty()
+    {
+        Expression<Func<IGrouping<int, TestEntity>, Bar>> expr = g => new Bar { BucketStart = g.WindowStart() };
+        var builder = new SelectClauseBuilder();
+        var sql = builder.Build(expr.Body);
+        Assert.Equal("WINDOWSTART AS BucketStart", sql);
     }
 }

--- a/tests/Query/Dsl/KsqlCreateStatementBuilderDslTests.cs
+++ b/tests/Query/Dsl/KsqlCreateStatementBuilderDslTests.cs
@@ -17,7 +17,7 @@ public class KsqlCreateStatementBuilderDslTests
         var model = new KsqlQueryRoot()
             .From<Order>()
             .Join<Customer>((o, c) => o.CustomerId == c.Id)
-            .Within(5)
+            .Within(TimeSpan.FromSeconds(5))
             .Where((o, c) => c.IsActive)
             .Select((o, c) => new { o.Id, c.Name })
             .Build();
@@ -37,7 +37,7 @@ public class KsqlCreateStatementBuilderDslTests
         var model = new KsqlQueryRoot()
             .From<Order>()
             .Join<Customer>((o, c) => o.CustomerId == c.Id)
-            .Within(5)
+            .Within(TimeSpan.FromSeconds(5))
             .Select((o, c) => new { o.Id, c.Name })
             .Build();
 

--- a/tests/Query/Dsl/KsqlQueryable2Tests.cs
+++ b/tests/Query/Dsl/KsqlQueryable2Tests.cs
@@ -45,7 +45,7 @@ public class KsqlQueryable2Tests
     {
         var queryable = new KsqlQueryable<Order>()
             .Join<Payment>((o, p) => o.Id == p.OrderId)
-            .Within(300)
+            .Within(TimeSpan.FromSeconds(300))
             .Select((o, p) => new { o.Id, p.Paid });
         var model = queryable.Build();
         var sql = KsqlCreateStatementBuilder.Build("JoinTest", model);
@@ -71,7 +71,7 @@ public class KsqlQueryable2Tests
         var outside = new Order();
         var queryable = new KsqlQueryable<Order>()
             .Join<Payment>((o, p) => o.Id == p.OrderId)
-            .Within(5)
+            .Within(TimeSpan.FromSeconds(5))
             .Select((o, p) => new { outside.Id, p.Paid });
         var model = queryable.Build();
         Assert.Throws<InvalidOperationException>(() => KsqlCreateStatementBuilder.Build("JoinTest", model));
@@ -83,7 +83,7 @@ public class KsqlQueryable2Tests
         var outside = new Order();
         var queryable = new KsqlQueryable<Order>()
             .Join<Payment>((o, p) => outside.Id == p.OrderId)
-            .Within(5)
+            .Within(TimeSpan.FromSeconds(5))
             .Select((o, p) => new { o.Id, p.Paid });
         var model = queryable.Build();
         Assert.Throws<InvalidOperationException>(() => KsqlCreateStatementBuilder.Build("JoinTest", model));


### PR DESCRIPTION
## Summary\n- avoid reserved `WINDOWSTART` by aliasing MemberInit assignments in SelectExpressionVisitor\n- cover MemberInit window start in SelectClauseBuilder tests\n- update tests to TimeSpan-based Within\n\n## Testing\n- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter FullyQualifiedName~SelectClauseBuilderTests`\n- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` *(fails: multiple existing failures in integration and DSL tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc1d3e47c8327bbf421cfa0c4292e