### PR TITLE
build groupby before select clause

### DIFF
--- a/docs/diff_log/diff_groupby_select_build_order_20250906.md
+++ b/docs/diff_log/diff_groupby_select_build_order_20250906.md
@@ -1,0 +1,3 @@
+# GroupBy before Select build
+- Ensure `GroupByClauseBuilder` runs before `SelectClauseBuilder` in `KsqlCreateStatementBuilder.Build`.
+- Enables `SELECT` clause to include grouping keys like `Broker, Symbol, WINDOWSTART`.

--- a/src/Query/Builders/KsqlCreateStatementBuilder.cs
+++ b/src/Query/Builders/KsqlCreateStatementBuilder.cs
@@ -24,6 +24,8 @@ public static class KsqlCreateStatementBuilder
         if (model == null)
             throw new ArgumentNullException(nameof(model));
 
+        var groupByClause = BuildGroupByClause(model.GroupByExpression);
+
         string selectClause;
         if (model.SelectProjection == null)
         {
@@ -31,22 +33,20 @@ public static class KsqlCreateStatementBuilder
         }
         else
         {
-            // Map projection parameter names to resolved source names for qualification
             var map = new System.Collections.Generic.Dictionary<string, string>(StringComparer.Ordinal);
             var parameters = model.SelectProjection.Parameters;
             for (int i = 0; i < parameters.Count && i < (model.SourceTypes?.Length ?? 0); i++)
             {
                 var pname = parameters[i].Name ?? string.Empty;
-                // Use the same aliases as FROM/JOIN (o/i) for qualification
                 var alias = i == 0 ? "o" : "i";
                 map[pname] = alias;
             }
             var builder = new SelectClauseBuilder(map);
             selectClause = builder.Build(model.SelectProjection.Body);
         }
+
         var fromClause = BuildFromClauseCore(model, sourceNameResolver);
         var whereClause = BuildWhereClause(model.WhereCondition, model);
-        var groupByClause = BuildGroupByClause(model.GroupByExpression);
         var havingClause = BuildHavingClause(model.HavingCondition);
 
         var createType = model.IsAggregateQuery ? "CREATE TABLE" : "CREATE STREAM";


### PR DESCRIPTION
## Summary
- set GroupBy clause before Select clause in KSQL create statement builder
- document groupby/select build order change

## Testing
- `dotnet test physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj --filter "FullyQualifiedName=Kafka.Ksql.Linq.Tests.Integration.BarDslExplainTests.Tumbling_1m_5m_Live_Ohlc_Materialize_And_Verify" -c Release` *(fails: BarScheduleExplainTests.cs(81,34): error CS1061: 'IGrouping<..>' does not contain a definition for 'Max' ...)*
- manual verification via console app generating DDL showing `SELECT Broker, Symbol, WINDOWSTART AS BucketStart...`

------
https://chatgpt.com/codex/tasks/task_e_68bbc55237a4832783ee8b375349dc7f