### PR TITLE
Validate select projection property types

### DIFF
--- a/docs/diff_log/diff_toqueryvalidator_typemismatch_20250906.md
+++ b/docs/diff_log/diff_toqueryvalidator_typemismatch_20250906.md
@@ -1,0 +1,4 @@
+# ToQueryValidator type check
+
+- Ensure `ValidateSelectMatchesPoco` compares property types between entity and select projection.
+- Added unit test verifying mismatched types raise an exception.

--- a/src/Query/Dsl/ToQueryValidator.cs
+++ b/src/Query/Dsl/ToQueryValidator.cs
@@ -20,8 +20,10 @@ internal static class ToQueryValidator
             .Where(p => !Attribute.IsDefined(p, typeof(KsqlIgnoreAttribute), true))
             .ToArray();
 
+        var entityPropMap = entityProps.ToDictionary(p => p.Name);
+
         var projectionProps = ExtractProjectionProperties(model.SelectProjection, resultType)
-            .Where(p => !Attribute.IsDefined(p, typeof(KsqlIgnoreAttribute), true))
+            .Where(p => entityPropMap.ContainsKey(p.Name))
             .ToArray();
 
         if (entityProps.Length != projectionProps.Length)
@@ -31,6 +33,8 @@ internal static class ToQueryValidator
         {
             if (entityProps[i].Name != projectionProps[i].Name)
                 throw new InvalidOperationException("Select projection does not match POCO property order.");
+            if (entityProps[i].PropertyType != projectionProps[i].PropertyType)
+                throw new InvalidOperationException("Select projection property types do not match POCO.");
         }
 
         var entityKeys = entityProps
@@ -41,10 +45,12 @@ internal static class ToQueryValidator
             .ToArray();
 
         var projectionKeys = projectionProps
-            .Select(p => (Prop: p, Attr: p.GetCustomAttribute<KsqlKeyAttribute>(true)))
+            .Select(p => (Name: p.Name, Attr: entityPropMap.TryGetValue(p.Name, out var ep)
+                ? ep.GetCustomAttribute<KsqlKeyAttribute>(true)
+                : null))
             .Where(x => x.Attr != null)
             .OrderBy(x => x.Attr!.Order)
-            .Select(x => x.Prop.Name)
+            .Select(x => x.Name)
             .ToArray();
 
         if (!entityKeys.SequenceEqual(projectionKeys))
@@ -64,15 +70,15 @@ internal static class ToQueryValidator
             case NewExpression newExpr when newExpr.Members != null:
                 foreach (var mem in newExpr.Members.OfType<PropertyInfo>())
                 {
-                    var p = resultType.GetProperty(mem.Name);
-                    if (p != null) props.Add(p);
+                    if (resultType.GetProperty(mem.Name) != null)
+                        props.Add(mem);
                 }
                 break;
             case MemberInitExpression initExpr:
                 foreach (var binding in initExpr.Bindings.OfType<MemberAssignment>())
                 {
-                    var p = resultType.GetProperty(binding.Member.Name);
-                    if (p != null) props.Add(p);
+                    if (resultType.GetProperty(binding.Member.Name) != null)
+                        props.Add((PropertyInfo)binding.Member);
                 }
                 break;
             case ParameterExpression:
@@ -80,8 +86,8 @@ internal static class ToQueryValidator
                     .OrderBy(p => p.MetadataToken));
                 break;
             case MemberExpression me when me.Member is PropertyInfo pi:
-                var prop = resultType.GetProperty(pi.Name);
-                if (prop != null) props.Add(prop);
+                if (resultType.GetProperty(pi.Name) != null)
+                    props.Add(pi);
                 break;
         }
         return props;

--- a/tests/Query/Dsl/ToQueryDslTests.cs
+++ b/tests/Query/Dsl/ToQueryDslTests.cs
@@ -33,6 +33,13 @@ public class ToQueryDslTests
         public string Name { get; set; } = string.Empty;
     }
 
+    private class OrderAmountString
+    {
+        [KsqlKey]
+        public int Id { get; set; }
+        public string Amount { get; set; } = string.Empty;
+    }
+
     private class KeylessView
     {
         public string Name { get; set; } = string.Empty;
@@ -150,6 +157,18 @@ public class ToQueryDslTests
         Assert.Throws<InvalidOperationException>(() =>
             entityBuilder.ToQuery(q => q.From<Order>()
                 .Select(o => new { o.CustomerId }))); 
+    }
+
+    [Fact]
+    public void TypeMismatch_Throws()
+    {
+        var builder = new ModelBuilder();
+        builder.Entity<Order>();
+        var entityBuilder = builder.Entity<OrderAmountString>();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            entityBuilder.ToQuery(q => q.From<Order>()
+                .Select(o => new { o.Id, o.Amount })));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- validate select projections against POCO property types
- add test ensuring mismatched projection types throw
- log changes in diff_log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` *(fails: 17, passed: 476)*
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj` *(build error: TableCache<T> inaccessible)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd4031fa0832794780a96f8e405cf