### PR TITLE
Validate select projection property types and precision

### DIFF
--- a/docs/diff_log/diff_toqueryvalidator_typemismatch_20250906.md
+++ b/docs/diff_log/diff_toqueryvalidator_typemismatch_20250906.md
@@ -1,0 +1,6 @@
+# ToQueryValidator type check
+
+- Ensure `ValidateSelectMatchesPoco` compares property types between entity and select projection.
+- Added unit test verifying mismatched types raise an exception.
+- Decimal projection precision and scale are validated against entity attributes.
+- Added unit test verifying decimal precision mismatch raises an exception.

--- a/src/Query/Dsl/ToQueryValidator.cs
+++ b/src/Query/Dsl/ToQueryValidator.cs
@@ -1,3 +1,4 @@
+using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Attributes;
 using System;
 using System.Collections.Generic;
@@ -20,8 +21,10 @@ internal static class ToQueryValidator
             .Where(p => !Attribute.IsDefined(p, typeof(KsqlIgnoreAttribute), true))
             .ToArray();
 
+        var entityPropMap = entityProps.ToDictionary(p => p.Name);
+
         var projectionProps = ExtractProjectionProperties(model.SelectProjection, resultType)
-            .Where(p => !Attribute.IsDefined(p, typeof(KsqlIgnoreAttribute), true))
+            .Where(p => entityPropMap.ContainsKey(p.Prop.Name))
             .ToArray();
 
         if (entityProps.Length != projectionProps.Length)
@@ -29,8 +32,23 @@ internal static class ToQueryValidator
 
         for (int i = 0; i < entityProps.Length; i++)
         {
-            if (entityProps[i].Name != projectionProps[i].Name)
+            var proj = projectionProps[i];
+            if (entityProps[i].Name != proj.Prop.Name)
                 throw new InvalidOperationException("Select projection does not match POCO property order.");
+            if (entityProps[i].PropertyType != proj.Type)
+                throw new InvalidOperationException("Select projection property types do not match POCO.");
+            if ((entityProps[i].PropertyType == typeof(decimal) || entityProps[i].PropertyType == typeof(decimal?))
+                && (proj.Type == typeof(decimal) || proj.Type == typeof(decimal?)) && proj.Source != null)
+            {
+                var ea = entityProps[i].GetCustomAttribute<KsqlDecimalAttribute>(true);
+                var sa = proj.Source.GetCustomAttribute<KsqlDecimalAttribute>(true);
+                var ep = DecimalPrecisionConfig.ResolvePrecision(ea?.Precision, entityProps[i]);
+                var es = DecimalPrecisionConfig.ResolveScale(ea?.Scale, entityProps[i]);
+                var sp = DecimalPrecisionConfig.ResolvePrecision(sa?.Precision, proj.Source);
+                var ss = DecimalPrecisionConfig.ResolveScale(sa?.Scale, proj.Source);
+                if (ep != sp || es != ss)
+                    throw new InvalidOperationException("Select projection decimal precision does not match POCO.");
+            }
         }
 
         var entityKeys = entityProps
@@ -41,47 +59,57 @@ internal static class ToQueryValidator
             .ToArray();
 
         var projectionKeys = projectionProps
-            .Select(p => (Prop: p, Attr: p.GetCustomAttribute<KsqlKeyAttribute>(true)))
+            .Select(p => (Name: p.Prop.Name, Attr: entityPropMap.TryGetValue(p.Prop.Name, out var ep)
+                ? ep.GetCustomAttribute<KsqlKeyAttribute>(true)
+                : null))
             .Where(x => x.Attr != null)
             .OrderBy(x => x.Attr!.Order)
-            .Select(x => x.Prop.Name)
+            .Select(x => x.Name)
             .ToArray();
 
         if (!entityKeys.SequenceEqual(projectionKeys))
             throw new InvalidOperationException("Select projection key order does not match POCO.");
     }
 
-    private static List<PropertyInfo> ExtractProjectionProperties(LambdaExpression? projection, Type resultType)
+    private static List<(PropertyInfo Prop, PropertyInfo? Source, Type Type)> ExtractProjectionProperties(LambdaExpression? projection, Type resultType)
     {
         if (projection == null)
             return resultType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
                 .OrderBy(p => p.MetadataToken)
+                .Select(p => (Prop: p, Source: (PropertyInfo?)p, Type: p.PropertyType))
                 .ToList();
 
-        var props = new List<PropertyInfo>();
+        var props = new List<(PropertyInfo, PropertyInfo?, Type)>();
         switch (projection.Body)
         {
             case NewExpression newExpr when newExpr.Members != null:
-                foreach (var mem in newExpr.Members.OfType<PropertyInfo>())
+                for (int i = 0; i < newExpr.Members.Count; i++)
                 {
-                    var p = resultType.GetProperty(mem.Name);
-                    if (p != null) props.Add(p);
+                    if (newExpr.Members[i] is PropertyInfo mem && resultType.GetProperty(mem.Name) != null)
+                    {
+                        PropertyInfo? src = (newExpr.Arguments[i] as MemberExpression)?.Member as PropertyInfo;
+                        props.Add((mem, src, newExpr.Arguments[i].Type));
+                    }
                 }
                 break;
             case MemberInitExpression initExpr:
                 foreach (var binding in initExpr.Bindings.OfType<MemberAssignment>())
                 {
-                    var p = resultType.GetProperty(binding.Member.Name);
-                    if (p != null) props.Add(p);
+                    if (binding.Member is PropertyInfo mem && resultType.GetProperty(mem.Name) != null)
+                    {
+                        PropertyInfo? src = (binding.Expression as MemberExpression)?.Member as PropertyInfo;
+                        props.Add((mem, src, binding.Expression.Type));
+                    }
                 }
                 break;
             case ParameterExpression:
                 props.AddRange(resultType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                    .OrderBy(p => p.MetadataToken));
+                    .OrderBy(p => p.MetadataToken)
+                    .Select(p => (p, p, p.PropertyType)));
                 break;
             case MemberExpression me when me.Member is PropertyInfo pi:
-                var prop = resultType.GetProperty(pi.Name);
-                if (prop != null) props.Add(prop);
+                if (resultType.GetProperty(pi.Name) != null)
+                    props.Add((pi, me.Member as PropertyInfo, me.Type));
                 break;
         }
         return props;

--- a/tests/Query/Dsl/ToQueryDslTests.cs
+++ b/tests/Query/Dsl/ToQueryDslTests.cs
@@ -33,6 +33,29 @@ public class ToQueryDslTests
         public string Name { get; set; } = string.Empty;
     }
 
+    private class OrderAmountString
+    {
+        [KsqlKey]
+        public int Id { get; set; }
+        public string Amount { get; set; } = string.Empty;
+    }
+
+    private class OrderDecimal
+    {
+        [KsqlKey]
+        public int Id { get; set; }
+        [KsqlDecimal(18, 2)]
+        public decimal Amount { get; set; }
+    }
+
+    private class OrderDecimalScaled
+    {
+        [KsqlKey]
+        public int Id { get; set; }
+        [KsqlDecimal(18, 4)]
+        public decimal Amount { get; set; }
+    }
+
     private class KeylessView
     {
         public string Name { get; set; } = string.Empty;
@@ -150,6 +173,30 @@ public class ToQueryDslTests
         Assert.Throws<InvalidOperationException>(() =>
             entityBuilder.ToQuery(q => q.From<Order>()
                 .Select(o => new { o.CustomerId }))); 
+    }
+
+    [Fact]
+    public void TypeMismatch_Throws()
+    {
+        var builder = new ModelBuilder();
+        builder.Entity<Order>();
+        var entityBuilder = builder.Entity<OrderAmountString>();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            entityBuilder.ToQuery(q => q.From<Order>()
+                .Select(o => new { o.Id, o.Amount }))); 
+    }
+
+    [Fact]
+    public void DecimalPrecisionMismatch_Throws()
+    {
+        var builder = new ModelBuilder();
+        builder.Entity<OrderDecimal>();
+        var entityBuilder = builder.Entity<OrderDecimalScaled>();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            entityBuilder.ToQuery(q => q.From<OrderDecimal>()
+                .Select(o => new { o.Id, o.Amount })));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- validate select projections against POCO property types and decimal precision
- add tests verifying mismatched projection types and decimal precision throw
- log changes in diff_log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` *(fails: 17, passed: 477, skipped: 23)*
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj` *(fails: TableCache<T> inaccessible)*
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter "FullyQualifiedName=Kafka.Ksql.Linq.Tests.Query.Dsl.ToQueryDslTests.TypeMismatch_Throws"`
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter "FullyQualifiedName=Kafka.Ksql.Linq.Tests.Query.Dsl.ToQueryDslTests.DecimalPrecisionMismatch_Throws"`


------
https://chatgpt.com/codex/tasks/task_e_68bbd4031fa0832794780a96f8e405cf