### PR TITLE
Materialize ToQuery entities with separate CREATE and INSERT

### DIFF
--- a/docs/diff_log/diff_queryentity_create_insert_20250907.md
+++ b/docs/diff_log/diff_queryentity_create_insert_20250907.md
@@ -1,0 +1,5 @@
+# diff_queryentity_create_insert_20250907
+
+- Execute CREATE TABLE for query entities and follow with `INSERT INTO ... EMIT CHANGES` when defined via `ToQuery`.
+- Update `EnsureQueryEntityDdlAsync` to run CREATE first and conditional INSERT.
+- Adjust unit test to expect separate CREATE and INSERT statements.

--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -15,6 +15,7 @@ using Kafka.Ksql.Linq.Runtime.Heartbeat;
 using Confluent.Kafka;
 using Kafka.Ksql.Linq.Query.Abstractions;
 using Kafka.Ksql.Linq.Query.Adapters;
+using Kafka.Ksql.Linq.Query.Ddl;
 using Kafka.Ksql.Linq.SchemaRegistryTools;
 using Kafka.Ksql.Linq.Core.Dlq;
 using Microsoft.Extensions.Configuration;
@@ -734,39 +735,33 @@ public abstract class KsqlContext : IKsqlContext
         }
     }
 
-    /// <summary>
-    /// Generate and execute CREATE TABLE/STREAM AS statements for query entities.
-    /// </summary>
     private async Task EnsureQueryEntityDdlAsync(Type type, EntityModel model)
     {
         if (model.QueryModel != null)
-        {
             RegisterQueryModelMapping(model);
-            // Resolve FROM/JOIN object names:
-            // 1) SourceNameOverrides (by type name) > 2) EntityModel.TopicName > 3) type.Name
-            Func<Type, string>? resolver = (Type t) =>
+
+        var ddl = new Kafka.Ksql.Linq.Query.Pipeline.DDLQueryGenerator().GenerateCreateTable(new EntityModelDdlAdapter(model));
+        Logger.LogInformation("KSQL DDL (query {Entity}): {Sql}", type.Name, ddl);
+        await ExecuteWithRetryAsync(ddl);
+
+        if (model.QueryModel != null)
+        {
+            Func<Type, string>? resolver = t =>
             {
                 var key = t?.Name ?? string.Empty;
-                if (!string.IsNullOrEmpty(key) && _dslOptions.SourceNameOverrides is { Count: > 0 } &&
-                    _dslOptions.SourceNameOverrides.TryGetValue(key, out var overrideName))
-                {
+                if (!string.IsNullOrEmpty(key) && _dslOptions.SourceNameOverrides is { Count: > 0 } && _dslOptions.SourceNameOverrides.TryGetValue(key, out var overrideName))
                     return overrideName;
-                }
                 if (t != null && _entityModels.TryGetValue(t, out var srcModel))
-                {
-                    // Use the configured topic/entity name (uppercase for KSQL identifiers)
                     return srcModel.GetTopicName().ToUpperInvariant();
-                }
                 return key;
             };
-            var topicName = model.GetTopicName();
-            var sql = Query.Builders.KsqlCreateStatementBuilder.Build(
-                    topicName,
-                    model.QueryModel,
-                    model.KeySchemaFullName,
-                    model.ValueSchemaFullName,
-                    resolver);
-            Logger.LogInformation("KSQL DDL (query {Entity}): {Sql}", type.Name, sql);
+            var insert = Query.Builders.KsqlInsertStatementBuilder.Build(model.GetTopicName(), model.QueryModel, resolver);
+            Logger.LogInformation("KSQL DDL (query {Entity}): {Sql}", type.Name, insert);
+            await ExecuteWithRetryAsync(insert);
+        }
+
+        async Task ExecuteWithRetryAsync(string sql)
+        {
             var attempts = 0;
             var maxAttempts = Math.Max(0, _dslOptions.KsqlDdlRetryCount) + 1;
             var delayMs = Math.Max(0, _dslOptions.KsqlDdlRetryInitialDelayMs);
@@ -787,10 +782,7 @@ public abstract class KsqlContext : IKsqlContext
                 await _delay(TimeSpan.FromMilliseconds(delayMs), default);
                 delayMs = Math.Min(delayMs * 2, 8000);
             }
-            return;
         }
-
-        // QueryModel が指定されていない場合は何もしない
     }
 
     /// <summary>

--- a/tests/Core/EnsureQueryEntityDdlAsyncTests.cs
+++ b/tests/Core/EnsureQueryEntityDdlAsyncTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Modeling;
+using Kafka.Ksql.Linq.Mapping;
+using Kafka.Ksql.Linq.Query.Dsl;
+using Kafka.Ksql.Linq.Infrastructure.KsqlDb;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Core;
+
+public class EnsureQueryEntityDdlAsyncTests
+{
+    private class CapturingClient : IKsqlDbClient
+    {
+        public List<string> Statements { get; } = new();
+        public Task<KsqlDbResponse> ExecuteStatementAsync(string statement)
+        {
+            Statements.Add(statement);
+            return Task.FromResult(new KsqlDbResponse(true, string.Empty));
+        }
+        public Task<KsqlDbResponse> ExecuteExplainAsync(string ksql) => Task.FromResult(new KsqlDbResponse(true, string.Empty));
+        public Task<HashSet<string>> GetTableTopicsAsync() => Task.FromResult(new HashSet<string>());
+        public Task<int> ExecuteQueryStreamCountAsync(string sql, TimeSpan? timeout = null) => Task.FromResult(0);
+        public Task<int> ExecutePullQueryCountAsync(string sql, TimeSpan? timeout = null) => Task.FromResult(0);
+    }
+
+    private class ListLogger : ILogger
+    {
+        public List<string> Messages { get; } = new();
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => null!;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Messages.Add(formatter(state, exception));
+    }
+
+    private class DummyContext : KsqlContext
+    {
+        private DummyContext() : base(new Microsoft.Extensions.Configuration.ConfigurationBuilder().Build()) { }
+    }
+
+    private static DummyContext CreateContext(CapturingClient client, ListLogger logger, Dictionary<Type, EntityModel> models)
+    {
+        var ctx = (DummyContext)RuntimeHelpers.GetUninitializedObject(typeof(DummyContext));
+        var dsl = new KsqlDslOptions();
+        DefaultValueBinder.ApplyDefaults(dsl);
+        typeof(KsqlContext).GetField("_dslOptions", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(ctx, dsl);
+        typeof(KsqlContext).GetField("_mappingRegistry", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(ctx, new MappingRegistry());
+        typeof(KsqlContext).GetField("_entityModels", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(ctx, models);
+        typeof(KsqlContext).GetField("_ksqlDbClient", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(ctx, client);
+        typeof(KsqlContext).GetField("_logger", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(ctx, logger);
+        return ctx;
+    }
+
+    private class Source { public int Id { get; set; } }
+    private class Target { public int Id { get; set; } }
+
+    [Fact]
+    public async Task LogsCreateThenInsert()
+    {
+        var client = new CapturingClient();
+        var logger = new ListLogger();
+        var models = new Dictionary<Type, EntityModel>();
+
+        models[typeof(Source)] = new EntityModel
+        {
+            EntityType = typeof(Source),
+            TopicName = "src",
+            KeyProperties = new[] { typeof(Source).GetProperty(nameof(Source.Id))! },
+            AllProperties = typeof(Source).GetProperties()
+        };
+
+        var targetModel = new EntityModel
+        {
+            EntityType = typeof(Target),
+            TopicName = "tgt",
+            QueryModel = new KsqlQueryRoot().From<Source>().Select(s => new { s.Id }).Build(),
+            KeyProperties = new[] { typeof(Target).GetProperty(nameof(Target.Id))! },
+            AllProperties = typeof(Target).GetProperties(),
+            KeySchemaFullName = "k",
+            ValueSchemaFullName = "v"
+        };
+        models[typeof(Target)] = targetModel;
+
+        var ctx = CreateContext(client, logger, models);
+
+        using (Kafka.Ksql.Linq.Core.Modeling.ModelCreatingScope.Enter())
+        {
+            var task = (Task)PrivateAccessor.InvokePrivate(ctx, "EnsureQueryEntityDdlAsync", new[] { typeof(Type), typeof(EntityModel) }, args: new object[] { typeof(Target), targetModel })!;
+            await task;
+        }
+
+        Assert.Equal(2, logger.Messages.Count);
+        Assert.Contains("CREATE TABLE", logger.Messages[0]);
+        Assert.Contains("INSERT INTO", logger.Messages[1]);
+        Assert.DoesNotContain("CREATE TABLE AS", string.Join("\n", logger.Messages));
+        Assert.Equal(2, client.Statements.Count);
+        Assert.Contains("CREATE TABLE", client.Statements[0]);
+        Assert.Contains("INSERT INTO", client.Statements[1]);
+        Assert.Contains("EMIT CHANGES", client.Statements[1]);
+    }
+}


### PR DESCRIPTION
## Summary
- run CREATE TABLE for query entities and follow with `INSERT INTO ... EMIT CHANGES` when defined via `ToQuery`
- test query entity materialization logs both CREATE and INSERT
- document split materialization flow in diff_log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` *(fails: 15 failed, 483 passed, 23 skipped)*
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter EnsureQueryEntityDdlAsyncTests`


------
https://chatgpt.com/codex/tasks/task_e_68bbe1b32c38832798de0486817475d3