### PR TITLE
Use GenericRecord for table produce/consume

### DIFF
--- a/docs/diff_log/diff_produce_consume_record_type_20250907.md
+++ b/docs/diff_log/diff_produce_consume_record_type_20250907.md
@@ -1,0 +1,5 @@
+## Summary
+- use `GenericRecord` for table POCO values and `ISpecificRecord` for streams during produce/consume
+
+## Testing
+- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -366,7 +366,7 @@ public abstract class KsqlContext : IKsqlContext
             }
             else
             {
-                _mappingRegistry.RegisterEntityModel(model);
+                _mappingRegistry.RegisterEntityModel(model, genericValue: model.StreamTableType == StreamTableType.Table);
             }
         }
     }
@@ -476,7 +476,7 @@ public abstract class KsqlContext : IKsqlContext
 
         model ??= CreateEntityModelFromType(entityType);
         _entityModels[entityType] = model;
-        _mappingRegistry.RegisterEntityModel(model);
+        _mappingRegistry.RegisterEntityModel(model, genericValue: model.StreamTableType == StreamTableType.Table);
 
         return model;
     }
@@ -797,7 +797,8 @@ public abstract class KsqlContext : IKsqlContext
             model.EntityType,
             model.QueryModel,
             model.KeyProperties,
-            model.GetTopicName());
+            model.GetTopicName(),
+            genericValue: model.StreamTableType == StreamTableType.Table);
     }
 
 

--- a/src/Mapping/KeyValueTypeMapping.cs
+++ b/src/Mapping/KeyValueTypeMapping.cs
@@ -34,6 +34,7 @@ internal class KeyValueTypeMapping
     // Avro schema json strings for key and value
     public string? AvroKeySchema { get; set; }
     public string? AvroValueSchema { get; set; }
+    public RecordSchema? AvroValueRecordSchema { get; set; }
 
     private static readonly ConcurrentDictionary<(Type poco, Type avro, string fp), Action<object, object>> PlanCache = new();
 
@@ -417,31 +418,56 @@ internal class KeyValueTypeMapping
     {
         if (poco == null) throw new ArgumentNullException(nameof(poco));
         if (AvroValueType == null) throw new InvalidOperationException("AvroValueType not registered");
-        var valueInstance = Activator.CreateInstance(AvroValueType)!;
-        for (int i = 0; i < ValueProperties.Length; i++)
+        if (AvroValueType == typeof(GenericRecord))
         {
-            var meta = ValueProperties[i];
-            var value = meta.PropertyInfo!.GetValue(poco);
-            var avroProp = AvroValueType!.GetProperty(meta.PropertyInfo!.Name)!;
-            var scale = DecimalPrecisionConfig.ResolveScale(meta.Scale, meta.PropertyInfo);
-            var avroTypeVal = avroProp.PropertyType;
-            var isNullableAvroDecimalVal = avroTypeVal.IsGenericType && avroTypeVal.GetGenericTypeDefinition() == typeof(Nullable<>) && avroTypeVal.GetGenericArguments()[0] == typeof(AvroDecimal);
-            if (isNullableAvroDecimalVal && value is null)
+            var schema = AvroValueRecordSchema ??= (RecordSchema)Schema.Parse(AvroValueSchema!);
+            var record = new GenericRecord(schema);
+            for (int i = 0; i < ValueProperties.Length; i++)
             {
-                avroProp.SetValue(valueInstance, null);
+                var meta = ValueProperties[i];
+                var val = meta.PropertyInfo!.GetValue(poco);
+                var scale = DecimalPrecisionConfig.ResolveScale(meta.Scale, meta.PropertyInfo);
+                var pType = meta.PropertyInfo.PropertyType;
+                var fname = meta.PropertyInfo!.Name;
+                if ((pType == typeof(decimal) || pType == typeof(decimal?)) && val is decimal decv)
+                    record.Add(fname, ToAvroDecimal(decv, scale));
+                else if ((pType == typeof(Guid) || pType == typeof(Guid?)) && val is Guid gv)
+                    record.Add(fname, gv.ToString("D"));
+                else if ((pType == typeof(float) || pType == typeof(float?)) && val is float fv)
+                    record.Add(fname, (double)fv);
+                else
+                    record.Add(fname, val);
             }
-            else if ((avroTypeVal == typeof(AvroDecimal) || isNullableAvroDecimalVal) && value is decimal decVal)
-            {
-                avroProp.SetValue(valueInstance, ToAvroDecimal(decVal, scale));
-            }
-            else if (avroProp.PropertyType == typeof(string) && value is Guid g)
-                avroProp.SetValue(valueInstance, g.ToString("D"));
-            else if (avroProp.PropertyType == typeof(double) && value is float fv)
-                avroProp.SetValue(valueInstance, (double)fv);
-            else
-                avroProp.SetValue(valueInstance, value);
+            return record;
         }
-        return valueInstance;
+        else
+        {
+            var valueInstance = Activator.CreateInstance(AvroValueType)!;
+            for (int i = 0; i < ValueProperties.Length; i++)
+            {
+                var meta = ValueProperties[i];
+                var value = meta.PropertyInfo!.GetValue(poco);
+                var avroProp = AvroValueType!.GetProperty(meta.PropertyInfo!.Name)!;
+                var scale = DecimalPrecisionConfig.ResolveScale(meta.Scale, meta.PropertyInfo);
+                var avroTypeVal = avroProp.PropertyType;
+                var isNullableAvroDecimalVal = avroTypeVal.IsGenericType && avroTypeVal.GetGenericTypeDefinition() == typeof(Nullable<>) && avroTypeVal.GetGenericArguments()[0] == typeof(AvroDecimal);
+                if (isNullableAvroDecimalVal && value is null)
+                {
+                    avroProp.SetValue(valueInstance, null);
+                }
+                else if ((avroTypeVal == typeof(AvroDecimal) || isNullableAvroDecimalVal) && value is decimal decVal)
+                {
+                    avroProp.SetValue(valueInstance, ToAvroDecimal(decVal, scale));
+                }
+                else if (avroProp.PropertyType == typeof(string) && value is Guid g)
+                    avroProp.SetValue(valueInstance, g.ToString("D"));
+                else if (avroProp.PropertyType == typeof(double) && value is float fv)
+                    avroProp.SetValue(valueInstance, (double)fv);
+                else
+                    avroProp.SetValue(valueInstance, value);
+            }
+            return valueInstance;
+        }
     }
 
     public void PopulateAvroKeyValue(object poco, object? key, object value)
@@ -449,28 +475,51 @@ internal class KeyValueTypeMapping
         if (poco == null) throw new ArgumentNullException(nameof(poco));
         if (value == null) throw new ArgumentNullException(nameof(value));
 
-        for (int i = 0; i < ValueProperties.Length; i++)
+        if (value is GenericRecord grec)
         {
-            var meta = ValueProperties[i];
-            var val = meta.PropertyInfo!.GetValue(poco);
-            var avroProp = AvroValueType!.GetProperty(meta.PropertyInfo!.Name)!;
-            var scale = DecimalPrecisionConfig.ResolveScale(meta.Scale, meta.PropertyInfo);
-            var avroTypeValueProp = avroProp.PropertyType;
-            var isNullableAvroDecimalValueProp = avroTypeValueProp.IsGenericType && avroTypeValueProp.GetGenericTypeDefinition() == typeof(Nullable<>) && avroTypeValueProp.GetGenericArguments()[0] == typeof(AvroDecimal);
-            if (isNullableAvroDecimalValueProp && val is null)
+            AvroValueRecordSchema ??= (RecordSchema)Schema.Parse(AvroValueSchema!);
+            for (int i = 0; i < ValueProperties.Length; i++)
             {
-                avroProp.SetValue(value, null);
+                var meta = ValueProperties[i];
+                var val = meta.PropertyInfo!.GetValue(poco);
+                var scale = DecimalPrecisionConfig.ResolveScale(meta.Scale, meta.PropertyInfo);
+                var pType = meta.PropertyInfo.PropertyType;
+                var fname = meta.PropertyInfo!.Name;
+                if ((pType == typeof(decimal) || pType == typeof(decimal?)) && val is decimal decv)
+                    grec.Add(fname, ToAvroDecimal(decv, scale));
+                else if ((pType == typeof(Guid) || pType == typeof(Guid?)) && val is Guid gv)
+                    grec.Add(fname, gv.ToString("D"));
+                else if ((pType == typeof(float) || pType == typeof(float?)) && val is float fv)
+                    grec.Add(fname, (double)fv);
+                else
+                    grec.Add(fname, val);
             }
-            else if ((avroTypeValueProp == typeof(AvroDecimal) || isNullableAvroDecimalValueProp) && val is decimal decv)
+        }
+        else
+        {
+            for (int i = 0; i < ValueProperties.Length; i++)
             {
-                avroProp.SetValue(value, ToAvroDecimal(decv, scale));
+                var meta = ValueProperties[i];
+                var val = meta.PropertyInfo!.GetValue(poco);
+                var avroProp = AvroValueType!.GetProperty(meta.PropertyInfo!.Name)!;
+                var scale = DecimalPrecisionConfig.ResolveScale(meta.Scale, meta.PropertyInfo);
+                var avroTypeValueProp = avroProp.PropertyType;
+                var isNullableAvroDecimalValueProp = avroTypeValueProp.IsGenericType && avroTypeValueProp.GetGenericTypeDefinition() == typeof(Nullable<>) && avroTypeValueProp.GetGenericArguments()[0] == typeof(AvroDecimal);
+                if (isNullableAvroDecimalValueProp && val is null)
+                {
+                    avroProp.SetValue(value, null);
+                }
+                else if ((avroTypeValueProp == typeof(AvroDecimal) || isNullableAvroDecimalValueProp) && val is decimal decv)
+                {
+                    avroProp.SetValue(value, ToAvroDecimal(decv, scale));
+                }
+                else if (avroProp.PropertyType == typeof(string) && val is Guid gv)
+                    avroProp.SetValue(value, gv.ToString("D"));
+                else if (avroProp.PropertyType == typeof(double) && val is float fvv)
+                    avroProp.SetValue(value, (double)fvv);
+                else
+                    avroProp.SetValue(value, val);
             }
-            else if (avroProp.PropertyType == typeof(string) && val is Guid gv)
-                avroProp.SetValue(value, gv.ToString("D"));
-            else if (avroProp.PropertyType == typeof(double) && val is float fvv)
-                avroProp.SetValue(value, (double)fvv);
-            else
-                avroProp.SetValue(value, val);
         }
 
         if (key != null)

--- a/src/Mapping/MappingRegistry.cs
+++ b/src/Mapping/MappingRegistry.cs
@@ -47,7 +47,8 @@ internal class MappingRegistry
         PropertyMeta[] keyProperties,
         PropertyMeta[] valueProperties,
         string? topicName = null,
-        bool genericKey = false)
+        bool genericKey = false,
+        bool genericValue = false)
     {
         if (_mappings.TryGetValue(pocoType, out var existing))
         {
@@ -61,7 +62,7 @@ internal class MappingRegistry
         var keyType = CreateType(ns, $"{baseName}-key", keyProperties);
         var valueType = CreateType(ns, $"{baseName}-value", valueProperties);
 
-        // Generate ISpecificRecord types for Avro deserialization
+        // Generate Avro types or schemas
         Type? avroKeyType = null;
         string? avroKeySchema = null;
         if (!genericKey && keyProperties.Length > 0)
@@ -70,8 +71,21 @@ internal class MappingRegistry
             avroKeySchema = ((Avro.Specific.ISpecificRecord)Activator.CreateInstance(avroKeyType)!).Schema.ToString();
         }
 
-        var avroValueType = SpecificRecordGenerator.Generate(valueType);
-        var avroValueSchema = ((Avro.Specific.ISpecificRecord)Activator.CreateInstance(avroValueType)!).Schema.ToString();
+        Type avroValueType;
+        string avroValueSchema;
+        Avro.RecordSchema? avroValueRecordSchema = null;
+        if (genericValue)
+        {
+            var tmp = SpecificRecordGenerator.Generate(valueType);
+            avroValueSchema = ((Avro.Specific.ISpecificRecord)Activator.CreateInstance(tmp)!).Schema.ToString();
+            avroValueType = typeof(Avro.Generic.GenericRecord);
+            avroValueRecordSchema = (Avro.RecordSchema)Avro.Schema.Parse(avroValueSchema);
+        }
+        else
+        {
+            avroValueType = SpecificRecordGenerator.Generate(valueType);
+            avroValueSchema = ((Avro.Specific.ISpecificRecord)Activator.CreateInstance(avroValueType)!).Schema.ToString();
+        }
 
         var keyTypeProps = keyProperties
             .Select(p => keyType.GetProperty(p.Name)!)
@@ -91,7 +105,8 @@ internal class MappingRegistry
             AvroKeyType = avroKeyType,
             AvroValueType = avroValueType,
             AvroKeySchema = avroKeySchema,
-            AvroValueSchema = avroValueSchema
+            AvroValueSchema = avroValueSchema,
+            AvroValueRecordSchema = avroValueRecordSchema
         };
         _mappings[pocoType] = mapping;
         _lastRegisteredType = pocoType;
@@ -105,9 +120,10 @@ internal class MappingRegistry
         Type pocoType,
         (PropertyMeta[] KeyProperties, PropertyMeta[] ValueProperties) meta,
         string? topicName = null,
-        bool genericKey = false)
+        bool genericKey = false,
+        bool genericValue = false)
     {
-        return Register(pocoType, meta.KeyProperties, meta.ValueProperties, topicName, genericKey);
+        return Register(pocoType, meta.KeyProperties, meta.ValueProperties, topicName, genericKey, genericValue);
     }
 
     /// <summary>
@@ -115,7 +131,7 @@ internal class MappingRegistry
     /// Convenience wrapper so callers don't need to manually convert
     /// PropertyInfo to <see cref="PropertyMeta"/> arrays.
     /// </summary>
-    public KeyValueTypeMapping RegisterEntityModel(EntityModel model, bool genericKey = false)
+    public KeyValueTypeMapping RegisterEntityModel(EntityModel model, bool genericKey = false, bool genericValue = false)
     {
         if (model == null) throw new ArgumentNullException(nameof(model));
 
@@ -126,7 +142,7 @@ internal class MappingRegistry
             .Select(p => PropertyMeta.FromProperty(p))
             .ToArray();
 
-        return Register(model.EntityType, keyMeta, valueMeta, model.GetTopicName(), genericKey);
+        return Register(model.EntityType, keyMeta, valueMeta, model.GetTopicName(), genericKey, genericValue);
     }
 
     /// <summary>
@@ -139,7 +155,8 @@ internal class MappingRegistry
         KsqlQueryModel model,
         PropertyInfo[] keyProperties,
         string? topicName = null,
-        bool genericKey = false)
+        bool genericKey = false,
+        bool genericValue = false)
     {
         if (resultType == null) throw new ArgumentNullException(nameof(resultType));
         if (model == null) throw new ArgumentNullException(nameof(model));
@@ -158,7 +175,7 @@ internal class MappingRegistry
             .ToArray();
         var keyMeta = keyProperties.Select(p => PropertyMeta.FromProperty(p)).ToArray();
 
-        return Register(resultType, keyMeta, valueProps, topicName ?? resultType.Name.ToLowerInvariant(), genericKey);
+        return Register(resultType, keyMeta, valueProps, topicName ?? resultType.Name.ToLowerInvariant(), genericKey, genericValue);
     }
 
     private static List<PropertyInfo> ExtractProjectionProperties(LambdaExpression? projection, Type resultType)

--- a/src/Messaging/Producers/KafkaProducerManager.cs
+++ b/src/Messaging/Producers/KafkaProducerManager.cs
@@ -15,6 +15,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using ConfluentSchemaRegistry = Confluent.SchemaRegistry;
 using Kafka.Ksql.Linq.Core.Extensions;
+using Avro;
+using Avro.Generic;
 
 namespace Kafka.Ksql.Linq.Messaging.Producers;
 
@@ -205,7 +207,9 @@ internal class KafkaProducerManager : IDisposable
         var mapping = _mappingRegistry.GetMapping(typeof(TPOCO));
 
         object? keyObj = mapping.AvroKeyType != null ? Activator.CreateInstance(mapping.AvroKeyType)! : null;
-        object valueObj = Activator.CreateInstance(mapping.AvroValueType!)!;
+        object valueObj = mapping.AvroValueType == typeof(GenericRecord)
+            ? new GenericRecord(mapping.AvroValueRecordSchema ?? (RecordSchema)Schema.Parse(mapping.AvroValueSchema!))
+            : Activator.CreateInstance(mapping.AvroValueType!)!;
         mapping.PopulateAvroKeyValue(entity, keyObj, valueObj);
 
         var context = new KafkaMessageContext
@@ -235,7 +239,10 @@ internal class KafkaProducerManager : IDisposable
         object? keyObj = Activator.CreateInstance(mapping.AvroKeyType!)!;
         if (mapping.KeyProperties.Length > 0)
         {
-            mapping.PopulateAvroKeyValue(entity, keyObj, Activator.CreateInstance(mapping.AvroValueType!)!);
+            var tmp = mapping.AvroValueType == typeof(GenericRecord)
+                ? new GenericRecord(mapping.AvroValueRecordSchema ?? (RecordSchema)Schema.Parse(mapping.AvroValueSchema!))
+                : Activator.CreateInstance(mapping.AvroValueType!)!;
+            mapping.PopulateAvroKeyValue(entity, keyObj, tmp);
         }
 
         var context = new KafkaMessageContext

--- a/src/Query/Adapters/EntityModelRegistrar.cs
+++ b/src/Query/Adapters/EntityModelRegistrar.cs
@@ -18,7 +18,7 @@ internal static class EntityModelRegistrar
                 m.SetStreamTableType(StreamTableType.Table);
             else
                 m.SetStreamTableType(StreamTableType.Stream);
-            registry.RegisterEntityModel(m);
+            registry.RegisterEntityModel(m, genericValue: m.StreamTableType == StreamTableType.Table);
         }
     }
 }

--- a/tests/Mapping/MappingRegistryTests.cs
+++ b/tests/Mapping/MappingRegistryTests.cs
@@ -2,6 +2,7 @@ using Kafka.Ksql.Linq.Core.Models;
 using Kafka.Ksql.Linq.Mapping;
 using System.Linq;
 using Xunit;
+using Avro.Generic;
 
 namespace Kafka.Ksql.Linq.Tests.Mapping;
 
@@ -69,5 +70,24 @@ public class MappingRegistryTests
         Assert.Null(mapping.AvroKeyType);
         Assert.Null(mapping.AvroKeySchema);
         Assert.NotNull(mapping.AvroValueType);
+    }
+
+    [Fact]
+    public void Register_GenericValue_UsesGenericRecord()
+    {
+        var registry = new MappingRegistry();
+        var keyProps = new[] { PropertyMeta.FromProperty(typeof(Sample).GetProperty(nameof(Sample.Id))!) };
+        var valueProps = typeof(Sample).GetProperties()
+            .Select(p => PropertyMeta.FromProperty(p))
+            .ToArray();
+
+        var mapping = registry.Register(
+            typeof(Sample),
+            keyProps,
+            valueProps,
+            genericValue: true);
+
+        Assert.Equal(typeof(GenericRecord), mapping.AvroValueType);
+        Assert.NotNull(mapping.AvroValueSchema);
     }
 }


### PR DESCRIPTION
## Summary
- use GenericRecord for table POCO values during produce/consume
- keep streams on ISpecificRecord

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bbf34528cc832786d45dd7338c7107