### PR TITLE
Use CTAS for table queries

### DIFF
--- a/docs/diff_log/diff_queryentity_ctas_20250906.md
+++ b/docs/diff_log/diff_queryentity_ctas_20250906.md
@@ -1,0 +1,3 @@
+# Query entity CTAS for tables
+- Generate `CREATE TABLE AS SELECT` when ToQuery defines a table entity.
+- Streams still use `INSERT INTO ... SELECT` after initial creation.

--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -740,13 +740,41 @@ public abstract class KsqlContext : IKsqlContext
         if (model.QueryModel != null)
             RegisterQueryModelMapping(model);
 
-        var ddl = new Kafka.Ksql.Linq.Query.Pipeline.DDLQueryGenerator().GenerateCreateTable(new EntityModelDdlAdapter(model));
-        Logger.LogInformation("KSQL DDL (query {Entity}): {Sql}", type.Name, ddl);
-        await ExecuteWithRetryAsync(ddl);
+        var isTable = model.GetExplicitStreamTableType() == StreamTableType.Table || model.QueryModel?.IsAggregateQuery == true;
+
+        if (model.QueryModel != null && isTable)
+        {
+            Func<Type, string> resolver = t =>
+            {
+                var key = t?.Name ?? string.Empty;
+                if (!string.IsNullOrEmpty(key) && _dslOptions.SourceNameOverrides is { Count: > 0 } && _dslOptions.SourceNameOverrides.TryGetValue(key, out var overrideName))
+                    return overrideName;
+                if (t != null && _entityModels.TryGetValue(t, out var srcModel))
+                    return srcModel.GetTopicName().ToUpperInvariant();
+                return key;
+            };
+            var ddl = Query.Builders.KsqlCreateStatementBuilder.Build(
+                model.GetTopicName(),
+                model.QueryModel,
+                model.KeySchemaFullName,
+                model.ValueSchemaFullName,
+                resolver);
+            Logger.LogInformation("KSQL DDL (query {Entity}): {Sql}", type.Name, ddl);
+            await ExecuteWithRetryAsync(ddl);
+            return;
+        }
+
+        var generator = new Kafka.Ksql.Linq.Query.Pipeline.DDLQueryGenerator();
+        var adapter = new EntityModelDdlAdapter(model);
+        var ddlSql = isTable
+            ? generator.GenerateCreateTable(adapter)
+            : generator.GenerateCreateStream(adapter);
+        Logger.LogInformation("KSQL DDL (query {Entity}): {Sql}", type.Name, ddlSql);
+        await ExecuteWithRetryAsync(ddlSql);
 
         if (model.QueryModel != null)
         {
-            Func<Type, string>? resolver = t =>
+            Func<Type, string> resolver = t =>
             {
                 var key = t?.Name ?? string.Empty;
                 if (!string.IsNullOrEmpty(key) && _dslOptions.SourceNameOverrides is { Count: > 0 } && _dslOptions.SourceNameOverrides.TryGetValue(key, out var overrideName))

--- a/tests/Core/EnsureQueryEntityDdlAsyncTests.cs
+++ b/tests/Core/EnsureQueryEntityDdlAsyncTests.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using System.Linq;
 using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Modeling;
 using Kafka.Ksql.Linq.Mapping;
 using Kafka.Ksql.Linq.Query.Dsl;
+using Kafka.Ksql.Linq.Query.Abstractions;
 using Kafka.Ksql.Linq.Infrastructure.KsqlDb;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -97,12 +99,58 @@ public class EnsureQueryEntityDdlAsyncTests
         }
 
         Assert.Equal(2, logger.Messages.Count);
-        Assert.Contains("CREATE TABLE", logger.Messages[0]);
+        Assert.Contains("CREATE STREAM", logger.Messages[0]);
         Assert.Contains("INSERT INTO", logger.Messages[1]);
         Assert.DoesNotContain("CREATE TABLE AS", string.Join("\n", logger.Messages));
         Assert.Equal(2, client.Statements.Count);
-        Assert.Contains("CREATE TABLE", client.Statements[0]);
+        Assert.Contains("CREATE STREAM", client.Statements[0]);
         Assert.Contains("INSERT INTO", client.Statements[1]);
         Assert.Contains("EMIT CHANGES", client.Statements[1]);
+    }
+
+    [Fact]
+    public async Task LogsCtasForTable()
+    {
+        var client = new CapturingClient();
+        var logger = new ListLogger();
+        var models = new Dictionary<Type, EntityModel>();
+
+        models[typeof(Source)] = new EntityModel
+        {
+            EntityType = typeof(Source),
+            TopicName = "src",
+            KeyProperties = new[] { typeof(Source).GetProperty(nameof(Source.Id))! },
+            AllProperties = typeof(Source).GetProperties()
+        };
+
+        var targetModel = new EntityModel
+        {
+            EntityType = typeof(Target),
+            TopicName = "tgt",
+            QueryModel = new KsqlQueryRoot().From<Source>().GroupBy(s => s.Id).Select(g => new { Id = g.Key, Count = g.Count() }).Build(),
+            KeyProperties = new[] { typeof(Target).GetProperty(nameof(Target.Id))! },
+            AllProperties = typeof(Target).GetProperties(),
+            KeySchemaFullName = "k",
+            ValueSchemaFullName = "v"
+        };
+        targetModel.SetStreamTableType(StreamTableType.Table);
+        models[typeof(Target)] = targetModel;
+
+        var ctx = CreateContext(client, logger, models);
+
+        using (Kafka.Ksql.Linq.Core.Modeling.ModelCreatingScope.Enter())
+        {
+            var task = (Task)PrivateAccessor.InvokePrivate(ctx, "EnsureQueryEntityDdlAsync", new[] { typeof(Type), typeof(EntityModel) }, args: new object[] { typeof(Target), targetModel })!;
+            await task;
+        }
+
+        Assert.Single(logger.Messages);
+        Assert.Contains("CREATE TABLE", logger.Messages[0]);
+        Assert.Contains("AS", logger.Messages[0]);
+        Assert.Single(client.Statements);
+        Assert.Contains("CREATE TABLE", client.Statements[0]);
+        Assert.DoesNotContain("INSERT INTO", string.Join("\n", client.Statements));
+
+        DecimalPrecisionConfig.Configure(18, 2, null);
     }
 }

--- a/tests/Query/Dsl/KsqlCreateStatementBuilderDslTests.cs
+++ b/tests/Query/Dsl/KsqlCreateStatementBuilderDslTests.cs
@@ -60,6 +60,20 @@ public class KsqlCreateStatementBuilderDslTests
         Assert.DoesNotContain("PARTITION BY", sql);
     }
 
+    [Fact]
+    public void Build_AggregateQuery_UsesCreateTable()
+    {
+        var model = new KsqlQueryRoot()
+            .From<Order>()
+            .GroupBy(o => o.CustomerId)
+            .Select(g => new { g.Key, Count = g.Count() })
+            .Build();
+
+        var sql = KsqlCreateStatementBuilder.Build("agg_view", model);
+        Assert.StartsWith("CREATE TABLE", sql);
+        Assert.Contains("GROUP BY CustomerId", sql);
+    }
+
     private static KsqlQueryModel BuildAggregateModel()
     {
         return new KsqlQueryRoot()


### PR DESCRIPTION
## Summary
- use CREATE TABLE AS SELECT for ToQuery tables
- keep INSERT INTO for streams
- test CTAS generation and logging

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68bbf5971dd48327aba144904c1c2513