### PR TITLE
Reset decimal defaults when applying overrides

### DIFF
--- a/docs/diff_log/diff_decimal_precision_reset_20250906.md
+++ b/docs/diff_log/diff_decimal_precision_reset_20250906.md
@@ -1,0 +1,1 @@
+- `DecimalPrecisionConfig.Configure(overrides)` now resets global precision and scale to 18 and 2 before applying overrides.

--- a/src/Configuration/DecimalPrecisionConfig.cs
+++ b/src/Configuration/DecimalPrecisionConfig.cs
@@ -36,6 +36,8 @@ public static class DecimalPrecisionConfig
     /// </summary>
     public static void Configure(Dictionary<string, Dictionary<string, KsqlDslOptions.DecimalSetting>>? overrides)
     {
+        DecimalPrecision = 18;
+        DecimalScale = 2;
         _overrides = new();
         if (overrides == null) return;
         foreach (var (entity, props) in overrides)


### PR DESCRIPTION
## Summary
- ensure DecimalPrecisionConfig.Configure(overrides) restores global precision and scale to 18 and 2
- document the change

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -c Release`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68bc1a233ce88327acd500afe455241b