### PR TITLE
fix group key alias emission in select clause

### DIFF
--- a/docs/diff_log/diff_groupby_key_prefix_dot_20250907.md
+++ b/docs/diff_log/diff_groupby_key_prefix_dot_20250907.md
@@ -1,0 +1,2 @@
+- switch key prefix from `<entity>_key` to `<entity>.key` for ksql compatibility
+- update query builders and tests to expect `tablename.key->column` format

--- a/docs/diff_log/diff_select_groupkey_alias_20250906.md
+++ b/docs/diff_log/diff_select_groupkey_alias_20250906.md
@@ -1,0 +1,1 @@
+- fix: ensure group key properties in SELECT clause always emit explicit aliases with AS, preventing invalid SQL like `BROKER BROKER`

--- a/docs/diff_log/diff_select_groupkey_alias_agg_20250907.md
+++ b/docs/diff_log/diff_select_groupkey_alias_agg_20250907.md
@@ -1,0 +1,2 @@
+- ensure SelectExpressionVisitor emits AS for group key members even when alias matches column
+- add unit test verifying aliasing for group keys and aggregate functions

--- a/docs/diff_log/diff_select_groupkey_alias_ut_20250907.md
+++ b/docs/diff_log/diff_select_groupkey_alias_ut_20250907.md
@@ -1,0 +1,2 @@
+# diff: Select group key alias UT (2025-09-07)
+- add unit tests verifying `SelectExpressionVisitor` properly handles group key aliases

--- a/examples/tumbling-live-consumer/Program.cs
+++ b/examples/tumbling-live-consumer/Program.cs
@@ -21,12 +21,12 @@ class Program
 
         var unit = minutes == 1 ? "MINUTE" : "MINUTES";
         var sql = "SELECT " +
-                  " dedupraterecord_key->Broker AS BROKER, " +
-                  " dedupraterecord_key->Symbol AS SYMBOL, " +
+                  " dedupraterecord.key->Broker AS BROKER, " +
+                  " dedupraterecord.key->Symbol AS SYMBOL, " +
                   " WINDOWSTART AS WS, WINDOWEND AS WE, " +
                   " EARLIEST_BY_OFFSET(Bid) AS OPEN, MAX(Bid) AS HIGH, MIN(Bid) AS LOW, LATEST_BY_OFFSET(Bid) AS CLOSE " +
                   " FROM DEDUPRATES WINDOW TUMBLING (SIZE " + minutes + " " + unit + ") " +
-                  " GROUP BY dedupraterecord_key->Broker, dedupraterecord_key->Symbol " +
+                  " GROUP BY dedupraterecord.key->Broker, dedupraterecord.key->Symbol " +
                   " EMIT CHANGES;";
 
         using var http = new HttpClient { Timeout = Timeout.InfiniteTimeSpan };

--- a/src/Query/Builders/Common/KeyNameResolver.cs
+++ b/src/Query/Builders/Common/KeyNameResolver.cs
@@ -16,7 +16,7 @@ internal static class KeyNameResolver
             var builder = new ModelBuilder();
             builder.AddEntityModel(t);
             var model = builder.GetEntityModel(t)!;
-            return $"{model.GetTopicName()}_key";
+            return $"{model.GetTopicName()}.key";
         });
     }
 }

--- a/src/Query/Builders/SelectExpressionVisitor.cs
+++ b/src/Query/Builders/SelectExpressionVisitor.cs
@@ -51,7 +51,7 @@ internal class SelectExpressionVisitor : ExpressionVisitor
             var arg = node.Arguments[i];
             var memberName = node.Members?[i]?.Name ?? $"col{i}";
 
-            if (IsGroupKeyAccess(arg))
+            if (IsGroupKeyObject(arg))
             {
                 AddGroupKeyColumns();
             }
@@ -59,7 +59,7 @@ internal class SelectExpressionVisitor : ExpressionVisitor
             {
                 var columnExpression = ProcessProjectionArgument(arg);
                 var alias = GenerateUniqueAlias(memberName);
-                if (columnExpression != alias)
+                if (!string.Equals(columnExpression, alias, StringComparison.OrdinalIgnoreCase))
                     _columns.Add($"{columnExpression} AS {alias}");
                 else
                     _columns.Add(columnExpression);
@@ -76,7 +76,7 @@ internal class SelectExpressionVisitor : ExpressionVisitor
         {
             var memberName = binding.Member.Name;
             var expr = binding.Expression;
-            if (IsGroupKeyAccess(expr))
+            if (IsGroupKeyObject(expr))
             {
                 AddGroupKeyColumns();
             }
@@ -84,7 +84,9 @@ internal class SelectExpressionVisitor : ExpressionVisitor
             {
                 var columnExpression = ProcessProjectionArgument(expr);
                 var alias = GenerateUniqueAlias(memberName);
-                if (columnExpression != alias)
+                var needsAlias = !string.Equals(columnExpression, alias, StringComparison.OrdinalIgnoreCase)
+                                || IsGroupKeyMember(expr);
+                if (needsAlias)
                     _columns.Add($"{columnExpression} AS {alias}");
                 else
                     _columns.Add(columnExpression);
@@ -95,7 +97,7 @@ internal class SelectExpressionVisitor : ExpressionVisitor
 
     protected override Expression VisitMember(MemberExpression node)
     {
-        if (IsGroupKeyAccess(node))
+        if (IsGroupKeyObject(node))
         {
             AddGroupKeyColumns();
         }
@@ -291,21 +293,25 @@ internal class SelectExpressionVisitor : ExpressionVisitor
         return BuilderValidation.SafeToString(value);
     }
 
-    private static bool IsGroupKeyAccess(Expression expr)
+    private static bool IsGroupKeyObject(Expression expr)
+    {
+        return expr is MemberExpression member &&
+               member.Member.Name == "Key" &&
+               member.Expression is ParameterExpression;
+    }
+
+    private static bool IsGroupKeyMember(Expression expr)
     {
         if (expr is not MemberExpression member)
             return false;
 
-        // g.Key or g.Key.Property
         if (member.Member.Name == "Key" && member.Expression is ParameterExpression)
             return true;
 
         if (member.Expression is MemberExpression inner &&
             inner.Member.Name == "Key" &&
             inner.Expression is ParameterExpression)
-        {
             return true;
-        }
 
         return false;
     }
@@ -353,7 +359,7 @@ internal class SelectExpressionVisitor : ExpressionVisitor
 
         var dtoKeyMembers = node.Arguments
             .Zip(node.Members ?? Enumerable.Empty<MemberInfo>(), (arg, mem) => new { arg, mem })
-            .Where(x => IsGroupKeyAccess(x.arg))
+            .Where(x => IsGroupKeyMember(x.arg))
             .Select(x => x.mem.Name)
             .ToList();
 
@@ -375,7 +381,7 @@ internal class SelectExpressionVisitor : ExpressionVisitor
 
         var dtoKeyMembers = node.Bindings
             .OfType<MemberAssignment>()
-            .Where(b => IsGroupKeyAccess(b.Expression))
+            .Where(b => IsGroupKeyMember(b.Expression))
             .Select(b => b.Member.Name)
             .ToList();
 

--- a/tests/Query/Builders/GroupByClauseBuilderTests.cs
+++ b/tests/Query/Builders/GroupByClauseBuilderTests.cs
@@ -23,6 +23,6 @@ public class GroupByClauseBuilderTests
         Expression<Func<TestEntity, object>> expr = e => new { e.Id, e.Type };
         var builder = new GroupByClauseBuilder();
         var sql = builder.Build(expr.Body);
-        Assert.Equal("test-topic_key->ID, Type", sql);
+        Assert.Equal("test-topic.key->ID, Type", sql);
     }
 }

--- a/tests/Query/Builders/SelectClauseBuilderTests.cs
+++ b/tests/Query/Builders/SelectClauseBuilderTests.cs
@@ -16,7 +16,7 @@ public class SelectClauseBuilderTests
         Expression<Func<TestEntity, object>> expr = e => new { e.Id, e.Name };
         var builder = new SelectClauseBuilder();
         var sql = builder.Build(expr.Body);
-        Assert.Equal("test-topic_key->ID AS Id, Name", sql);
+        Assert.Equal("test-topic.key->ID AS Id, Name", sql);
     }
 
     [Fact]

--- a/tests/Query/Builders/Visitors/GroupByExpressionVisitorTests.cs
+++ b/tests/Query/Builders/Visitors/GroupByExpressionVisitorTests.cs
@@ -18,7 +18,7 @@ public class GroupByExpressionVisitorTests
         var visitor = new GroupByExpressionVisitor();
         visitor.Visit(expr.Body);
         var result = visitor.GetResult();
-        Assert.Equal("test-topic_key->ID, Type", result);
+        Assert.Equal("test-topic.key->ID, Type", result);
     }
 
     [Fact]

--- a/tests/Query/Builders/Visitors/SelectExpressionVisitorGroupKeyAliasTests.cs
+++ b/tests/Query/Builders/Visitors/SelectExpressionVisitorGroupKeyAliasTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Kafka.Ksql.Linq.Core.Attributes;
+using Kafka.Ksql.Linq.Query.Builders;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Builders.Visitors;
+
+public class SelectExpressionVisitorGroupKeyAliasTests
+{
+    private class Quote
+    {
+        [KsqlKey(order: 0)]
+        public string Broker { get; set; } = string.Empty;
+    }
+
+    private class QuoteKey
+    {
+        public string Broker { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public void VisitNew_GroupKeyProperty_NoDuplicateAlias()
+    {
+        Expression<Func<Quote, QuoteKey>> groupExpr = e => new QuoteKey { Broker = e.Broker };
+        var groupBuilder = new GroupByClauseBuilder();
+        groupBuilder.Build(groupExpr.Body);
+
+        Expression<Func<IGrouping<QuoteKey, Quote>, object>> select = g => new { g.Key.Broker };
+        var visitor = new SelectExpressionVisitor();
+        visitor.Visit(select.Body);
+        var result = visitor.GetResult();
+        Assert.Equal("Broker", result);
+    }
+
+    [Fact]
+    public void VisitNew_GroupKeyProperty_WithAlias_UsesAsKeyword()
+    {
+        Expression<Func<Quote, QuoteKey>> groupExpr = e => new QuoteKey { Broker = e.Broker };
+        var groupBuilder = new GroupByClauseBuilder();
+        groupBuilder.Build(groupExpr.Body);
+
+        Expression<Func<IGrouping<QuoteKey, Quote>, object>> select = g => new { b = g.Key.Broker };
+        var visitor = new SelectExpressionVisitor();
+        visitor.Visit(select.Body);
+        var result = visitor.GetResult();
+        Assert.Equal("Broker AS b", result);
+    }
+
+    private class QuoteFull
+    {
+        [KsqlKey(order: 0)]
+        public string Broker { get; set; } = string.Empty;
+        [KsqlKey(order: 1)]
+        public string Symbol { get; set; } = string.Empty;
+        public decimal Bid { get; set; }
+    }
+
+    private class QuoteKeyFull
+    {
+        public string Broker { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
+    }
+
+    private class Ohlc
+    {
+        public string Broker { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
+        public DateTime BucketStart { get; set; }
+        public decimal Open { get; set; }
+        public decimal High { get; set; }
+        public decimal Low { get; set; }
+        public decimal Close { get; set; }
+    }
+
+    [Fact]
+    public void VisitMemberInit_GroupKeysAndAggregates_EmitAsAliases()
+    {
+        Expression<Func<QuoteFull, QuoteKeyFull>> groupExpr = e => new QuoteKeyFull { Broker = e.Broker, Symbol = e.Symbol };
+        var groupBuilder = new GroupByClauseBuilder();
+        var groupClause = groupBuilder.Build(groupExpr.Body);
+        Assert.Equal("quotefull.key->BROKER, quotefull.key->SYMBOL", groupClause);
+
+        Expression<Func<IGrouping<QuoteKeyFull, QuoteFull>, Ohlc>> select = g => new Ohlc
+        {
+            Broker = g.Key.Broker,
+            Symbol = g.Key.Symbol,
+            BucketStart = g.WindowStart(),
+            Open = g.EarliestByOffset(x => x.Bid),
+            High = g.Max(x => x.Bid),
+            Low = g.Min(x => x.Bid),
+            Close = g.LatestByOffset(x => x.Bid)
+        };
+
+        var visitor = new SelectExpressionVisitor();
+        visitor.Visit(select.Body);
+        var result = visitor.GetResult();
+        Assert.Equal("Broker AS Broker, Symbol AS Symbol, WINDOWSTART AS BucketStart, EARLIEST_BY_OFFSET(Bid) AS Open, MAX(Bid) AS High, MIN(Bid) AS Low, LATEST_BY_OFFSET(Bid) AS Close", result);
+    }
+}

--- a/tests/Query/Dsl/ToQueryDslTests.cs
+++ b/tests/Query/Dsl/ToQueryDslTests.cs
@@ -90,7 +90,7 @@ public class ToQueryDslTests
             .Build();
 
         var sql = KsqlCreateStatementBuilder.Build("orders", model);
-        Assert.Contains("SELECT order_key->ID AS Id", sql);
+        Assert.Contains("SELECT order.key->ID AS Id", sql);
     }
 
     [Fact]

--- a/tests/Query/Pipeline/DMLQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/DMLQueryGeneratorTests.cs
@@ -126,7 +126,7 @@ public class DMLQueryGeneratorTests
         var generator = new DMLQueryGenerator();
         var query = ExecuteInScope(() => generator.GenerateLinqQuery("deduprate", expr.Expression, false));
 
-        Assert.Contains("GROUP BY deduprate_key->BROKER, deduprate_key->SYMBOL", query);
+        Assert.Contains("GROUP BY deduprate.key->BROKER, deduprate.key->SYMBOL", query);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- ensure SelectExpressionVisitor adds `AS` aliases for group key member assignments even when names match
- add unit test covering group key aliases with aggregate functions
- switch group key prefix to `tablename.key->column` and update tests

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter 'FullyQualifiedName!~Kafka.Ksql.Linq.Tests.Integration'`

------
https://chatgpt.com/codex/tasks/task_e_68bc2c0a36408327a001cd6664a5b7df