### PR TITLE
Add CreateStream multi-key unit test

### DIFF
--- a/docs/diff_log/diff_create_stream_multi_key_20250906.md
+++ b/docs/diff_log/diff_create_stream_multi_key_20250906.md
@@ -1,0 +1,3 @@
+# Create stream multi-key test
+
+- Added unit test verifying GenerateCreateStream produces STRUCT key column when multiple key properties exist.

--- a/tests/Query/Pipeline/DDLQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/DDLQueryGeneratorTests.cs
@@ -122,6 +122,27 @@ public class DDLQueryGeneratorTests
     }
 
     [Fact]
+    public void GenerateCreateStream_WithMultipleKeys_UsesStructKey()
+    {
+        var model = new EntityModel
+        {
+            EntityType = typeof(MultiKeyEntity),
+            TopicName = "multi",
+            KeyProperties = new[]
+            {
+                typeof(MultiKeyEntity).GetProperty(nameof(MultiKeyEntity.Id1))!,
+                typeof(MultiKeyEntity).GetProperty(nameof(MultiKeyEntity.Id2))!
+            },
+            AllProperties = typeof(MultiKeyEntity).GetProperties()
+        };
+        var generator = new DDLQueryGenerator();
+        var query = ExecuteInScope(() => generator.GenerateCreateStream(new EntityModelDdlAdapter(model)));
+        Assert.Contains("multikeyentity_key STRUCT<Id1 INT, Id2 INT> KEY", query);
+        Assert.DoesNotContain("Id1 INT KEY", query);
+        Assert.DoesNotContain("Id2 INT KEY", query);
+    }
+
+    [Fact]
     public void GenerateCreateStream_SanitizesHyphenName()
     {
         var model = CreateEntityModel();
@@ -169,6 +190,13 @@ public class DDLQueryGeneratorTests
             generator.GenerateCreateStream(new EntityModelDdlAdapter(model)));
 
         Assert.Contains("Where/GroupBy/Select", ex.Message);
+    }
+
+    private class MultiKeyEntity
+    {
+        public int Id1 { get; set; }
+        public int Id2 { get; set; }
+        public string Name { get; set; } = string.Empty;
     }
 
     [KsqlTopic("attr_entity", PartitionCount = 3, ReplicationFactor = 2)]


### PR DESCRIPTION
## Summary
- add DDLQueryGenerator test ensuring GenerateCreateStream handles entities with multiple key columns
- document multi-key CreateStream test in diff log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bc4b82479483278be954cc393b3ae7