### PR TITLE
Use column keys for multi-key streams

### DIFF
--- a/docs/diff_log/diff_stream_multi_key_20250906.md
+++ b/docs/diff_log/diff_stream_multi_key_20250906.md
@@ -1,0 +1,4 @@
+# diff_stream_multi_key_20250906
+- Stream DDL generation no longer groups multiple keys into a STRUCT.
+- Each key column is marked with `KEY` individually.
+- Added unit test `GenerateCreateStream_WithMultipleKeys_UsesColumnKeys`.

--- a/src/Query/Pipeline/DDLQueryGenerator.cs
+++ b/src/Query/Pipeline/DDLQueryGenerator.cs
@@ -180,7 +180,7 @@ internal class DDLQueryGenerator : GeneratorBase, IDDLQueryGenerator
 
         var columns = new List<string>();
 
-        if (keyColumns.Count > 1)
+        if (keyColumns.Count > 1 && !isStream)
         {
             var fields = keyColumns.Select(c => $"{QuoteIfReserved(c.Name)} {c.Type}");
             var structDef = $"STRUCT<{string.Join(", ", fields)}>";

--- a/tests/Query/DDLQueryGeneratorTests.cs
+++ b/tests/Query/DDLQueryGeneratorTests.cs
@@ -47,7 +47,7 @@ public class DdlColumnDefinitionsTests
     }
 
     [Fact]
-    public void CreateStream_MultiKey_StructKey_QuotesReservedFields()
+    public void CreateStream_MultiKey_QuotesReservedFields()
     {
         var schema = new DdlSchemaBuilder("dead_letter_queue", DdlObjectType.Stream, "dead-letter-queue", 1, 1)
             .AddColumn("Topic", "VARCHAR", isKey: true)
@@ -59,7 +59,9 @@ public class DdlColumnDefinitionsTests
         using (Kafka.Ksql.Linq.Core.Modeling.ModelCreatingScope.Enter())
         {
             var sql = gen.GenerateCreateStream(new SchemaProvider(schema));
-            Assert.Contains("STRUCT<`Topic` VARCHAR, `Partition` INT, `Offset` BIGINT> KEY", sql);
+            Assert.Contains("`Topic` VARCHAR KEY", sql);
+            Assert.Contains("`Partition` INT KEY", sql);
+            Assert.Contains("`Offset` BIGINT KEY", sql);
             Assert.Contains("ErrorMessage VARCHAR", sql);
         }
     }

--- a/tests/Query/Pipeline/DDLQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/DDLQueryGeneratorTests.cs
@@ -122,7 +122,7 @@ public class DDLQueryGeneratorTests
     }
 
     [Fact]
-    public void GenerateCreateStream_WithMultipleKeys_UsesStructKey()
+    public void GenerateCreateStream_WithMultipleKeys_UsesColumnKeys()
     {
         var model = new EntityModel
         {
@@ -131,15 +131,15 @@ public class DDLQueryGeneratorTests
             KeyProperties = new[]
             {
                 typeof(MultiKeyEntity).GetProperty(nameof(MultiKeyEntity.Id1))!,
-                typeof(MultiKeyEntity).GetProperty(nameof(MultiKeyEntity.Id2))!
+                typeof(MultiKeyEntity).GetProperty(nameof(MultiKeyEntity.Id2))!,
             },
             AllProperties = typeof(MultiKeyEntity).GetProperties()
         };
         var generator = new DDLQueryGenerator();
         var query = ExecuteInScope(() => generator.GenerateCreateStream(new EntityModelDdlAdapter(model)));
-        Assert.Contains("multikeyentity_key STRUCT<Id1 INT, Id2 INT> KEY", query);
-        Assert.DoesNotContain("Id1 INT KEY", query);
-        Assert.DoesNotContain("Id2 INT KEY", query);
+        Assert.Contains("Id1 INT KEY", query);
+        Assert.Contains("Id2 INT KEY", query);
+        Assert.DoesNotContain("STRUCT", query);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- use individual KEY markers for multi-key streams instead of STRUCT
- add unit tests verifying column-level keys and reserved-name quoting
- log changes in diff_log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bc5720f840832793adabaa2e11fe79