### PR TITLE
feat: add key path rendering options

### DIFF
--- a/docs/diff_log/diff_key_reference_policy_20250907.md
+++ b/docs/diff_log/diff_key_reference_policy_20250907.md
@@ -1,0 +1,4 @@
+# Key reference policy update
+- DSL now writes key columns using plain column names.
+- `KsqlCreateStatementBuilder` adds `RenderOptions.KeyPathStyle` to render keys as inline, `key.` or `KEY->`.
+- Default `KeyPathStyle.None` outputs inline key columns, while `Arrow` generates `KEY->col` for table compatibility.

--- a/src/Query/Builders/KsqlCreateStatementBuilder.cs
+++ b/src/Query/Builders/KsqlCreateStatementBuilder.cs
@@ -1,4 +1,5 @@
 using Kafka.Ksql.Linq.Query.Dsl;
+using Kafka.Ksql.Linq.Core.Attributes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,15 +10,15 @@ namespace Kafka.Ksql.Linq.Query.Builders;
 
 public static class KsqlCreateStatementBuilder
 {
-    public static string Build(string streamName, KsqlQueryModel model, string? keySchemaFullName = null, string? valueSchemaFullName = null, string? partitionBy = null)
+    public static string Build(string streamName, KsqlQueryModel model, string? keySchemaFullName = null, string? valueSchemaFullName = null, string? partitionBy = null, RenderOptions? options = null)
     {
-        return Build(streamName, model, keySchemaFullName, valueSchemaFullName, ResolveSourceName, partitionBy);
+        return Build(streamName, model, keySchemaFullName, valueSchemaFullName, ResolveSourceName, partitionBy, options);
     }
 
     /// <summary>
     /// Build a CREATE statement with an optional source name resolver for FROM/JOIN tables.
     /// </summary>
-    public static string Build(string streamName, KsqlQueryModel model, string? keySchemaFullName, string? valueSchemaFullName, Func<Type, string> sourceNameResolver, string? partitionBy = null)
+    public static string Build(string streamName, KsqlQueryModel model, string? keySchemaFullName, string? valueSchemaFullName, Func<Type, string> sourceNameResolver, string? partitionBy = null, RenderOptions? options = null)
     {
         if (string.IsNullOrWhiteSpace(streamName))
             throw new ArgumentException("Stream name is required", nameof(streamName));
@@ -48,6 +49,13 @@ public static class KsqlCreateStatementBuilder
         var fromClause = BuildFromClauseCore(model, sourceNameResolver);
         var whereClause = BuildWhereClause(model.WhereCondition, model);
         var havingClause = BuildHavingClause(model.HavingCondition);
+
+        var keyMap = BuildKeyAliasMap(model);
+        var style = options?.KeyPathStyle ?? KeyPathStyle.None;
+        selectClause = ApplyKeyStyle(selectClause, keyMap, style);
+        groupByClause = ApplyKeyStyle(groupByClause, keyMap, style);
+        whereClause = ApplyKeyStyle(whereClause, keyMap, style);
+        havingClause = ApplyKeyStyle(havingClause, keyMap, style);
 
         var createType = model.IsAggregateQuery ? "CREATE TABLE" : "CREATE STREAM";
 
@@ -230,6 +238,47 @@ public static class KsqlCreateStatementBuilder
         var builder = new HavingClauseBuilder();
         var condition = builder.Build(having.Body);
         return $"HAVING {condition}";
+    }
+
+    private static System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>> BuildKeyAliasMap(KsqlQueryModel model)
+    {
+        var map = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        var types = model.SourceTypes ?? Array.Empty<Type>();
+        if (types.Length > 0)
+            map["o"] = ExtractKeyNames(types[0]);
+        if (types.Length > 1)
+            map["i"] = ExtractKeyNames(types[1]);
+        return map;
+    }
+
+    private static System.Collections.Generic.HashSet<string> ExtractKeyNames(Type type)
+    {
+        return type
+            .GetProperties()
+            .Where(p => p.GetCustomAttributes(true).OfType<KsqlKeyAttribute>().Any())
+            .Select(p => p.Name.ToUpperInvariant())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string ApplyKeyStyle(string clause, System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>> map, KeyPathStyle style)
+    {
+        if (string.IsNullOrEmpty(clause)) return clause;
+        foreach (var kv in map)
+        {
+            var alias = kv.Key;
+            foreach (var key in kv.Value)
+            {
+                var pattern = $@"\b{alias}\.{key}\b";
+                var replacement = style switch
+                {
+                    KeyPathStyle.Dot => $"key.{key}",
+                    KeyPathStyle.Arrow => $"KEY->{key}",
+                    _ => key
+                };
+                clause = System.Text.RegularExpressions.Regex.Replace(clause, pattern, replacement);
+            }
+        }
+        return clause;
     }
 
     private static string FormatTimeSpan(TimeSpan timeSpan)

--- a/src/Query/Builders/RenderOptions.cs
+++ b/src/Query/Builders/RenderOptions.cs
@@ -1,0 +1,13 @@
+namespace Kafka.Ksql.Linq.Query.Builders;
+
+public enum KeyPathStyle
+{
+    None,
+    Dot,
+    Arrow
+}
+
+public class RenderOptions
+{
+    public KeyPathStyle KeyPathStyle { get; set; } = KeyPathStyle.None;
+}

--- a/tests/Query/Dsl/ToQueryDslTests.cs
+++ b/tests/Query/Dsl/ToQueryDslTests.cs
@@ -89,8 +89,8 @@ public class ToQueryDslTests
             .Select(o => new { o.Id })
             .Build();
 
-        var sql = KsqlCreateStatementBuilder.Build("orders", model);
-        Assert.Contains("SELECT o.ID AS Id", sql);
+        var sql = KsqlCreateStatementBuilder.Build("orders", model, options: new RenderOptions());
+        Assert.Contains("SELECT ID AS Id", sql);
     }
 
     [Fact]
@@ -259,7 +259,7 @@ public class ToQueryDslTests
     }
 
     [Fact]
-    public void GroupByKey_UsesAliasPrefix()
+    public void GroupByKey_RendersKeyWithoutAlias()
     {
         var model = new KsqlQueryRoot()
             .From<Order>()
@@ -267,9 +267,23 @@ public class ToQueryDslTests
             .Select(g => new { g.Key })
             .Build();
 
-        var sql = KsqlCreateStatementBuilder.Build("orders", model);
-        Assert.Contains("GROUP BY o.ID", sql);
-        Assert.Contains("SELECT o.ID AS ID", sql);
+        var sql = KsqlCreateStatementBuilder.Build("orders", model, options: new RenderOptions());
+        Assert.Contains("GROUP BY ID", sql);
+        Assert.Contains("SELECT ID AS ID", sql);
+    }
+
+    [Fact]
+    public void KeyPathStyle_Arrow_RendersKeyArrowForTable()
+    {
+        var model = new KsqlQueryRoot()
+            .From<Order>()
+            .GroupBy(o => o.Id)
+            .Select(g => new { g.Key })
+            .Build();
+
+        var sql = KsqlCreateStatementBuilder.Build("orders", model, options: new RenderOptions { KeyPathStyle = KeyPathStyle.Arrow });
+        Assert.Contains("GROUP BY KEY->ID", sql);
+        Assert.Contains("SELECT KEY->ID AS ID", sql);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add `RenderOptions` with `KeyPathStyle` to control key column rendering
- update `KsqlCreateStatementBuilder` to render key columns with inline, dot, or arrow styles
- cover key path styles in `ToQueryDslTests`

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bcc90cb478832789e931284237ac87