### PR TITLE
Auto key path style for tables vs streams

### DIFF
--- a/docs/diff_log/diff_keypath_auto_20250908.md
+++ b/docs/diff_log/diff_keypath_auto_20250908.md
@@ -1,0 +1,4 @@
+# DSL Key Path Auto Selection
+- KsqlCreateStatementBuilder now chooses key path style based on source type attributes.
+- Streams render key columns as regular names; tables render `KEY->` syntax.
+- RenderOptions remains for tests to force Dot or Arrow styles.

--- a/src/Query/Builders/KsqlCreateStatementBuilder.cs
+++ b/src/Query/Builders/KsqlCreateStatementBuilder.cs
@@ -50,12 +50,11 @@ public static class KsqlCreateStatementBuilder
         var whereClause = BuildWhereClause(model.WhereCondition, model);
         var havingClause = BuildHavingClause(model.HavingCondition);
 
-        var keyMap = BuildKeyAliasMap(model);
-        var style = options?.KeyPathStyle ?? KeyPathStyle.None;
-        selectClause = ApplyKeyStyle(selectClause, keyMap, style);
-        groupByClause = ApplyKeyStyle(groupByClause, keyMap, style);
-        whereClause = ApplyKeyStyle(whereClause, keyMap, style);
-        havingClause = ApplyKeyStyle(havingClause, keyMap, style);
+        var keyMap = BuildKeyAliasMap(model, options?.KeyPathStyle ?? KeyPathStyle.None);
+        selectClause = ApplyKeyStyle(selectClause, keyMap);
+        groupByClause = ApplyKeyStyle(groupByClause, keyMap);
+        whereClause = ApplyKeyStyle(whereClause, keyMap);
+        havingClause = ApplyKeyStyle(havingClause, keyMap);
 
         var createType = model.IsAggregateQuery ? "CREATE TABLE" : "CREATE STREAM";
 
@@ -240,15 +239,24 @@ public static class KsqlCreateStatementBuilder
         return $"HAVING {condition}";
     }
 
-    private static System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>> BuildKeyAliasMap(KsqlQueryModel model)
+    private static System.Collections.Generic.Dictionary<string, (System.Collections.Generic.HashSet<string> Keys, KeyPathStyle Style)> BuildKeyAliasMap(KsqlQueryModel model, KeyPathStyle overrideStyle)
     {
-        var map = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        var map = new System.Collections.Generic.Dictionary<string, (System.Collections.Generic.HashSet<string>, KeyPathStyle)>(StringComparer.OrdinalIgnoreCase);
         var types = model.SourceTypes ?? Array.Empty<Type>();
         if (types.Length > 0)
-            map["o"] = ExtractKeyNames(types[0]);
+            map["o"] = (ExtractKeyNames(types[0]), DetermineStyle(types[0], overrideStyle));
         if (types.Length > 1)
-            map["i"] = ExtractKeyNames(types[1]);
+            map["i"] = (ExtractKeyNames(types[1]), DetermineStyle(types[1], overrideStyle));
         return map;
+    }
+
+    private static KeyPathStyle DetermineStyle(Type type, KeyPathStyle overrideStyle)
+    {
+        if (overrideStyle != KeyPathStyle.None)
+            return overrideStyle;
+        return type.GetCustomAttributes(true).OfType<KsqlTableAttribute>().Any()
+            ? KeyPathStyle.Arrow
+            : KeyPathStyle.None;
     }
 
     private static System.Collections.Generic.HashSet<string> ExtractKeyNames(Type type)
@@ -260,13 +268,15 @@ public static class KsqlCreateStatementBuilder
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 
-    private static string ApplyKeyStyle(string clause, System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>> map, KeyPathStyle style)
+    private static string ApplyKeyStyle(string clause, System.Collections.Generic.Dictionary<string, (System.Collections.Generic.HashSet<string> Keys, KeyPathStyle Style)> map)
     {
         if (string.IsNullOrEmpty(clause)) return clause;
         foreach (var kv in map)
         {
             var alias = kv.Key;
-            foreach (var key in kv.Value)
+            var keys = kv.Value.Keys;
+            var style = kv.Value.Style;
+            foreach (var key in keys)
             {
                 var pattern = $@"\b{alias}\.{key}\b";
                 var replacement = style switch

--- a/tests/Query/Dsl/ToQueryDslTests.cs
+++ b/tests/Query/Dsl/ToQueryDslTests.cs
@@ -56,6 +56,14 @@ public class ToQueryDslTests
         public decimal Amount { get; set; }
     }
 
+    [KsqlTable]
+    private class OrderTable
+    {
+        [KsqlKey]
+        public int Id { get; set; }
+        public double Amount { get; set; }
+    }
+
     private class KeylessView
     {
         public string Name { get; set; } = string.Empty;
@@ -89,7 +97,7 @@ public class ToQueryDslTests
             .Select(o => new { o.Id })
             .Build();
 
-        var sql = KsqlCreateStatementBuilder.Build("orders", model, options: new RenderOptions());
+        var sql = KsqlCreateStatementBuilder.Build("orders", model);
         Assert.Contains("SELECT ID AS Id", sql);
     }
 
@@ -267,7 +275,7 @@ public class ToQueryDslTests
             .Select(g => new { g.Key })
             .Build();
 
-        var sql = KsqlCreateStatementBuilder.Build("orders", model, options: new RenderOptions());
+        var sql = KsqlCreateStatementBuilder.Build("orders", model);
         Assert.Contains("GROUP BY ID", sql);
         Assert.Contains("SELECT ID AS ID", sql);
     }
@@ -282,6 +290,20 @@ public class ToQueryDslTests
             .Build();
 
         var sql = KsqlCreateStatementBuilder.Build("orders", model, options: new RenderOptions { KeyPathStyle = KeyPathStyle.Arrow });
+        Assert.Contains("GROUP BY KEY->ID", sql);
+        Assert.Contains("SELECT KEY->ID AS ID", sql);
+    }
+
+    [Fact]
+    public void TableKey_RendersKeyArrowAutomatically()
+    {
+        var model = new KsqlQueryRoot()
+            .From<OrderTable>()
+            .GroupBy(o => o.Id)
+            .Select(g => new { g.Key })
+            .Build();
+
+        var sql = KsqlCreateStatementBuilder.Build("orders", model);
         Assert.Contains("GROUP BY KEY->ID", sql);
         Assert.Contains("SELECT KEY->ID AS ID", sql);
     }


### PR DESCRIPTION
## Summary
- auto-select key path style in `KsqlCreateStatementBuilder` based on source type attributes
- add unit tests covering stream/table SQL generation and retain RenderOptions override
- document key path auto selection

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68bccfea1b5083278d52117fe0324296