### PR TITLE
Auto key path style for tables vs streams

### DIFF
--- a/docs/diff_log/diff_keypath_auto_20250908.md
+++ b/docs/diff_log/diff_keypath_auto_20250908.md
@@ -1,0 +1,6 @@
+# DSL Key Path Auto Selection
+- KsqlCreateStatementBuilder now chooses key path style based on source type attributes.
+- Streams render key columns as regular names; tables render `KEY->` syntax.
+- RenderOptions is an internal test/back-compat knob; Dot style is override-only and never chosen automatically.
+- Join/WHERE/HAVING clauses also auto-apply key styles with guards to avoid double or quoted replacements.
+- Key projections use column aliases directly; `AS_VALUE` is not emitted for key columns.

--- a/src/Query/Builders/KsqlCreateStatementBuilder.cs
+++ b/src/Query/Builders/KsqlCreateStatementBuilder.cs
@@ -50,12 +50,14 @@ public static class KsqlCreateStatementBuilder
         var whereClause = BuildWhereClause(model.WhereCondition, model);
         var havingClause = BuildHavingClause(model.HavingCondition);
 
-        var keyMap = BuildKeyAliasMap(model);
-        var style = options?.KeyPathStyle ?? KeyPathStyle.None;
-        selectClause = ApplyKeyStyle(selectClause, keyMap, style);
-        groupByClause = ApplyKeyStyle(groupByClause, keyMap, style);
-        whereClause = ApplyKeyStyle(whereClause, keyMap, style);
-        havingClause = ApplyKeyStyle(havingClause, keyMap, style);
+        var keyMap = BuildKeyAliasMap(model, options?.KeyPathStyle ?? KeyPathStyle.None);
+        var mapForFrom = keyMap.Where(kv => kv.Value.Style != KeyPathStyle.None)
+            .ToDictionary(kv => kv.Key, kv => kv.Value);
+        fromClause = ApplyKeyStyle(fromClause, mapForFrom);
+        selectClause = ApplyKeyStyle(selectClause, keyMap);
+        groupByClause = ApplyKeyStyle(groupByClause, keyMap);
+        whereClause = ApplyKeyStyle(whereClause, keyMap);
+        havingClause = ApplyKeyStyle(havingClause, keyMap);
 
         var createType = model.IsAggregateQuery ? "CREATE TABLE" : "CREATE STREAM";
 
@@ -240,15 +242,26 @@ public static class KsqlCreateStatementBuilder
         return $"HAVING {condition}";
     }
 
-    private static System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>> BuildKeyAliasMap(KsqlQueryModel model)
+    private static System.Collections.Generic.Dictionary<string, (System.Collections.Generic.HashSet<string> Keys, KeyPathStyle Style)> BuildKeyAliasMap(KsqlQueryModel model, KeyPathStyle overrideStyle)
     {
-        var map = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        var map = new System.Collections.Generic.Dictionary<string, (System.Collections.Generic.HashSet<string>, KeyPathStyle)>(StringComparer.OrdinalIgnoreCase);
         var types = model.SourceTypes ?? Array.Empty<Type>();
         if (types.Length > 0)
-            map["o"] = ExtractKeyNames(types[0]);
+            map["o"] = (ExtractKeyNames(types[0]), DetermineStyle(types[0], overrideStyle));
         if (types.Length > 1)
-            map["i"] = ExtractKeyNames(types[1]);
+            map["i"] = (ExtractKeyNames(types[1]), DetermineStyle(types[1], overrideStyle));
+        // TODO: future model-provided aliases should feed this map instead of fixed o/i.
         return map;
+    }
+
+    private static KeyPathStyle DetermineStyle(Type type, KeyPathStyle overrideStyle)
+    {
+        if (overrideStyle != KeyPathStyle.None)
+            return overrideStyle;
+        // Auto-detection only yields Arrow for tables; Dot is reserved for explicit overrides.
+        return type.GetCustomAttributes(true).OfType<KsqlTableAttribute>().Any()
+            ? KeyPathStyle.Arrow
+            : KeyPathStyle.None;
     }
 
     private static System.Collections.Generic.HashSet<string> ExtractKeyNames(Type type)
@@ -260,22 +273,45 @@ public static class KsqlCreateStatementBuilder
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 
-    private static string ApplyKeyStyle(string clause, System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>> map, KeyPathStyle style)
+    private static string ApplyKeyStyle(string clause, System.Collections.Generic.Dictionary<string, (System.Collections.Generic.HashSet<string> Keys, KeyPathStyle Style)> map)
     {
         if (string.IsNullOrEmpty(clause)) return clause;
         foreach (var kv in map)
         {
             var alias = kv.Key;
-            foreach (var key in kv.Value)
+            var keys = kv.Value.Keys;
+            var style = kv.Value.Style;
+            if (style != KeyPathStyle.None && keys.Count == 1)
             {
-                var pattern = $@"\b{alias}\.{key}\b";
+                var lone = keys.First();
+                var standAlonePattern = @"\bKEY\b";
+                var standAloneReplacement = style switch
+                {
+                    KeyPathStyle.Dot => $"key.{lone}",
+                    KeyPathStyle.Arrow => $"KEY->{lone}",
+                    _ => lone
+                };
+                clause = System.Text.RegularExpressions.Regex.Replace(
+                    clause,
+                    standAlonePattern,
+                    standAloneReplacement,
+                    System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Compiled | System.Text.RegularExpressions.RegexOptions.CultureInvariant);
+            }
+            foreach (var key in keys)
+            {
+                // Skip tokens already prefixed (KEY-> or key.) and any inside quotes/backticks.
+                var pattern = $@"(?<!KEY->)(?<!key\.)(?<![`'""])\b{alias}\.{key}\b(?![`'""])";
                 var replacement = style switch
                 {
                     KeyPathStyle.Dot => $"key.{key}",
                     KeyPathStyle.Arrow => $"KEY->{key}",
                     _ => key
                 };
-                clause = System.Text.RegularExpressions.Regex.Replace(clause, pattern, replacement);
+                clause = System.Text.RegularExpressions.Regex.Replace(
+                    clause,
+                    pattern,
+                    replacement,
+                    System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Compiled | System.Text.RegularExpressions.RegexOptions.CultureInvariant);
             }
         }
         return clause;

--- a/src/Query/Builders/RenderOptions.cs
+++ b/src/Query/Builders/RenderOptions.cs
@@ -1,13 +1,17 @@
 namespace Kafka.Ksql.Linq.Query.Builders;
 
-public enum KeyPathStyle
-{
-    None,
-    Dot,
-    Arrow
-}
+  public enum KeyPathStyle
+  {
+      None,
+      Dot,
+      Arrow
+  }
 
-public class RenderOptions
-{
-    public KeyPathStyle KeyPathStyle { get; set; } = KeyPathStyle.None;
-}
+  /// <summary>
+  /// Internal hook for tests and backward compatibility. Regular DSL usage relies on auto-detection
+  /// which selects Arrow for tables and None for streams. Dot style is available only via explicit override.
+  /// </summary>
+  public class RenderOptions
+  {
+      public KeyPathStyle KeyPathStyle { get; set; } = KeyPathStyle.None;
+  }

--- a/tests/Query/Dsl/ToQueryDslTests.cs
+++ b/tests/Query/Dsl/ToQueryDslTests.cs
@@ -5,6 +5,7 @@ using Kafka.Ksql.Linq.Query.Builders;
 using Kafka.Ksql.Linq.Core.Modeling;
 using System;
 using System.Linq;
+using System.Linq.Expressions;
 using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Query.Dsl;
@@ -56,6 +57,24 @@ public class ToQueryDslTests
         public decimal Amount { get; set; }
     }
 
+    [KsqlTable]
+    private class OrderTable
+    {
+        [KsqlKey]
+        public int Id { get; set; }
+        public double Amount { get; set; }
+    }
+
+    [KsqlTable]
+    private class QuoteTable
+    {
+        [KsqlKey]
+        public string Broker { get; set; } = string.Empty;
+        [KsqlKey]
+        public string Symbol { get; set; } = string.Empty;
+        public double Price { get; set; }
+    }
+
     private class KeylessView
     {
         public string Name { get; set; } = string.Empty;
@@ -89,7 +108,7 @@ public class ToQueryDslTests
             .Select(o => new { o.Id })
             .Build();
 
-        var sql = KsqlCreateStatementBuilder.Build("orders", model, options: new RenderOptions());
+        var sql = KsqlCreateStatementBuilder.Build("orders", model);
         Assert.Contains("SELECT ID AS Id", sql);
     }
 
@@ -267,7 +286,7 @@ public class ToQueryDslTests
             .Select(g => new { g.Key })
             .Build();
 
-        var sql = KsqlCreateStatementBuilder.Build("orders", model, options: new RenderOptions());
+        var sql = KsqlCreateStatementBuilder.Build("orders", model);
         Assert.Contains("GROUP BY ID", sql);
         Assert.Contains("SELECT ID AS ID", sql);
     }
@@ -284,6 +303,83 @@ public class ToQueryDslTests
         var sql = KsqlCreateStatementBuilder.Build("orders", model, options: new RenderOptions { KeyPathStyle = KeyPathStyle.Arrow });
         Assert.Contains("GROUP BY KEY->ID", sql);
         Assert.Contains("SELECT KEY->ID AS ID", sql);
+    }
+
+    [Fact]
+    public void TableKey_RendersKeyArrowAutomatically()
+    {
+        var model = new KsqlQueryRoot()
+            .From<OrderTable>()
+            .GroupBy(o => o.Id)
+            .Select(g => new { g.Key })
+            .Build();
+
+        var sql = KsqlCreateStatementBuilder.Build("orders", model);
+        Assert.Contains("GROUP BY KEY->ID", sql);
+        Assert.Contains("SELECT KEY->ID AS ID", sql);
+    }
+
+    [Fact]
+    public void TableCompositeKey_RendersArrowForEachKey()
+    {
+        var model = new KsqlQueryRoot()
+            .From<QuoteTable>()
+            .GroupBy(q => new { q.Broker, q.Symbol })
+            .Select(g => new { g.Key.Broker, g.Key.Symbol })
+            .Build();
+
+        var sql = KsqlCreateStatementBuilder.Build("quotes", model);
+        Assert.Contains("GROUP BY KEY->BROKER, KEY->SYMBOL", sql);
+        Assert.Contains("SELECT KEY->BROKER AS Broker, KEY->SYMBOL AS Symbol", sql);
+    }
+
+    [Fact]
+    public void StreamTableJoin_AppliesArrowOnlyToTableSide()
+    {
+        var model = new KsqlQueryModel
+        {
+            SourceTypes = new[] { typeof(OrderTable), typeof(Customer) },
+            JoinCondition = (Expression<Func<OrderTable, Customer, bool>>)((o, c) => o.Id == c.Id),
+            WhereCondition = (Expression<Func<OrderTable, Customer, bool>>)((o, c) => o.Id > 0 && c.Id > 0),
+            GroupByExpression = (Expression<Func<OrderTable, Customer, object>>)((o, c) => new { o.Id, c.Name }),
+            SelectProjection = (Expression<Func<OrderTable, Customer, object>>)((o, c) => new { o.Id, c.Name }),
+            WithinSeconds = 300,
+            IsAggregateQuery = true
+        };
+
+        var sql = KsqlCreateStatementBuilder.Build("view", model);
+        Assert.Contains("ON (KEY->ID = i.Id)", sql);
+        Assert.Contains("SELECT KEY->ID AS Id", sql);
+        Assert.Contains("GROUP BY KEY->ID, Name", sql);
+        Assert.DoesNotContain("KEY->Name", sql);
+        Assert.Contains("WHERE ((KEY->ID > 0) AND (ID > 0))", sql);
+    }
+
+    [Fact]
+    public void WhereClause_KeyArrowApplied()
+    {
+        var model = new KsqlQueryRoot()
+            .From<OrderTable>()
+            .Where(o => o.Id > 0)
+            .Select(o => new { o.Amount })
+            .Build();
+
+        var sql = KsqlCreateStatementBuilder.Build("orders", model);
+        Assert.Contains("WHERE (KEY->ID > 0)", sql);
+    }
+
+    [Fact]
+    public void HavingClause_KeyArrowApplied()
+    {
+        var model = new KsqlQueryRoot()
+            .From<OrderTable>()
+            .GroupBy(o => o.Id)
+            .Having(g => g.Key > 1)
+            .Select(g => new { g.Key })
+            .Build();
+
+        var sql = KsqlCreateStatementBuilder.Build("orders", model);
+        Assert.Contains("HAVING (KEY->ID > 1)", sql);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- guard key style replacement to skip existing prefixes and quoted identifiers
- auto-apply key style to JOIN/WHERE/HAVING clauses with stream-table join coverage
- document RenderOptions as internal override knob

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bccfea1b5083278d52117fe0324296