### PR TITLE
Use tumbling windows for final bars

### DIFF
--- a/docs/diff_log/diff_tumbling_final_window_20250907.md
+++ b/docs/diff_log/diff_tumbling_final_window_20250907.md
@@ -1,0 +1,4 @@
+## Tumbling final window emits
+- Final tables now use `WINDOW TUMBLING` with `EMIT FINAL`
+- Derivation planner links finals to base 1m tables instead of compose
+- Tests updated for new final semantics

--- a/src/Query/Adapters/QueryAdapter.cs
+++ b/src/Query/Adapters/QueryAdapter.cs
@@ -20,7 +20,7 @@ internal static class QueryAdapter
             {
                 Role.AggFinal => $"Window(TUMBLING,{e.Timeframe.Value}{e.Timeframe.Unit})+Emit(FINAL+GRACE)",
                 Role.Live => $"Window(TUMBLING,{e.Timeframe.Value}{e.Timeframe.Unit})+Emit(CHANGES)",
-                Role.Final => "Compose(AggFinal⟂BarPrev1m)",
+                Role.Final => $"Window(TUMBLING,{e.Timeframe.Value}{e.Timeframe.Unit})+Emit(FINAL)",
                 _ => string.Empty
             };
             var projector = e.Role == Role.AggFinal ? "BucketStartFromWindowStart" : null;

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -60,15 +60,17 @@ internal static class DerivationPlanner
                 Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
-                InputHint = tf.Unit == "m" && tf.Value == 1 ? "bar_1m_agg_final ⟂ bar_prev_1m" : $"bar_{tfStr}_agg_final ⟂ bar_prev_1m",
+                InputHint = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? "bar_1m_final" : "bar_1m_live",
                 SyncHint = tf.Unit == "m" && tf.Value == 1 ? "HB_1m" : null,
                 BasedOnSpec = qao.BasedOn,
                 WeekAnchor = qao.WeekAnchor
             };
             entities.Add(final); dag.AddNode(finalId);
 
-            dag.AddEdge(aggId, finalId);
-            dag.AddEdge("bar_prev_1m", finalId);
+            if (tf.Unit == "wk")
+                dag.AddEdge("bar_1m_final", finalId);
+            else if (!(tf.Unit == "m" && tf.Value == 1))
+                dag.AddEdge("bar_1m_live", finalId);
             if (tf.Unit == "wk")
                 dag.AddEdge("bar_1m_final", liveId);
             else if (!(tf.Unit == "m" && tf.Value == 1))

--- a/src/Query/Builders/Core/RoleTraits.cs
+++ b/src/Query/Builders/Core/RoleTraits.cs
@@ -11,7 +11,7 @@ internal static class RoleTraits
         {
             Role.Live => new(true, "CHANGES", false, false, is1m),
             Role.AggFinal => new(true, "FINAL GRACE", true, false, false),
-            Role.Final => new(false, null, false, true, is1m),
+            Role.Final => new(true, "FINAL", false, false, is1m),
             _ => new(false, null, false, false, false)
         };
     }

--- a/src/Query/Pipeline/ExpressionAnalysisResult.cs
+++ b/src/Query/Pipeline/ExpressionAnalysisResult.cs
@@ -59,7 +59,7 @@ internal class ExpressionAnalysisResult
                 _ => "bar_1m_live"
             };
             md = md.WithProperty($"input/{tf}Live", liveInput);
-            md = md.WithProperty($"input/{tf}Final", $"bar_{tf}_agg_final ⟂ bar_prev_1m");
+            md = md.WithProperty($"input/{tf}Final", liveInput);
         }
         return md;
     }

--- a/tests/Query/Analysis/ChartChecklistTests.cs
+++ b/tests/Query/Analysis/ChartChecklistTests.cs
@@ -157,8 +157,7 @@ public class ChartChecklistTests
         Assert.Equal("Window(TUMBLING,1m)+Emit(FINAL+GRACE)", specs.First(s => s.TargetId == "bar_1m_agg_final").Operation);
         Assert.Equal("Window(TUMBLING,1m)+Emit(CHANGES)", specs.First(s => s.TargetId == "bar_1m_live").Operation);
         var final = specs.First(s => s.TargetId == "bar_1m_final");
-        Assert.Contains("bar_prev_1m", final.Sources);
-        Assert.Equal("Compose(AggFinal⟂BarPrev1m)", final.Operation);
+        Assert.Equal("Window(TUMBLING,1m)+Emit(FINAL)", final.Operation);
     }
 
     [Fact]
@@ -213,7 +212,7 @@ public class ChartChecklistTests
     }
 
     [Fact]
-    public void QueryAdapter_Composes_5m_Final_With_1m_Prev()
+    public void QueryAdapter_Builds_5m_Final_Window()
     {
         var qao = new TumblingQao
         {
@@ -234,9 +233,9 @@ public class ChartChecklistTests
         Assert.Contains(entities, e => e.Id == "bar_prev_1m" && e.Role == Role.Prev1m);
         var specs = QueryAdapter.Build(entities, dag);
         var final5m = specs.First(s => s.TargetId == "bar_5m_final");
-        Assert.Contains("bar_prev_1m", final5m.Sources);
-        Assert.Equal("Compose(AggFinal⟂BarPrev1m)", final5m.Operation);
-        Assert.Contains("bar_prev_1m", dag.Edges["bar_5m_final"]);
+        Assert.Contains("bar_1m_live", final5m.Sources);
+        Assert.Equal("Window(TUMBLING,5m)+Emit(FINAL)", final5m.Operation);
+        Assert.Contains("bar_1m_live", dag.Edges["bar_5m_final"]);
     }
 
     [Fact]

--- a/tests/Query/Analysis/Step1Tests.cs
+++ b/tests/Query/Analysis/Step1Tests.cs
@@ -102,7 +102,7 @@ public class Step1Tests
         var live = specs.First(s => s.TargetId.StartsWith("bar_1m_live"));
         Assert.Contains("CHANGES", live.Operation);
         var final = specs.First(s => s.TargetId.StartsWith("bar_1m_final"));
-        Assert.Contains("Compose", final.Operation);
+        Assert.Contains("FINAL", final.Operation);
         Assert.NotEmpty(agg.BasedOnRef.JoinKeys);
     }
 

--- a/tests/Query/Builders/RollupBuilderTests.cs
+++ b/tests/Query/Builders/RollupBuilderTests.cs
@@ -92,11 +92,12 @@ public class RollupBuilderTests
     }
 
     [Fact]
-    public void Final_Composes_AggFinal_Or_Prev1m_NonNull()
+    public void Final_Uses_Window_EmitFinal()
     {
         var md = BuildMetadata();
         var sql = FinalBuilder.Build(md, "5m");
-        Assert.Contains("COMPOSE(bar_5m_agg_final ⟂ bar_prev_1m)", sql);
+        Assert.Contains("WINDOW TUMBLING(5m)", sql);
+        Assert.Contains("EMIT FINAL", sql);
         Assert.DoesNotContain("HB_1m", sql);
         var sql1 = FinalBuilder.Build(md, "1m");
         Assert.Contains("SYNC HB_1m", sql1);
@@ -129,6 +130,8 @@ public class RollupBuilderTests
         Assert.True(specAgg.Projector);
 
         var specFinal = RoleTraits.For(Role.Final, new Timeframe(5, "m"));
+        Assert.True(specFinal.Window);
+        Assert.Equal("FINAL", specFinal.Emit);
         Assert.False(specFinal.SyncHb1m);
     }
 }

--- a/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
+++ b/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
@@ -40,17 +40,19 @@ public class WindowedQueryBuilderCoreTests
     }
 
     [Fact]
-    public void Core_Builds_Final_Compose_AggOrPrev_SyncsOnlyOn1m()
+    public void Core_Builds_Final_Window_EmitFinal_SyncsOnlyOn1m()
     {
         var md1 = BaseMd()
-            .WithProperty("input/1mFinal", "agg1")
+            .WithProperty("input/1mFinal", "src1")
             .WithProperty("sync/1mFinal", "HB_1m");
         var q1 = FinalBuilder.Build(md1, "1m");
-        Assert.Contains("COMPOSE(agg1)", q1);
+        Assert.Contains("WINDOW TUMBLING(1m)", q1);
+        Assert.Contains("EMIT FINAL", q1);
         Assert.Contains("SYNC HB_1m", q1);
 
-        var md5 = BaseMd().WithProperty("input/5mFinal", "agg5");
+        var md5 = BaseMd().WithProperty("input/5mFinal", "src5");
         var q5 = FinalBuilder.Build(md5, "5m");
+        Assert.Contains("WINDOW TUMBLING(5m)", q5);
         Assert.DoesNotContain("SYNC", q5);
     }
 


### PR DESCRIPTION
## Summary
- emit tumbling final queries instead of composing agg+prev
- derive final tables from 1m bars
- document tumbling final change

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68bcda9671308327a3e4a222e1e288fb