### PR TITLE
Use tumbling windows for final bars

### DIFF
--- a/docs/diff_log/diff_tumbling_final_window_20250907.md
+++ b/docs/diff_log/diff_tumbling_final_window_20250907.md
@@ -1,0 +1,6 @@
+## Tumbling final window emits
+- Final tables now use `WINDOW TUMBLING` with `EMIT FINAL`
+- Derivation planner links finals to base 1m tables instead of compose
+- Tests updated for new final semantics
+- Final は常に TUMBLING + EMIT FINAL、AS_VALUE は使わずキーは自動 Arrow、WINDOWSTART は Final/Lateでも擬似列として使用
+- Final queries read directly from source tables without `COMPOSE()` wrappers

--- a/docs/diff_log/diff_tumbling_final_window_20250907.md
+++ b/docs/diff_log/diff_tumbling_final_window_20250907.md
@@ -4,3 +4,4 @@
 - Tests updated for new final semantics
 - Final は常に TUMBLING + EMIT FINAL、AS_VALUE は使わずキーは自動 Arrow、WINDOWSTART は Final/Lateでも擬似列として使用
 - Final queries read directly from source tables without `COMPOSE()` wrappers
+- Added regression ensuring mixed stream-table finals render Arrow only for table keys and guard against COMPOSE

--- a/src/Query/Adapters/QueryAdapter.cs
+++ b/src/Query/Adapters/QueryAdapter.cs
@@ -20,7 +20,7 @@ internal static class QueryAdapter
             {
                 Role.AggFinal => $"Window(TUMBLING,{e.Timeframe.Value}{e.Timeframe.Unit})+Emit(FINAL+GRACE)",
                 Role.Live => $"Window(TUMBLING,{e.Timeframe.Value}{e.Timeframe.Unit})+Emit(CHANGES)",
-                Role.Final => "Compose(AggFinal⟂BarPrev1m)",
+                Role.Final => $"Window(TUMBLING,{e.Timeframe.Value}{e.Timeframe.Unit})+Emit(FINAL)",
                 _ => string.Empty
             };
             var projector = e.Role == Role.AggFinal ? "BucketStartFromWindowStart" : null;

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -60,15 +60,17 @@ internal static class DerivationPlanner
                 Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
-                InputHint = tf.Unit == "m" && tf.Value == 1 ? "bar_1m_agg_final ⟂ bar_prev_1m" : $"bar_{tfStr}_agg_final ⟂ bar_prev_1m",
+                InputHint = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? "bar_1m_final" : "bar_1m_live",
                 SyncHint = tf.Unit == "m" && tf.Value == 1 ? "HB_1m" : null,
                 BasedOnSpec = qao.BasedOn,
                 WeekAnchor = qao.WeekAnchor
             };
             entities.Add(final); dag.AddNode(finalId);
 
-            dag.AddEdge(aggId, finalId);
-            dag.AddEdge("bar_prev_1m", finalId);
+            if (tf.Unit == "wk")
+                dag.AddEdge("bar_1m_final", finalId);
+            else if (!(tf.Unit == "m" && tf.Value == 1))
+                dag.AddEdge("bar_1m_live", finalId);
             if (tf.Unit == "wk")
                 dag.AddEdge("bar_1m_final", liveId);
             else if (!(tf.Unit == "m" && tf.Value == 1))

--- a/src/Query/Builders/Core/RoleTraits.cs
+++ b/src/Query/Builders/Core/RoleTraits.cs
@@ -11,7 +11,7 @@ internal static class RoleTraits
         {
             Role.Live => new(true, "CHANGES", false, false, is1m),
             Role.AggFinal => new(true, "FINAL GRACE", true, false, false),
-            Role.Final => new(false, null, false, true, is1m),
+            Role.Final => new(true, "FINAL", true, false, is1m),
             _ => new(false, null, false, false, false)
         };
     }

--- a/src/Query/Builders/Core/RoleTraits.cs
+++ b/src/Query/Builders/Core/RoleTraits.cs
@@ -2,6 +2,11 @@ using Kafka.Ksql.Linq.Query.Analysis;
 
 namespace Kafka.Ksql.Linq.Query.Builders.Core;
 
+/// <summary>
+/// Describes window, emit and sync behavior for each query role.
+/// Final roles never compose intermediate sources; they operate on physical or view tables
+/// and require windowing with <c>EMIT FINAL</c>.
+/// </summary>
 internal static class RoleTraits
 {
     public static OperationSpec For(Role role, Timeframe tf)

--- a/src/Query/Builders/Core/WindowedQueryBuilder.cs
+++ b/src/Query/Builders/Core/WindowedQueryBuilder.cs
@@ -20,10 +20,8 @@ internal static class WindowedQueryBuilder
             _ => string.Empty
         };
         var sb = new StringBuilder();
-        if (role == Role.Live)
+        if (role == Role.Live || role == Role.Final)
             sb.Append($"TABLE {input}");
-        else if (role == Role.Final)
-            sb.Append(QueryBuilderUtils.ApplyCompose_FinalNonNull(input));
         if (spec.Window)
             sb.Append(' ').Append(QueryBuilderUtils.ApplyWindowTumbling(tfStr));
         if (spec.Emit != null)

--- a/src/Query/Builders/Core/WindowedQueryBuilder.cs
+++ b/src/Query/Builders/Core/WindowedQueryBuilder.cs
@@ -35,7 +35,10 @@ internal static class WindowedQueryBuilder
                 sb.Append(' ').Append(QueryBuilderUtils.ApplySync_HB1m(sync));
         }
         sb.Append(' ').Append(QueryBuilderUtils.ApplyTimeFrame(md));
-        return sb.ToString().Trim();
+        var sql = sb.ToString().Trim();
+        if (role == Role.Final && sql.Contains("COMPOSE(", System.StringComparison.OrdinalIgnoreCase))
+            throw new System.InvalidOperationException("Final SQL should not include COMPOSE()");
+        return sql;
     }
 
     private static Timeframe Parse(string tf)

--- a/src/Query/Builders/KsqlCreateWindowedStatementBuilder.cs
+++ b/src/Query/Builders/KsqlCreateWindowedStatementBuilder.cs
@@ -20,6 +20,8 @@ internal static class KsqlCreateWindowedStatementBuilder
         var baseSql = KsqlCreateStatementBuilder.Build(name, model);
         if (model.IsFinal)
         {
+            // remove any existing BucketStart alias from the SELECT list; regex scope is limited to SELECT
+            // TODO: anchor to the SELECT segment explicitly if the builder ever rewrites other clauses
             baseSql = Regex.Replace(baseSql, @",\s*[^,]*?AS BucketStart", string.Empty, RegexOptions.IgnoreCase);
             baseSql = baseSql.Replace("SELECT ", "SELECT WINDOWSTART AS BucketStart, ");
         }

--- a/src/Query/Builders/KsqlCreateWindowedStatementBuilder.cs
+++ b/src/Query/Builders/KsqlCreateWindowedStatementBuilder.cs
@@ -18,6 +18,11 @@ internal static class KsqlCreateWindowedStatementBuilder
         if (string.IsNullOrWhiteSpace(timeframe)) throw new ArgumentException("timeframe required", nameof(timeframe));
 
         var baseSql = KsqlCreateStatementBuilder.Build(name, model);
+        if (model.IsFinal)
+        {
+            baseSql = Regex.Replace(baseSql, @",\s*[^,]*?AS BucketStart", string.Empty, RegexOptions.IgnoreCase);
+            baseSql = baseSql.Replace("SELECT ", "SELECT WINDOWSTART AS BucketStart, ");
+        }
         var window = FormatWindow(model, timeframe);
         var sql = InjectWindowAfterFrom(baseSql, window);
         sql = InjectEmitMode(sql, model);

--- a/src/Query/Builders/Utils/QueryBuilderUtils.cs
+++ b/src/Query/Builders/Utils/QueryBuilderUtils.cs
@@ -23,7 +23,5 @@ internal static class QueryBuilderUtils
 
     public static string ApplyProjector_BucketStartFromWindowStart() => "SELECT WINDOWSTART AS BucketStart";
 
-    public static string ApplyCompose_FinalNonNull(string input) => $"COMPOSE({input})";
-
     public static string ApplySync_HB1m(string sync) => $"SYNC {sync}";
 }

--- a/src/Query/Pipeline/ExpressionAnalysisResult.cs
+++ b/src/Query/Pipeline/ExpressionAnalysisResult.cs
@@ -59,7 +59,7 @@ internal class ExpressionAnalysisResult
                 _ => "bar_1m_live"
             };
             md = md.WithProperty($"input/{tf}Live", liveInput);
-            md = md.WithProperty($"input/{tf}Final", $"bar_{tf}_agg_final ⟂ bar_prev_1m");
+            md = md.WithProperty($"input/{tf}Final", liveInput);
         }
         return md;
     }

--- a/tests/Query/Analysis/ChartChecklistTests.cs
+++ b/tests/Query/Analysis/ChartChecklistTests.cs
@@ -157,8 +157,7 @@ public class ChartChecklistTests
         Assert.Equal("Window(TUMBLING,1m)+Emit(FINAL+GRACE)", specs.First(s => s.TargetId == "bar_1m_agg_final").Operation);
         Assert.Equal("Window(TUMBLING,1m)+Emit(CHANGES)", specs.First(s => s.TargetId == "bar_1m_live").Operation);
         var final = specs.First(s => s.TargetId == "bar_1m_final");
-        Assert.Contains("bar_prev_1m", final.Sources);
-        Assert.Equal("Compose(AggFinal⟂BarPrev1m)", final.Operation);
+        Assert.Equal("Window(TUMBLING,1m)+Emit(FINAL)", final.Operation);
     }
 
     [Fact]
@@ -213,7 +212,7 @@ public class ChartChecklistTests
     }
 
     [Fact]
-    public void QueryAdapter_Composes_5m_Final_With_1m_Prev()
+    public void QueryAdapter_Builds_5m_Final_Window()
     {
         var qao = new TumblingQao
         {
@@ -234,9 +233,9 @@ public class ChartChecklistTests
         Assert.Contains(entities, e => e.Id == "bar_prev_1m" && e.Role == Role.Prev1m);
         var specs = QueryAdapter.Build(entities, dag);
         var final5m = specs.First(s => s.TargetId == "bar_5m_final");
-        Assert.Contains("bar_prev_1m", final5m.Sources);
-        Assert.Equal("Compose(AggFinal⟂BarPrev1m)", final5m.Operation);
-        Assert.Contains("bar_prev_1m", dag.Edges["bar_5m_final"]);
+        Assert.Contains("bar_1m_live", final5m.Sources);
+        Assert.Equal("Window(TUMBLING,5m)+Emit(FINAL)", final5m.Operation);
+        Assert.Contains("bar_1m_live", dag.Edges["bar_5m_final"]);
     }
 
     [Fact]

--- a/tests/Query/Analysis/Step1Tests.cs
+++ b/tests/Query/Analysis/Step1Tests.cs
@@ -102,7 +102,7 @@ public class Step1Tests
         var live = specs.First(s => s.TargetId.StartsWith("bar_1m_live"));
         Assert.Contains("CHANGES", live.Operation);
         var final = specs.First(s => s.TargetId.StartsWith("bar_1m_final"));
-        Assert.Contains("Compose", final.Operation);
+        Assert.Contains("FINAL", final.Operation);
         Assert.NotEmpty(agg.BasedOnRef.JoinKeys);
     }
 
@@ -161,6 +161,77 @@ public class Step1Tests
         var liveWeek = entities.First(e => e.Id == "bar_1wk_live");
         Assert.Equal("bar_1m_final", liveWeek.InputHint);
         Assert.Contains("bar_1m_final", dag.Edges[liveWeek.Id]);
+    }
+
+    [Fact]
+    public void Planner_Uses_10sAgg_For_1m_Final()
+    {
+        var qao = new TumblingQao
+        {
+            TimeKey = "Timestamp",
+            Windows = new List<Timeframe> { new(1, "m") },
+            Keys = new[] { "Broker", "Symbol", "BucketStart" },
+            Projection = new[] { "Broker", "Symbol", "BucketStart" },
+            PocoShape = new[]
+            {
+                new ColumnShape("Broker", typeof(string), false),
+                new ColumnShape("Symbol", typeof(string), false),
+                new ColumnShape("Timestamp", typeof(DateTime), false),
+                new ColumnShape("BucketStart", typeof(DateTime), false)
+            },
+            BasedOn = new BasedOnSpec(new[] { "Broker" }, "Open", "Close", "MarketDate")
+        };
+        var (entities, _) = DerivationPlanner.Plan(qao);
+        var final1m = entities.First(e => e.Id == "bar_1m_final");
+        Assert.Equal("10sAgg", final1m.InputHint);
+    }
+
+    [Fact]
+    public void Planner_Connects_5m_Final_To_1m_Live()
+    {
+        var qao = new TumblingQao
+        {
+            TimeKey = "Timestamp",
+            Windows = new List<Timeframe> { new(1, "m"), new(5, "m") },
+            Keys = new[] { "Broker", "Symbol", "BucketStart" },
+            Projection = new[] { "Broker", "Symbol", "BucketStart" },
+            PocoShape = new[]
+            {
+                new ColumnShape("Broker", typeof(string), false),
+                new ColumnShape("Symbol", typeof(string), false),
+                new ColumnShape("Timestamp", typeof(DateTime), false),
+                new ColumnShape("BucketStart", typeof(DateTime), false)
+            },
+            BasedOn = new BasedOnSpec(new[] { "Broker" }, "Open", "Close", "MarketDate")
+        };
+        var (entities, dag) = DerivationPlanner.Plan(qao);
+        var final5m = entities.First(e => e.Id == "bar_5m_final");
+        Assert.Equal("bar_1m_live", final5m.InputHint);
+        Assert.Contains("bar_1m_live", dag.Edges[final5m.Id]);
+    }
+
+    [Fact]
+    public void Planner_Connects_Week_Final_To_1m_Final()
+    {
+        var qao = new TumblingQao
+        {
+            TimeKey = "Timestamp",
+            Windows = new List<Timeframe> { new(1, "m"), new(1, "wk") },
+            Keys = new[] { "Broker", "Symbol", "BucketStart" },
+            Projection = new[] { "Broker", "Symbol", "BucketStart" },
+            PocoShape = new[]
+            {
+                new ColumnShape("Broker", typeof(string), false),
+                new ColumnShape("Symbol", typeof(string), false),
+                new ColumnShape("Timestamp", typeof(DateTime), false),
+                new ColumnShape("BucketStart", typeof(DateTime), false)
+            },
+            BasedOn = new BasedOnSpec(new[] { "Broker" }, "Open", "Close", "MarketDate")
+        };
+        var (entities, dag) = DerivationPlanner.Plan(qao);
+        var finalWeek = entities.First(e => e.Id == "bar_1wk_final");
+        Assert.Equal("bar_1m_final", finalWeek.InputHint);
+        Assert.Contains("bar_1m_final", dag.Edges[finalWeek.Id]);
     }
 
     [Fact]

--- a/tests/Query/Builders/KsqlCreateWindowedStatementBuilderTests.cs
+++ b/tests/Query/Builders/KsqlCreateWindowedStatementBuilderTests.cs
@@ -1,6 +1,7 @@
 using System;
 using Kafka.Ksql.Linq.Query.Dsl;
 using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Core.Attributes;
 using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Query.Builders;
@@ -11,6 +12,15 @@ public class KsqlCreateWindowedStatementBuilderTests
     {
         public string Broker { get; set; } = string.Empty;
         public string Symbol { get; set; } = string.Empty;
+        public DateTime Timestamp { get; set; }
+        public double Bid { get; set; }
+    }
+
+    [KsqlTable]
+    private class RateTable
+    {
+        [KsqlKey(0)] public string Broker { get; set; } = string.Empty;
+        [KsqlKey(1)] public string Symbol { get; set; } = string.Empty;
         public DateTime Timestamp { get; set; }
         public double Bid { get; set; }
     }
@@ -51,6 +61,49 @@ public class KsqlCreateWindowedStatementBuilderTests
         Assert.True(map.ContainsKey("5m"));
         Assert.Contains("bar_1m_live", map["1m"]);
         Assert.Contains("bar_5m_live", map["5m"]);
+    }
+
+    [Fact]
+    public void Build_Final_1m_Emits_Windowstart_Arrow_And_Final()
+    {
+        var model = new KsqlQueryRoot()
+            .From<RateTable>()
+            .Tumbling(r => r.Timestamp, minutes: new[] { 1 })
+            .GroupBy(r => new { r.Broker, r.Symbol, BucketStart = r.Timestamp })
+            .Select(g => new { g.Key.Broker, g.Key.Symbol, Open = g.EarliestByOffset(x => x.Bid) })
+            .AsFinal()
+            .AsPush()
+            .Build();
+        var sql = Kafka.Ksql.Linq.Query.Builders.KsqlCreateWindowedStatementBuilder.Build("bar_1m_final", model, "1m");
+        Assert.Contains("WINDOW TUMBLING (SIZE 1 MINUTES)", sql);
+        Assert.Contains("SELECT WINDOWSTART AS BucketStart", sql);
+        Assert.Contains("EMIT FINAL", sql);
+        Assert.Contains("GROUP BY KEY->BROKER, KEY->SYMBOL", sql);
+        Assert.Contains("KEY->BROKER AS Broker, KEY->SYMBOL AS Symbol", sql);
+    }
+
+    [Fact]
+    public void Build_Final_5m_Emits_Windowstart_Arrow_And_Final()
+    {
+        var model = new KsqlQueryRoot()
+            .From<RateTable>()
+            .Tumbling(r => r.Timestamp, minutes: new[] { 1, 5 })
+            .GroupBy(r => new { r.Broker, r.Symbol, BucketStart = r.Timestamp })
+            .Select(g => new { g.Key.Broker, g.Key.Symbol, Open = g.EarliestByOffset(x => x.Bid) })
+            .AsFinal()
+            .AsPush()
+            .Build();
+
+        var map = Kafka.Ksql.Linq.Query.Builders.KsqlCreateWindowedStatementBuilder.BuildAll(
+            "bar",
+            model,
+            tf => $"bar_{tf}_final");
+        var sql = map["5m"];
+        Assert.Contains("WINDOW TUMBLING (SIZE 5 MINUTES)", sql);
+        Assert.Contains("SELECT WINDOWSTART AS BucketStart", sql);
+        Assert.Contains("EMIT FINAL", sql);
+        Assert.Contains("GROUP BY KEY->BROKER, KEY->SYMBOL", sql);
+        Assert.Contains("KEY->BROKER AS Broker, KEY->SYMBOL AS Symbol", sql);
     }
 }
 

--- a/tests/Query/Builders/KsqlCreateWindowedStatementBuilderTests.cs
+++ b/tests/Query/Builders/KsqlCreateWindowedStatementBuilderTests.cs
@@ -2,6 +2,8 @@ using System;
 using Kafka.Ksql.Linq.Query.Dsl;
 using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Core.Attributes;
+using Kafka.Ksql.Linq.Query.Pipeline;
+using System.Linq.Expressions;
 using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Query.Builders;
@@ -80,6 +82,7 @@ public class KsqlCreateWindowedStatementBuilderTests
         Assert.Contains("EMIT FINAL", sql);
         Assert.Contains("GROUP BY KEY->BROKER, KEY->SYMBOL", sql);
         Assert.Contains("KEY->BROKER AS Broker, KEY->SYMBOL AS Symbol", sql);
+        Assert.DoesNotContain("COMPOSE(", sql);
     }
 
     [Fact]
@@ -104,6 +107,32 @@ public class KsqlCreateWindowedStatementBuilderTests
         Assert.Contains("EMIT FINAL", sql);
         Assert.Contains("GROUP BY KEY->BROKER, KEY->SYMBOL", sql);
         Assert.Contains("KEY->BROKER AS Broker, KEY->SYMBOL AS Symbol", sql);
+        Assert.DoesNotContain("COMPOSE(", sql);
+    }
+
+    [Fact]
+    public void Build_Final_StreamTableJoin_Applies_Arrow_To_Table_Side()
+    {
+        var model = new KsqlQueryModel
+        {
+            SourceTypes = new[] { typeof(RateTable), typeof(Rate) },
+            JoinCondition = (Expression<Func<RateTable, Rate, bool>>)((t, s) => t.Broker == s.Broker && t.Symbol == s.Symbol),
+            WhereCondition = (Expression<Func<RateTable, Rate, bool>>)((t, s) => t.Broker != string.Empty && s.Symbol != string.Empty),
+            GroupByExpression = (Expression<Func<RateTable, Rate, object>>)((t, s) => new { t.Broker, s.Symbol }),
+            SelectProjection = (Expression<Func<RateTable, Rate, object>>)((t, s) => new { t.Broker, s.Symbol }),
+            IsAggregateQuery = true,
+            HasTumbling = true,
+            IsFinal = true,
+            ExecutionMode = QueryExecutionMode.PushQuery
+        };
+        model.Windows.Add("1m");
+
+        var sql = Kafka.Ksql.Linq.Query.Builders.KsqlCreateWindowedStatementBuilder.Build("mix_1m_final", model, "1m");
+        Assert.Contains("SELECT WINDOWSTART AS BucketStart, KEY->BROKER AS Broker, i.Symbol AS Symbol", sql);
+        Assert.Contains("GROUP BY KEY->BROKER, Symbol", sql);
+        Assert.Contains("WHERE ((KEY->BROKER != Empty) AND (i.Symbol != Empty))", sql);
+        Assert.DoesNotContain("KEY->SYMBOL", sql);
+        Assert.DoesNotContain("COMPOSE(", sql);
     }
 }
 

--- a/tests/Query/Builders/RollupBuilderTests.cs
+++ b/tests/Query/Builders/RollupBuilderTests.cs
@@ -92,13 +92,15 @@ public class RollupBuilderTests
     }
 
     [Fact]
-    public void Final_Composes_AggFinal_Or_Prev1m_NonNull()
+    public void Final_Uses_Window_EmitFinal()
     {
         var md = BuildMetadata();
         var sql = FinalBuilder.Build(md, "5m");
-        Assert.Contains("COMPOSE(bar_5m_agg_final ⟂ bar_prev_1m)", sql);
+        Assert.Contains("TABLE bar_1m_live WINDOW TUMBLING(5m)", sql);
+        Assert.Contains("EMIT FINAL", sql);
         Assert.DoesNotContain("HB_1m", sql);
         var sql1 = FinalBuilder.Build(md, "1m");
+        Assert.Contains("TABLE 10sAgg WINDOW TUMBLING(1m)", sql1);
         Assert.Contains("SYNC HB_1m", sql1);
     }
 
@@ -129,6 +131,8 @@ public class RollupBuilderTests
         Assert.True(specAgg.Projector);
 
         var specFinal = RoleTraits.For(Role.Final, new Timeframe(5, "m"));
+        Assert.True(specFinal.Window);
+        Assert.Equal("FINAL", specFinal.Emit);
         Assert.False(specFinal.SyncHb1m);
     }
 }

--- a/tests/Query/Builders/RollupBuilderTests.cs
+++ b/tests/Query/Builders/RollupBuilderTests.cs
@@ -99,9 +99,11 @@ public class RollupBuilderTests
         Assert.Contains("TABLE bar_1m_live WINDOW TUMBLING(5m)", sql);
         Assert.Contains("EMIT FINAL", sql);
         Assert.DoesNotContain("HB_1m", sql);
+        Assert.DoesNotContain("COMPOSE(", sql);
         var sql1 = FinalBuilder.Build(md, "1m");
         Assert.Contains("TABLE 10sAgg WINDOW TUMBLING(1m)", sql1);
         Assert.Contains("SYNC HB_1m", sql1);
+        Assert.DoesNotContain("COMPOSE(", sql1);
     }
 
     [Fact]

--- a/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
+++ b/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
@@ -40,17 +40,21 @@ public class WindowedQueryBuilderCoreTests
     }
 
     [Fact]
-    public void Core_Builds_Final_Compose_AggOrPrev_SyncsOnlyOn1m()
+    public void Core_Builds_Final_Window_EmitFinal_SyncsOnlyOn1m()
     {
         var md1 = BaseMd()
-            .WithProperty("input/1mFinal", "agg1")
+            .WithProperty("input/1mFinal", "src1")
             .WithProperty("sync/1mFinal", "HB_1m");
         var q1 = FinalBuilder.Build(md1, "1m");
-        Assert.Contains("COMPOSE(agg1)", q1);
+        Assert.StartsWith("TABLE src1", q1);
+        Assert.Contains("WINDOW TUMBLING(1m)", q1);
+        Assert.Contains("EMIT FINAL", q1);
         Assert.Contains("SYNC HB_1m", q1);
 
-        var md5 = BaseMd().WithProperty("input/5mFinal", "agg5");
+        var md5 = BaseMd().WithProperty("input/5mFinal", "src5");
         var q5 = FinalBuilder.Build(md5, "5m");
+        Assert.StartsWith("TABLE src5", q5);
+        Assert.Contains("WINDOW TUMBLING(5m)", q5);
         Assert.DoesNotContain("SYNC", q5);
     }
 

--- a/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
+++ b/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
@@ -50,12 +50,14 @@ public class WindowedQueryBuilderCoreTests
         Assert.Contains("WINDOW TUMBLING(1m)", q1);
         Assert.Contains("EMIT FINAL", q1);
         Assert.Contains("SYNC HB_1m", q1);
+        Assert.DoesNotContain("COMPOSE(", q1);
 
         var md5 = BaseMd().WithProperty("input/5mFinal", "src5");
         var q5 = FinalBuilder.Build(md5, "5m");
         Assert.StartsWith("TABLE src5", q5);
         Assert.Contains("WINDOW TUMBLING(5m)", q5);
         Assert.DoesNotContain("SYNC", q5);
+        Assert.DoesNotContain("COMPOSE(", q5);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- ensure final windows project WINDOWSTART and Arrow keys
- verify final input hints for 1m, 5m and weekly rollups
- document tumbling final behavior and automatic key handling
- drop compose wrapper so final queries read directly from source tables

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bcda9671308327a3e4a222e1e288fb