### PR TITLE
Add unit test to ensure tumbling avoids base Bar table

### DIFF
--- a/docs/diff_log/diff_bar_table_absence_20250907.md
+++ b/docs/diff_log/diff_bar_table_absence_20250907.md
@@ -1,0 +1,1 @@
+- add unit test ensuring tumbling query derives bar_x tables without creating base Bar table

--- a/docs/diff_log/diff_warning_cleanup_20250907.md
+++ b/docs/diff_log/diff_warning_cleanup_20250907.md
@@ -1,0 +1,1 @@
+- fix nullability warnings in ConfigLoggingExtensions, KafkaProducerManager, KeyValueTypeMapping, DerivedEntity, ToQueryValidator

--- a/docs/diff_log/diff_warning_error_fixes_20250907.md
+++ b/docs/diff_log/diff_warning_error_fixes_20250907.md
@@ -1,0 +1,3 @@
+- clean integration tests and unit tests warnings
+- add System.Linq and #nullable enable directives
+- async fix for PortConnectivityTests and Assert.Single usage

--- a/physicalTests/Connectivity/KafkaConnectivityTests.cs
+++ b/physicalTests/Connectivity/KafkaConnectivityTests.cs
@@ -9,6 +9,8 @@ using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Integration;
 
+#nullable enable
+
 [Collection("Connectivity")]
 public class KafkaConnectivityTests
 {

--- a/physicalTests/Connectivity/PortConnectivityTests.cs
+++ b/physicalTests/Connectivity/PortConnectivityTests.cs
@@ -18,9 +18,9 @@ public class PortConnectivityTests
 {
 [Fact]
 //[TestPriority(1)]
-    public void Kafka_Broker_Should_Be_Reachable()
+    public async Task Kafka_Broker_Should_Be_Reachable()
     {
-        EnvPortConnectivityTests.SetupAsync().GetAwaiter().GetResult();
+        await EnvPortConnectivityTests.SetupAsync();
         using var admin = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = EnvPortConnectivityTests.KafkaBootstrapServers }).Build();
         var meta = admin.GetMetadata(TimeSpan.FromSeconds(10));
         Assert.NotEmpty(meta.Brokers);

--- a/physicalTests/Connectivity/SchemaRegistryResetTests.cs
+++ b/physicalTests/Connectivity/SchemaRegistryResetTests.cs
@@ -16,6 +16,8 @@ using Xunit.Sdk;
 
 namespace Kafka.Ksql.Linq.Tests.Integration;
 
+#nullable enable
+
 [Collection("Schema")]
 public class SchemaRegistryResetTests
 {

--- a/physicalTests/Env/KsqlHelpers.cs
+++ b/physicalTests/Env/KsqlHelpers.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 
 namespace PhysicalTestEnv;
 
+#nullable enable
+
 public static class KsqlHelpers
 {
     public static async Task<KsqlDbResponse> ExecuteStatementWithRetryAsync(KsqlContext ctx, string statement, int retries = 3, int delayMs = 1000)

--- a/physicalTests/KafkaAdminServiceIntegrationTests.cs
+++ b/physicalTests/KafkaAdminServiceIntegrationTests.cs
@@ -33,7 +33,7 @@ public class KafkaAdminServiceIntegrationTests
         await svc.EnsureTopicExistsAsync("it.topic");
         using var admin = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = EnvKafkaAdminServiceIntegrationTests.KafkaBootstrapServers }).Build();
         var meta = admin.GetMetadata("it.topic", TimeSpan.FromSeconds(10));
-        Assert.Equal(1, meta.Topics[0].Partitions.Count);
+        Assert.Single(meta.Topics[0].Partitions);
     }
 }
 

--- a/physicalTests/OssSamples/BarDslExplainTests.cs
+++ b/physicalTests/OssSamples/BarDslExplainTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Attributes;
@@ -10,6 +11,8 @@ using System.Threading.Tasks;
 using Kafka.Ksql.Linq.Core.Modeling;
 
 namespace Kafka.Ksql.Linq.Tests.Integration;
+
+#nullable enable
 
 /// <summary>
 /// OnModelCreating → ToQuery → Materialize(SQL) → Verify の流れに統一したDSLテスト。

--- a/physicalTests/OssSamples/BarScheduleAnchorTests.cs
+++ b/physicalTests/OssSamples/BarScheduleAnchorTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Attributes;

--- a/physicalTests/OssSamples/BarScheduleDataTests.cs
+++ b/physicalTests/OssSamples/BarScheduleDataTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Attributes;

--- a/physicalTests/OssSamples/BarScheduleExplainTests.cs
+++ b/physicalTests/OssSamples/BarScheduleExplainTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Attributes;

--- a/physicalTests/OssSamples/PrimingBehaviorTests.cs
+++ b/physicalTests/OssSamples/PrimingBehaviorTests.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 
+#nullable enable
+
 namespace Kafka.Ksql.Linq.Tests.Integration;
 
 [Collection("DataRoundTrip")]

--- a/src/Core/Extensions/ConfigLoggingExtensions.cs
+++ b/src/Core/Extensions/ConfigLoggingExtensions.cs
@@ -13,7 +13,7 @@ internal static class ConfigLoggingExtensions
     private static bool IsSensitive(string key)
         => SensitiveKeys.Any(k => key.IndexOf(k, StringComparison.OrdinalIgnoreCase) >= 0);
 
-    private static IEnumerable<(string Key, object? Value)> ReflectProps(object config)
+    private static IEnumerable<(string Key, object Value)> ReflectProps(object config)
     {
         var type = config.GetType();
         var props = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
@@ -26,7 +26,7 @@ internal static class ConfigLoggingExtensions
             try { val = p.GetValue(config); }
             catch { continue; }
             if (val is null) continue;
-            yield return (p.Name, val);
+            yield return (p.Name, val!);
         }
     }
 

--- a/src/Mapping/KeyValueTypeMapping.cs
+++ b/src/Mapping/KeyValueTypeMapping.cs
@@ -199,7 +199,7 @@ internal class KeyValueTypeMapping
                         throw new InvalidOperationException($"Field '{name}' not found in key schema '{rs.Fullname}'");
                 }
                 var raw = krec.GetValue(pos);
-                parts[i] = ToSortableString(raw, meta.PropertyInfo.PropertyType);
+                parts[i] = ToSortableString(raw, meta.PropertyInfo!.PropertyType);
             }
             return string.Join(KeySep, parts);
         }
@@ -211,7 +211,7 @@ internal class KeyValueTypeMapping
             var p = avroKey.GetType().GetProperty(meta.PropertyInfo!.Name)
                     ?? throw new InvalidOperationException($"Key property '{meta.PropertyInfo!.Name}' not found on {avroKey.GetType().Name}");
             var raw = p.GetValue(avroKey);
-            fallback[i] = ToSortableString(raw, meta.PropertyInfo.PropertyType);
+              fallback[i] = ToSortableString(raw, meta.PropertyInfo!.PropertyType);
         }
         return string.Join(KeySep, fallback);
     }

--- a/src/Messaging/Producers/KafkaProducerManager.cs
+++ b/src/Messaging/Producers/KafkaProducerManager.cs
@@ -141,12 +141,12 @@ internal class KafkaProducerManager : IDisposable
         return new ProducerHolder(
             topicName,
             (k, v, ctx, ct) =>
-            {
-                var msg = new Message<Null, TValue> { Key = default, Value = (TValue?)v! };
+                {
+                var msg = new Message<Null, TValue> { Key = default!, Value = (TValue?)v! };
                 if (ctx?.Headers?.Count > 0)
                     msg.Headers = BuildHeaders(ctx);
                 return prod.ProduceAsync(topicName, msg, ct);
-            },
+                },
             t => prod.Flush(t),
             () => { prod.Flush(System.TimeSpan.FromSeconds(5)); prod.Dispose(); });
     }

--- a/src/Query/Analysis/DerivedEntity.cs
+++ b/src/Query/Analysis/DerivedEntity.cs
@@ -24,7 +24,7 @@ internal class DerivedEntity
 {
     public string Id { get; init; } = string.Empty;
     public Role Role { get; init; }
-    public Timeframe Timeframe { get; init; }
+    public Timeframe Timeframe { get; init; } = default!;
     public IReadOnlyList<ColumnShape> KeyShape { get; init; } = Array.Empty<ColumnShape>();
     public IReadOnlyList<ColumnShape> ValueShape { get; init; } = Array.Empty<ColumnShape>();
     public MaterializationHint MaterializationHint { get; init; } = MaterializationHint.Table;

--- a/src/Query/Dsl/ToQueryValidator.cs
+++ b/src/Query/Dsl/ToQueryValidator.cs
@@ -105,7 +105,7 @@ internal static class ToQueryValidator
             case ParameterExpression:
                 props.AddRange(resultType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
                     .OrderBy(p => p.MetadataToken)
-                    .Select(p => (p, p, p.PropertyType)));
+                    .Select(p => (p, (PropertyInfo?)p, p.PropertyType)));
                 break;
             case MemberExpression me when me.Member is PropertyInfo pi:
                 if (resultType.GetProperty(pi.Name) != null)

--- a/tests/Configuration/MessagingConfigurationTests.cs
+++ b/tests/Configuration/MessagingConfigurationTests.cs
@@ -86,7 +86,7 @@ public class MessagingConfigurationTests
     [Fact]
     public void TopicConfig_DeepMerge_DoesNotErase_Unspecified_Sections()
     {
-        var dict = new Dictionary<string, string>
+        var dict = new Dictionary<string, string?>
         {
             ["KsqlDsl:Topics:foo:Producer:Acks"] = "1"
         };
@@ -103,7 +103,7 @@ public class MessagingConfigurationTests
     [Fact]
     public void RetentionMs_Parses_NegativeOne_And_LongValues_Invariant()
     {
-        var dict = new Dictionary<string, string>
+        var dict = new Dictionary<string, string?>
         {
             ["KsqlDsl:DlqOptions:RetentionMs"] = "-1"
         };

--- a/tests/Kafka.Ksql.Linq.Cache.Tests/TableCacheTests.cs
+++ b/tests/Kafka.Ksql.Linq.Cache.Tests/TableCacheTests.cs
@@ -27,9 +27,9 @@ public class TableCacheTests
             var parts = key.Split(NUL);
             return new Dummy
             {
-                Broker = parts.ElementAtOrDefault(0),
-                Symbol = parts.ElementAtOrDefault(1),
-                Ts = parts.ElementAtOrDefault(2),
+                Broker = parts.ElementAtOrDefault(0) ?? string.Empty,
+                Symbol = parts.ElementAtOrDefault(1) ?? string.Empty,
+                Ts = parts.ElementAtOrDefault(2) ?? string.Empty,
                 V = (int)val
             };
         }

--- a/tests/ModelBuilderTests/TableAttributeTests.cs
+++ b/tests/ModelBuilderTests/TableAttributeTests.cs
@@ -26,7 +26,7 @@ public class TableAttributeTests
     {
         var builder = new ModelBuilder();
         builder.Entity<TableEntity>();
-        var model = builder.GetEntityModel<TableEntity>();
+        var model = builder.GetEntityModel<TableEntity>()!;
         Assert.Equal(StreamTableType.Table, model.StreamTableType);
     }
 
@@ -35,7 +35,7 @@ public class TableAttributeTests
     {
         var builder = new ModelBuilder();
         builder.Entity<KeyedEntity>();
-        var model = builder.GetEntityModel<KeyedEntity>();
+        var model = builder.GetEntityModel<KeyedEntity>()!;
         Assert.Equal(StreamTableType.Stream, model.StreamTableType);
     }
 }

--- a/tests/Query/Analysis/BarTableAbsenceTests.cs
+++ b/tests/Query/Analysis/BarTableAbsenceTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Query.Analysis;
+using Kafka.Ksql.Linq.Query.Dsl;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Analysis;
+
+public class BarTableAbsenceTests
+{
+    private class Rate
+    {
+        public string Broker { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
+        public DateTime Timestamp { get; set; }
+        public DateTime BucketStart { get; set; }
+        public decimal Bid { get; set; }
+    }
+
+    private class Bar
+    {
+        public string Broker { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
+        public DateTime BucketStart { get; set; }
+        public decimal Open { get; set; }
+        public decimal High { get; set; }
+        public decimal Low { get; set; }
+        public decimal Close { get; set; }
+    }
+
+    private class MarketSchedule
+    {
+        public string Broker { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
+        public DateTime Open { get; set; }
+        public DateTime Close { get; set; }
+        public DateTime MarketDate { get; set; }
+    }
+
+    [Fact]
+    public void Tumbling_DoesNot_Create_Base_Bar_Table()
+    {
+        Expression expr = ((Expression<Func<KsqlQueryable<Rate>, object>>)(q => q
+            .TimeFrame<MarketSchedule>(
+                (r, s) =>
+                    r.Broker == s.Broker &&
+                    r.Symbol == s.Symbol &&
+                    s.Open <= r.Timestamp &&
+                    r.Timestamp < s.Close,
+                s => s.MarketDate)
+            .Tumbling(r => r.Timestamp, new[] { 1, 5 }, null, null, null, null, null)
+            .GroupBy(r => new { r.Broker, r.Symbol, BucketStart = r.Timestamp })
+            .Select(g => new Bar
+            {
+                Broker = g.Key.Broker,
+                Symbol = g.Key.Symbol,
+                BucketStart = g.WindowStart(),
+                Open = g.EarliestByOffset(x => x.Bid),
+                High = g.Max(x => x.Bid),
+                Low = g.Min(x => x.Bid),
+                Close = g.LatestByOffset(x => x.Bid)
+            }))).Body;
+
+        var qao = TumblingAnalyzer.Analyze(expr, typeof(Rate));
+        var (entities, _) = DerivationPlanner.Plan(qao);
+
+        Assert.DoesNotContain(entities, e => e.Id.Equals("bar", StringComparison.OrdinalIgnoreCase));
+        Assert.All(entities.Where(e => e.Role != Role.Hb), e => Assert.StartsWith("bar_", e.Id));
+    }
+}


### PR DESCRIPTION
## Summary
- add BarTableAbsenceTests verifying tumbling produces only bar_x tables and no base Bar table
- log change in diff_log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68bcef47e9f883278c8b01119329ae42