### PR TITLE
Use properties for query stream offset reset

### DIFF
--- a/docs/diff_log/diff_ksqldbclient_query_stream_offset_reset_20250910.md
+++ b/docs/diff_log/diff_ksqldbclient_query_stream_offset_reset_20250910.md
@@ -1,0 +1,2 @@
+# diff_ksqldbclient_query_stream_offset_reset_20250910
+- use `properties` with `ksql.streams.auto.offset.reset` in `ExecuteQueryStreamCountAsync`

--- a/src/Infrastructure/KsqlDb/KsqlDbClient.cs
+++ b/src/Infrastructure/KsqlDb/KsqlDbClient.cs
@@ -82,13 +82,12 @@ internal class KsqlDbClient : IKsqlDbClient, IDisposable
 
     public async Task<int> ExecuteQueryStreamCountAsync(string sql, TimeSpan? timeout = null)
     {
-        // Include streamsProperties to ensure we consume from the beginning in tests
         var payload = new
         {
             sql,
-            streamsProperties = new System.Collections.Generic.Dictionary<string, object>
+            properties = new System.Collections.Generic.Dictionary<string, object>
             {
-                ["auto.offset.reset"] = "earliest"
+                ["ksql.streams.auto.offset.reset"] = "earliest"
             }
         };
         var json = JsonSerializer.Serialize(payload);


### PR DESCRIPTION
## Summary
- replace `streamsProperties` with `properties` using `ksql.streams.auto.offset.reset`
- log diff entry for query stream offset reset change

## Testing
- `dotnet build src/Kafka.Ksql.Linq.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`
- manual verification against local server


------
https://chatgpt.com/codex/tasks/task_e_68bd11cbbf74832782d133dcc2585b34