### PR TITLE
feat: add ksql statement logging

### DIFF
--- a/docs/diff_log/diff_bardsl_debug_logging_20250907.md
+++ b/docs/diff_log/diff_bardsl_debug_logging_20250907.md
@@ -1,0 +1,2 @@
+# diff_bardsl_debug_logging_20250907
+- enable console debug logging in BarDslExplainTests to capture ksqlDB statements

--- a/docs/diff_log/diff_ksqldbclient_logging_20250907.md
+++ b/docs/diff_log/diff_ksqldbclient_logging_20250907.md
@@ -1,0 +1,3 @@
+# diff_ksqldbclient_logging_20250907
+- enable debug logging for KSQL statements and responses in `KsqlDbClient`
+- propagate logger from `KsqlContext`

--- a/physicalTests/OssSamples/BarDslExplainTests.cs
+++ b/physicalTests/OssSamples/BarDslExplainTests.cs
@@ -3,6 +3,7 @@ using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Attributes;
 using Kafka.Ksql.Linq.Core.Modeling;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Integration;
@@ -38,12 +39,15 @@ public class BarDslExplainTests
 
     private sealed class TestContext : KsqlContext
     {
+        private static readonly ILoggerFactory _loggerFactory = LoggerFactory.Create(b =>
+            b.AddConsole().SetMinimumLevel(LogLevel.Debug));
+
         public TestContext() : base(new KsqlDslOptions
         {
             Common = new CommonSection { BootstrapServers = "localhost:9092" },
             SchemaRegistry = new Kafka.Ksql.Linq.Core.Configuration.SchemaRegistrySection { Url = "http://localhost:8081" },
             KsqlDbUrl = "http://localhost:8088"
-        })
+        }, _loggerFactory)
         { }
         // 物理テスト: スキーマ登録を有効化
         protected override bool SkipSchemaRegistration => false;

--- a/src/Infrastructure/KsqlDb/KsqlDbClient.cs
+++ b/src/Infrastructure/KsqlDb/KsqlDbClient.cs
@@ -6,25 +6,30 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Kafka.Ksql.Linq.Infrastructure.KsqlDb;
 
 internal class KsqlDbClient : IKsqlDbClient, IDisposable
 {
     private readonly HttpClient _client;
+    private readonly ILogger<KsqlDbClient> _logger;
 
-    public KsqlDbClient(Uri baseAddress)
+    public KsqlDbClient(Uri baseAddress, ILogger<KsqlDbClient>? logger = null)
     {
         _client = new HttpClient { BaseAddress = baseAddress };
+        _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<KsqlDbClient>.Instance;
     }
 
     public async Task<KsqlDbResponse> ExecuteStatementAsync(string statement)
     {
+        _logger.LogDebug("Executing KSQL statement: {Statement}", statement);
         var payload = new { ksql = statement, streamsProperties = new { } };
         var json = JsonSerializer.Serialize(payload);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var response = await _client.PostAsync("/ksql", content);
         var body = await response.Content.ReadAsStringAsync();
+        _logger.LogDebug("KSQL response ({StatusCode}): {Body}", (int)response.StatusCode, body);
         var success = response.IsSuccessStatusCode && !body.Contains("\"error_code\"");
         return new KsqlDbResponse(success, body);
     }

--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -100,7 +100,7 @@ public abstract partial class KsqlContext : IKsqlContext
         DecimalPrecisionConfig.Configure(_dslOptions.Decimals);
 
         _schemaRegistryClient = new Lazy<ConfluentSchemaRegistry.ISchemaRegistryClient>(CreateSchemaRegistryClient);
-        _ksqlDbClient = new KsqlDbClient(GetDefaultKsqlDbUrl());
+        _ksqlDbClient = new KsqlDbClient(GetDefaultKsqlDbUrl(), loggerFactory?.CreateLogger<KsqlDbClient>());
 
         _loggerFactory = loggerFactory;
         _logger = _loggerFactory.CreateLoggerOrNull<KsqlContext>();


### PR DESCRIPTION
## Summary
- log executed KSQL statements and responses in KsqlDbClient
- pass logger from KsqlContext into KsqlDbClient
- enable debug logging in BarDslExplainTests for DDL tracing

## Testing
- `dotnet build physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj` *(fails: CS0246 in unrelated test files)*
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bd442cd9c083279af6b8608a0d4d08