### PR TITLE
Verify CTAS queries and topic partitions

### DIFF
--- a/docs/diff_log/diff_schema_registration_runtime_check_20250907.md
+++ b/docs/diff_log/diff_schema_registration_runtime_check_20250907.md
@@ -1,0 +1,5 @@
+# diff_schema_registration_runtime_check_20250907
+
+- CTAS statements validated via `SHOW QUERIES` ensuring running status.
+- `DESCRIBE EXTENDED` used for DDL readiness and topic metadata verification.
+- Sink topic partitions asserted through `SHOW TOPICS`.

--- a/features/schema_registration_runtime_check/instruction.md
+++ b/features/schema_registration_runtime_check/instruction.md
@@ -1,0 +1,3 @@
+# schema_registration_runtime_check
+
+Validate CTAS queries and sink topics at runtime using SHOW QUERIES, DESCRIBE EXTENDED, and SHOW TOPICS.

--- a/src/KsqlContext.SchemaRegistration.cs
+++ b/src/KsqlContext.SchemaRegistration.cs
@@ -256,9 +256,7 @@ public abstract partial class KsqlContext
     {
         var deadline = DateTime.UtcNow + timeout;
         var entity = model.GetTopicName().ToUpperInvariant();
-        var stmt = model.StreamTableType == StreamTableType.Table
-            ? $"DESCRIBE {entity};"
-            : $"DESCRIBE {entity};";
+        var stmt = $"DESCRIBE EXTENDED {entity};";
 
         while (DateTime.UtcNow < deadline)
         {
@@ -267,14 +265,50 @@ public abstract partial class KsqlContext
                 var res = await ExecuteStatementAsync(stmt);
                 if (res.IsSuccess && !string.IsNullOrWhiteSpace(res.Message))
                 {
-                    var msg = res.Message.ToUpperInvariant();
-                    if (!msg.Contains("STATEMENT_ERROR"))
+                    var msg = res.Message;
+                    if (!msg.ToUpperInvariant().Contains("STATEMENT_ERROR") && HasDescribeInfo(msg))
+                    {
+                        await AssertTopicPartitionsAsync(model);
                         return;
+                    }
                 }
             }
             catch { }
             await Task.Delay(500);
         }
+
+        static bool HasDescribeInfo(string message)
+        {
+            var lines = message.Split('\n');
+            bool hasKey = lines.Any(l => l.Contains("Key format", StringComparison.OrdinalIgnoreCase));
+            bool hasValue = lines.Any(l => l.Contains("Value format", StringComparison.OrdinalIgnoreCase));
+            bool hasTs = lines.Any(l => l.Contains("Timestamp column", StringComparison.OrdinalIgnoreCase));
+            bool hasStats = lines.Any(l => l.Contains("Runtime statistics", StringComparison.OrdinalIgnoreCase));
+            bool hasSchema = lines.Any(l => l.Contains("|"));
+            return hasKey && hasValue && hasTs && hasStats && hasSchema;
+        }
+    }
+
+    private async Task AssertTopicPartitionsAsync(EntityModel model)
+    {
+        var res = await ExecuteStatementAsync("SHOW TOPICS;");
+        if (!res.IsSuccess || string.IsNullOrWhiteSpace(res.Message))
+            throw new InvalidOperationException("SHOW TOPICS failed");
+
+        var lines = res.Message.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        foreach (var line in lines)
+        {
+            if (!line.Contains('|')) continue;
+            var parts = line.Split('|', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 2) continue;
+            if (parts[0].Trim().Equals(model.GetTopicName(), StringComparison.OrdinalIgnoreCase))
+            {
+                if (int.TryParse(parts[1].Trim(), out var partitions) && partitions == model.Partitions)
+                    return;
+                throw new InvalidOperationException($"Topic {model.GetTopicName()} partition mismatch");
+            }
+        }
+        throw new InvalidOperationException($"Topic {model.GetTopicName()} not found");
     }
 
     private async Task EnsureQueryEntityDdlAsync(Type type, EntityModel model)
@@ -325,7 +359,28 @@ public abstract partial class KsqlContext
                 resolver);
             Logger.LogInformation("KSQL DDL (query {Entity}): {Sql}", type.Name, ddl);
             await ExecuteWithRetryAsync(ddl);
+
+            var qs = await ExecuteStatementAsync("SHOW QUERIES;");
+            if (!qs.IsSuccess || string.IsNullOrWhiteSpace(qs.Message) || !QueryRunning(qs.Message))
+                throw new InvalidOperationException($"CTAS query for {model.GetTopicName()} not running");
+
+            await AssertTopicPartitionsAsync(model);
             return;
+
+            bool QueryRunning(string message)
+            {
+                var lines = message.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+                foreach (var line in lines)
+                {
+                    if (!line.Contains('|')) continue;
+                    var parts = line.Split('|', StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length > 3 &&
+                        parts[1].Trim().Equals(model.GetTopicName(), StringComparison.OrdinalIgnoreCase) &&
+                        parts[3].Trim().Equals("RUNNING", StringComparison.OrdinalIgnoreCase))
+                        return true;
+                }
+                return false;
+            }
         }
 
         var generator = new Kafka.Ksql.Linq.Query.Pipeline.DDLQueryGenerator();

--- a/tests/Core/EnsureQueryEntityDdlAsyncTests.cs
+++ b/tests/Core/EnsureQueryEntityDdlAsyncTests.cs
@@ -20,9 +20,14 @@ public class EnsureQueryEntityDdlAsyncTests
     private class CapturingClient : IKsqlDbClient
     {
         public List<string> Statements { get; } = new();
+        public string Topic { get; set; } = "tgt";
         public Task<KsqlDbResponse> ExecuteStatementAsync(string statement)
         {
             Statements.Add(statement);
+            if (statement.StartsWith("SHOW QUERIES", StringComparison.OrdinalIgnoreCase))
+                return Task.FromResult(new KsqlDbResponse(true, $"Q1|{Topic}|PERSISTENT|RUNNING"));
+            if (statement.StartsWith("SHOW TOPICS", StringComparison.OrdinalIgnoreCase))
+                return Task.FromResult(new KsqlDbResponse(true, $"{Topic}|1"));
             return Task.FromResult(new KsqlDbResponse(true, string.Empty));
         }
         public Task<KsqlDbResponse> ExecuteExplainAsync(string ksql) => Task.FromResult(new KsqlDbResponse(true, string.Empty));
@@ -129,7 +134,8 @@ public class EnsureQueryEntityDdlAsyncTests
             KeyProperties = new[] { typeof(Target).GetProperty(nameof(Target.Id))! },
             AllProperties = typeof(Target).GetProperties(),
             KeySchemaFullName = "k",
-            ValueSchemaFullName = "v"
+            ValueSchemaFullName = "v",
+            Partitions = 1
         };
         targetModel.SetStreamTableType(StreamTableType.Stream);
         models[typeof(Target)] = targetModel;
@@ -145,8 +151,10 @@ public class EnsureQueryEntityDdlAsyncTests
         Assert.Single(logger.Messages);
         Assert.Contains("CREATE TABLE", logger.Messages[0]);
         Assert.Contains("AS", logger.Messages[0]);
-        Assert.Single(client.Statements);
+        Assert.Equal(3, client.Statements.Count);
         Assert.Contains("CREATE TABLE", client.Statements[0]);
+        Assert.Contains("SHOW QUERIES", client.Statements[1]);
+        Assert.Contains("SHOW TOPICS", client.Statements[2]);
         Assert.DoesNotContain("INSERT INTO", string.Join("\n", client.Statements));
 
         DecimalPrecisionConfig.Configure(18, 2, null);
@@ -222,7 +230,8 @@ public class EnsureQueryEntityDdlAsyncTests
             KeyProperties = new[] { typeof(Target).GetProperty(nameof(Target.Id))! },
             AllProperties = typeof(Target).GetProperties(),
             KeySchemaFullName = "k",
-            ValueSchemaFullName = "v"
+            ValueSchemaFullName = "v",
+            Partitions = 1
         };
         targetModel.SetStreamTableType(StreamTableType.Table);
         models[typeof(Target)] = targetModel;
@@ -238,8 +247,10 @@ public class EnsureQueryEntityDdlAsyncTests
         Assert.Single(logger.Messages);
         Assert.Contains("CREATE TABLE", logger.Messages[0]);
         Assert.Contains("AS", logger.Messages[0]);
-        Assert.Single(client.Statements);
+        Assert.Equal(3, client.Statements.Count);
         Assert.Contains("CREATE TABLE", client.Statements[0]);
+        Assert.Contains("SHOW QUERIES", client.Statements[1]);
+        Assert.Contains("SHOW TOPICS", client.Statements[2]);
         Assert.DoesNotContain("INSERT INTO", string.Join("\n", client.Statements));
 
         DecimalPrecisionConfig.Configure(18, 2, null);


### PR DESCRIPTION
## Summary
- ensure DESCRIBE EXTENDED verifies key/value formats and runtime stats
- validate CTAS queries are running and sink topics have expected partitions
- adjust tests for additional SHOW commands

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bd8baffb0c8327a34c81464f1f1296