### PR TITLE
Add DerivedTumblingPipeline for tumbling DDL

### DIFF
--- a/docs/diff_log/diff_derived_tumbling_pipeline_20250911.md
+++ b/docs/diff_log/diff_derived_tumbling_pipeline_20250911.md
@@ -1,0 +1,3 @@
+- Introduced DerivedTumblingPipeline to handle tumbling query derivation and DDL registration.
+- KsqlContext.SchemaRegistration now delegates tumbling DDL generation to the pipeline.
+- Added tests ensuring live, final and agg_final roles emit correct DDL.

--- a/src/KsqlContext.SchemaRegistration.cs
+++ b/src/KsqlContext.SchemaRegistration.cs
@@ -319,21 +319,13 @@ public abstract partial class KsqlContext
         if (model.QueryModel?.HasTumbling == true && model.QueryModel.Windows.Count > 0)
         {
             var qao = BuildQao(model);
-            var (entities, _) = DerivationPlanner.Plan(qao);
-            var derived = EntityModelAdapter.Adapt(entities);
-            foreach (var dm in derived)
-            {
-                var tf = (string)dm.AdditionalSettings["timeframe"];
-                var name = (string)dm.AdditionalSettings["id"];
-                var ddl = Query.Builders.KsqlCreateWindowedStatementBuilder.Build(name, model.QueryModel, tf);
-                Logger.LogInformation("KSQL DDL (derived {Entity}): {Sql}", name, ddl);
-                await ExecuteWithRetryAsync(ddl);
-                var dt = GetDerivedType(name);
-                dm.EntityType = dt;
-                dm.TopicName = name;
-                dm.SetStreamTableType(StreamTableType.Table);
-                _entityModels[dt] = dm;
-            }
+            await DerivedTumblingPipeline.RunAsync(
+                qao,
+                model.QueryModel,
+                ExecuteWithRetryAsync,
+                n => GetDerivedType(n),
+                _entityModels,
+                Logger);
             return;
         }
 

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -1,0 +1,61 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Query.Adapters;
+using Kafka.Ksql.Linq.Query.Builders;
+using Kafka.Ksql.Linq.Query.Dsl;
+using Kafka.Ksql.Linq.Query.Abstractions;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Kafka.Ksql.Linq.Query.Analysis;
+
+internal static class DerivedTumblingPipeline
+{
+    public static async Task RunAsync(
+        TumblingQao qao,
+        KsqlQueryModel queryModel,
+        Func<string, Task> execute,
+        Func<string, Type> resolveType,
+        IDictionary<Type, EntityModel> registry,
+        ILogger logger)
+    {
+        var entities = PlanDerivedEntities(qao);
+        var models = AdaptModels(entities);
+        foreach (var m in models)
+        {
+            var role = Enum.Parse<Role>((string)m.AdditionalSettings["role"]);
+            await BuildDdlAndRegister(queryModel, m, role, execute, resolveType, registry, logger);
+        }
+    }
+
+    public static IReadOnlyList<DerivedEntity> PlanDerivedEntities(TumblingQao qao)
+        => DerivationPlanner.Plan(qao).Item1;
+
+    public static IReadOnlyList<EntityModel> AdaptModels(IReadOnlyList<DerivedEntity> entities)
+        => EntityModelAdapter.Adapt(entities);
+
+    private static async Task BuildDdlAndRegister(
+        KsqlQueryModel queryModel,
+        EntityModel model,
+        Role role,
+        Func<string, Task> execute,
+        Func<string, Type> resolveType,
+        IDictionary<Type, EntityModel> registry,
+        ILogger logger)
+    {
+        var tf = (string)model.AdditionalSettings["timeframe"];
+        var name = (string)model.AdditionalSettings["id"];
+        var orig = queryModel.IsFinal;
+        queryModel.IsFinal = role is Role.Final or Role.AggFinal;
+        var ddl = KsqlCreateWindowedStatementBuilder.Build(name, queryModel, tf);
+        queryModel.IsFinal = orig;
+        logger.LogInformation("KSQL DDL (derived {Entity}): {Sql}", name, ddl);
+        await execute(ddl);
+        var dt = resolveType(name);
+        model.EntityType = dt;
+        model.TopicName = name;
+        model.SetStreamTableType(StreamTableType.Table);
+        registry[dt] = model;
+    }
+}

--- a/tests/Query/Analysis/DerivedTumblingPipelineDdlTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineDdlTests.cs
@@ -1,0 +1,87 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Query.Analysis;
+using Kafka.Ksql.Linq.Query.Dsl;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Analysis;
+
+public class DerivedTumblingPipelineDdlTests
+{
+    public class Rate
+    {
+        public string Broker { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
+        public DateTime Timestamp { get; set; }
+        public DateTime BucketStart { get; set; }
+        public decimal Open { get; set; }
+        public decimal High { get; set; }
+        public decimal Low { get; set; }
+        public decimal Close { get; set; }
+    }
+
+    public class MarketSchedule
+    {
+        public string Broker { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
+        public DateTime Open { get; set; }
+        public DateTime Close { get; set; }
+        public DateTime MarketDate { get; set; }
+    }
+
+    private static Expression BuildExpression() =>
+        ((Expression<Func<KsqlQueryable<Rate>, object>>)(q => q
+            .TimeFrame<MarketSchedule>(
+                (r, s) =>
+                    r.Broker == s.Broker &&
+                    r.Symbol == s.Symbol &&
+                    s.Open <= r.Timestamp &&
+                    r.Timestamp < s.Close,
+                s => s.MarketDate)
+            .Tumbling(r => r.Timestamp, new[] { 1 }, null, null, null, null, null)
+            .GroupBy(r => new { r.Broker, r.Symbol, BucketStart = r.Timestamp })
+            .Select(g => new
+            {
+                g.Key.Broker,
+                g.Key.Symbol,
+                g.Key.BucketStart,
+                Open = g.Max(x => x.Open)
+            }))).Body;
+
+    [Fact]
+    public async Task Builds_Expected_Ddl_For_Roles()
+    {
+        var qao = TumblingAnalyzer.Analyze(BuildExpression(), typeof(Rate));
+        var model = new KsqlQueryRoot()
+            .From<Rate>()
+            .Tumbling(r => r.Timestamp, minutes: new[] { 1 })
+            .GroupBy(r => new { r.Broker, r.Symbol, BucketStart = r.Timestamp })
+            .Select(g => new { g.Key.Broker, g.Key.Symbol, g.Key.BucketStart, Open = g.Max(x => x.Open) })
+            .AsPush()
+            .Build();
+
+        var ddls = new List<string>();
+        await DerivedTumblingPipeline.RunAsync(
+            qao,
+            model,
+            sql => { ddls.Add(sql); return Task.CompletedTask; },
+            _ => typeof(object),
+            new Dictionary<Type, EntityModel>(),
+            NullLogger.Instance);
+
+        var live = ddls.First(s => s.Contains("bar_1m_live"));
+        Assert.Contains("EMIT CHANGES", live);
+
+        var final = ddls.First(s => s.Contains("bar_1m_final"));
+        Assert.Contains("EMIT FINAL", final);
+        Assert.Contains("WINDOWSTART AS BucketStart", final);
+
+        var agg = ddls.First(s => s.Contains("bar_1m_agg_final"));
+        Assert.Contains("EMIT FINAL", agg);
+    }
+}


### PR DESCRIPTION
## Summary
- delegate tumbling DDL generation to new DerivedTumblingPipeline
- implement pipeline that plans entities, adapts models and registers DDL
- verify live/final/agg_final tumbling tables emit correct DDL

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bd948ebf808327bdaccebac55e178a