### PR TITLE
Use BaseTopicName for derived tumbling topics

### DIFF
--- a/docs/diff_log/diff_tumbling_topic_naming_20250911.md
+++ b/docs/diff_log/diff_tumbling_topic_naming_20250911.md
@@ -1,0 +1,2 @@
+- Added BaseTopicName to TumblingQao and wired through schema registration.
+- Derived tumbling entity names now prefix with BaseTopicName instead of fixed 'bar_'.

--- a/features/tumbling_topic_naming/instruction.md
+++ b/features/tumbling_topic_naming/instruction.md
@@ -1,0 +1,2 @@
+# Tumbling topic naming
+- Use BaseTopicName to build derived tumbling topics.

--- a/src/KsqlContext.SchemaRegistration.cs
+++ b/src/KsqlContext.SchemaRegistration.cs
@@ -1,5 +1,6 @@
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Attributes;
 using Kafka.Ksql.Linq.Core.Extensions;
 using Kafka.Ksql.Linq.Query.Abstractions;
 using Kafka.Ksql.Linq.Query.Adapters;
@@ -429,8 +430,10 @@ public abstract partial class KsqlContext
             var shape = m.AllProperties.Select(p => new ColumnShape(p.Name, p.PropertyType, ctx.Create(p).WriteState == NullabilityState.Nullable)).ToArray();
             var frames = m.QueryModel!.Windows.Select(ParseWindow).ToList();
             var keys = m.KeyProperties.Select(p => p.Name).ToArray();
+            var baseName = type.GetCustomAttribute<KsqlTopicAttribute>()?.Name ?? m.GetTopicName();
             return new TumblingQao
             {
+                BaseTopicName = baseName,
                 TimeKey = "Timestamp",
                 Windows = frames,
                 Keys = keys,

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -22,9 +22,10 @@ internal static class DerivationPlanner
         foreach (var tf in qao.Windows)
         {
             var tfStr = $"{tf.Value}{tf.Unit}";
-            var aggId = $"bar_{tfStr}_agg_final";
-            var liveId = $"bar_{tfStr}_live";
-            var finalId = $"bar_{tfStr}_final";
+            var baseId = qao.BaseTopicName;
+            var aggId = $"{baseId}_{tfStr}_agg_final";
+            var liveId = $"{baseId}_{tfStr}_live";
+            var finalId = $"{baseId}_{tfStr}_final";
 
             var agg = new DerivedEntity
             {
@@ -45,8 +46,8 @@ internal static class DerivationPlanner
                 Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
-                InputHint = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? "bar_1m_final" : "bar_1m_live",
-                SyncHint = tf.Unit == "m" && tf.Value == 1 ? "HB_1m" : null,
+                InputHint = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? $"{baseId}_1m_final" : $"{baseId}_1m_live",
+                SyncHint = tf.Unit == "m" && tf.Value == 1 ? $"{baseId}_hb_1m".ToUpperInvariant() : null,
                 BasedOnSpec = qao.BasedOn,
                 WeekAnchor = qao.WeekAnchor
             };
@@ -59,8 +60,8 @@ internal static class DerivationPlanner
                 Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
-                InputHint = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? "bar_1m_final" : "bar_1m_live",
-                SyncHint = tf.Unit == "m" && tf.Value == 1 ? "HB_1m" : null,
+                InputHint = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? $"{baseId}_1m_final" : $"{baseId}_1m_live",
+                SyncHint = tf.Unit == "m" && tf.Value == 1 ? $"{baseId}_hb_1m".ToUpperInvariant() : null,
                 BasedOnSpec = qao.BasedOn,
                 WeekAnchor = qao.WeekAnchor
             };
@@ -70,7 +71,7 @@ internal static class DerivationPlanner
             {
                 prev = new DerivedEntity
                 {
-                    Id = "bar_prev_1m",
+                    Id = $"{baseId}_prev_1m",
                     Role = Role.Prev1m,
                     Timeframe = tf,
                     KeyShape = keyShapes,
@@ -82,7 +83,7 @@ internal static class DerivationPlanner
 
                 var hb = new DerivedEntity
                 {
-                    Id = "hb_1m",
+                    Id = $"{baseId}_hb_1m",
                     Role = Role.Hb,
                     Timeframe = tf,
                     KeyShape = keyShapes,

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -25,7 +25,7 @@ internal static class DerivedTumblingPipeline
         foreach (var m in models)
         {
             var role = Enum.Parse<Role>((string)m.AdditionalSettings["role"]);
-            await BuildDdlAndRegister(queryModel, m, role, execute, resolveType, registry, logger);
+            await BuildDdlAndRegister(qao.BaseTopicName, queryModel, m, role, execute, resolveType, registry, logger);
         }
     }
 
@@ -36,6 +36,7 @@ internal static class DerivedTumblingPipeline
         => EntityModelAdapter.Adapt(entities);
 
     private static async Task BuildDdlAndRegister(
+        string baseName,
         KsqlQueryModel queryModel,
         EntityModel model,
         Role role,
@@ -45,7 +46,15 @@ internal static class DerivedTumblingPipeline
         ILogger logger)
     {
         var tf = (string)model.AdditionalSettings["timeframe"];
-        var name = (string)model.AdditionalSettings["id"];
+        var name = role switch
+        {
+            Role.AggFinal => $"{baseName}_{tf}_agg_final",
+            Role.Live => $"{baseName}_{tf}_live",
+            Role.Final => $"{baseName}_{tf}_final",
+            Role.Prev1m => $"{baseName}_prev_1m",
+            Role.Hb => $"{baseName}_hb_1m",
+            _ => $"{baseName}_{tf}"
+        };
         var orig = queryModel.IsFinal;
         queryModel.IsFinal = role is Role.Final or Role.AggFinal;
         var ddl = KsqlCreateWindowedStatementBuilder.Build(name, queryModel, tf);

--- a/src/Query/Analysis/TumblingQao.cs
+++ b/src/Query/Analysis/TumblingQao.cs
@@ -15,6 +15,7 @@ internal record BasedOnSpec(
 
 internal class TumblingQao
 {
+    public string BaseTopicName { get; init; } = string.Empty;
     public string TimeKey { get; init; } = string.Empty;
     public IReadOnlyList<Timeframe> Windows { get; init; } = new List<Timeframe>();
     public IReadOnlyList<string> Keys { get; init; } = new List<string>();

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -11,6 +11,7 @@ public class DerivationPlannerTests
     {
         var qao = new TumblingQao
         {
+            BaseTopicName = "bar",
             TimeKey = "Timestamp",
             Windows = new[] { new Timeframe(5, "m") },
             Keys = new[] { "Id" },

--- a/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
@@ -1,0 +1,60 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Attributes;
+using Kafka.Ksql.Linq.Query.Analysis;
+using Kafka.Ksql.Linq.Query.Dsl;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Analysis;
+
+[KsqlTopic("test-topic")]
+class TestSource
+{
+    public int Id { get; set; }
+}
+
+public class DerivedTumblingPipelineTests
+{
+    [Fact]
+    public async Task DerivedTopicsUseBaseTopicName()
+    {
+        var qao = new TumblingQao
+        {
+            BaseTopicName = typeof(TestSource).GetCustomAttribute<KsqlTopicAttribute>()!.Name,
+            TimeKey = "Timestamp",
+            Windows = new[] { new Timeframe(5, "m") },
+            Keys = new[] { "Id" },
+            Projection = new[] { "Id" },
+            PocoShape = new[] { new ColumnShape("Id", typeof(int), false) },
+            BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, string.Empty, string.Empty),
+            WeekAnchor = DayOfWeek.Monday
+        };
+        var model = new KsqlQueryModel
+        {
+            SourceTypes = new[] { typeof(TestSource) },
+            HasTumbling = true,
+            Windows = { "5m" }
+        };
+        var registry = new Dictionary<Type, EntityModel>();
+        var asm = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("dyn"), AssemblyBuilderAccess.Run);
+        var mod = asm.DefineDynamicModule("m");
+        Type Resolver(string n) => mod.DefineType("T" + Guid.NewGuid().ToString("N")).CreateType()!;
+        await DerivedTumblingPipeline.RunAsync(
+            qao,
+            model,
+            _ => Task.CompletedTask,
+            Resolver,
+            registry,
+            new LoggerFactory().CreateLogger("test"));
+        var topics = new List<string>();
+        foreach (var em in registry.Values)
+            topics.Add(em.TopicName!);
+        Assert.Contains("test-topic_5m_live", topics);
+        Assert.Contains("test-topic_5m_final", topics);
+    }
+}


### PR DESCRIPTION
## Summary
- derive tumbling topics from each entity's BaseTopicName
- register derived tumbling models without hardcoded `bar_` prefix
- verify topic naming with new pipeline test

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68bdaa8b22a88327a88cf7d0aa801751