### PR TITLE
Clone KsqlQueryModel per derived role

### DIFF
--- a/docs/diff_log/diff_querymodel_clone_20250907.md
+++ b/docs/diff_log/diff_querymodel_clone_20250907.md
@@ -1,0 +1,5 @@
+# Query model clone
+
+- DerivedTumblingPipeline now clones `KsqlQueryModel` per role
+- BuildDdlAndRegister expects preconfigured model without mutating flags
+- `KsqlQueryModel.Clone()` added for deep copy

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -25,7 +25,9 @@ internal static class DerivedTumblingPipeline
         foreach (var m in models)
         {
             var role = Enum.Parse<Role>((string)m.AdditionalSettings["role"]);
-            await BuildDdlAndRegister(qao.BaseTopicName, queryModel, m, role, execute, resolveType, registry, logger);
+            var qm = queryModel.Clone();
+            qm.IsFinal = role is Role.Final or Role.AggFinal;
+            await BuildDdlAndRegister(qao.BaseTopicName, qm, m, role, execute, resolveType, registry, logger);
         }
     }
 
@@ -55,10 +57,7 @@ internal static class DerivedTumblingPipeline
             Role.Hb => $"{baseName}_hb_1m",
             _ => $"{baseName}_{tf}"
         };
-        var orig = queryModel.IsFinal;
-        queryModel.IsFinal = role is Role.Final or Role.AggFinal;
         var ddl = KsqlCreateWindowedStatementBuilder.Build(name, queryModel, tf);
-        queryModel.IsFinal = orig;
         logger.LogInformation("KSQL DDL (derived {Entity}): {Sql}", name, ddl);
         await execute(ddl);
         var dt = resolveType(name);

--- a/src/Query/Dsl/KsqlQueryModel.cs
+++ b/src/Query/Dsl/KsqlQueryModel.cs
@@ -27,6 +27,33 @@ public class KsqlQueryModel
     public int? GraceSeconds { get; set; }
     public System.Collections.Generic.Dictionary<string, object?> Extras { get; } = new();
 
+    public KsqlQueryModel Clone()
+    {
+        var clone = new KsqlQueryModel
+        {
+            SourceTypes = (Type[])SourceTypes.Clone(),
+            JoinCondition = JoinCondition,
+            WhereCondition = WhereCondition,
+            SelectProjection = SelectProjection,
+            GroupByExpression = GroupByExpression,
+            HavingCondition = HavingCondition,
+            IsAggregateQuery = IsAggregateQuery,
+            ExecutionMode = ExecutionMode,
+            HasTumbling = HasTumbling,
+            BasedOnType = BasedOnType,
+            BasedOnDayKey = BasedOnDayKey,
+            WeekAnchor = WeekAnchor,
+            WithinSeconds = WithinSeconds,
+            ForbidDefaultWithin = ForbidDefaultWithin,
+            IsFinal = IsFinal,
+            GraceSeconds = GraceSeconds
+        };
+        clone.Windows.AddRange(Windows);
+        foreach (var kv in Extras)
+            clone.Extras[kv.Key] = kv.Value;
+        return clone;
+    }
+
     /// <summary>
     /// Returns a simple string representation useful for debugging.
     /// </summary>


### PR DESCRIPTION
## Summary
- clone `KsqlQueryModel` for each derived role in tumbling pipeline
- stop mutating `IsFinal` flag in `BuildDdlAndRegister`
- add deep copy capability to `KsqlQueryModel`

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -c Release`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68bdacbdd63483278940ea6fec3f3c2a