### PR TITLE
feat: allow overriding mapping namespace for derived entities

### DIFF
--- a/docs/diff_log/diff_mapping_namespace_override_20250911.md
+++ b/docs/diff_log/diff_mapping_namespace_override_20250911.md
@@ -1,0 +1,4 @@
+- Added namespace generation in EntityModelAdapter for derived entities.
+- MappingRegistry.RegisterEntityModel accepts overrideNamespace.
+- DerivedTumblingPipeline passes overrideNamespace when registering models.
+- Added unit test verifying namespace override.

--- a/src/KsqlContext.EntityManagement.cs
+++ b/src/KsqlContext.EntityManagement.cs
@@ -190,7 +190,8 @@ public abstract partial class KsqlContext
             dlqModel.TopicName = GetDlqTopicName();
             dlqModel.AccessMode = Core.Abstractions.EntityAccessMode.ReadOnly;
             _entityModels[typeof(Messaging.DlqEnvelope)] = dlqModel;
-            _mappingRegistry.RegisterEntityModel(dlqModel);
+            var ns = dlqModel.AdditionalSettings.TryGetValue("namespace", out var n) ? n?.ToString() : null;
+            _mappingRegistry.RegisterEntityModel(dlqModel, overrideNamespace: ns);
         }
     }
 
@@ -219,7 +220,8 @@ public abstract partial class KsqlContext
                 _entityModels[type] = model;
             }
 
-            _mappingRegistry.RegisterEntityModel(model, genericValue: model.StreamTableType == StreamTableType.Table);
+            var ns = model.AdditionalSettings.TryGetValue("namespace", out var n1) ? n1?.ToString() : null;
+            _mappingRegistry.RegisterEntityModel(model, genericValue: model.StreamTableType == StreamTableType.Table, overrideNamespace: ns);
         }
     }
 
@@ -328,7 +330,8 @@ public abstract partial class KsqlContext
 
         model ??= CreateEntityModelFromType(entityType);
         _entityModels[entityType] = model;
-        _mappingRegistry.RegisterEntityModel(model, genericValue: model.StreamTableType == StreamTableType.Table);
+        var ns2 = model.AdditionalSettings.TryGetValue("namespace", out var n2) ? n2?.ToString() : null;
+        _mappingRegistry.RegisterEntityModel(model, genericValue: model.StreamTableType == StreamTableType.Table, overrideNamespace: ns2);
 
         return model;
     }

--- a/src/KsqlContext.SchemaRegistration.cs
+++ b/src/KsqlContext.SchemaRegistration.cs
@@ -325,6 +325,7 @@ public abstract partial class KsqlContext
                 model.QueryModel,
                 ExecuteWithRetryAsync,
                 n => GetDerivedType(n),
+                _mappingRegistry,
                 _entityModels,
                 Logger);
             return;

--- a/src/Mapping/MappingRegistry.cs
+++ b/src/Mapping/MappingRegistry.cs
@@ -48,14 +48,15 @@ internal class MappingRegistry
         PropertyMeta[] valueProperties,
         string? topicName = null,
         bool genericKey = false,
-        bool genericValue = false)
+        bool genericValue = false,
+        string? overrideNamespace = null)
     {
         if (_mappings.TryGetValue(pocoType, out var existing))
         {
             return existing;
         }
 
-        string ns = AvroSanitizeName(pocoType.Namespace?.ToLower() ?? string.Empty);
+        string ns = AvroSanitizeName((overrideNamespace ?? pocoType.Namespace)?.ToLower() ?? string.Empty);
 
         var baseName = AvroSanitizeName((topicName ?? pocoType.Name).ToLower());
 
@@ -121,9 +122,10 @@ internal class MappingRegistry
         (PropertyMeta[] KeyProperties, PropertyMeta[] ValueProperties) meta,
         string? topicName = null,
         bool genericKey = false,
-        bool genericValue = false)
+        bool genericValue = false,
+        string? overrideNamespace = null)
     {
-        return Register(pocoType, meta.KeyProperties, meta.ValueProperties, topicName, genericKey, genericValue);
+        return Register(pocoType, meta.KeyProperties, meta.ValueProperties, topicName, genericKey, genericValue, overrideNamespace);
     }
 
     /// <summary>
@@ -131,7 +133,7 @@ internal class MappingRegistry
     /// Convenience wrapper so callers don't need to manually convert
     /// PropertyInfo to <see cref="PropertyMeta"/> arrays.
     /// </summary>
-    public KeyValueTypeMapping RegisterEntityModel(EntityModel model, bool genericKey = false, bool genericValue = false)
+    public KeyValueTypeMapping RegisterEntityModel(EntityModel model, bool genericKey = false, bool genericValue = false, string? overrideNamespace = null)
     {
         if (model == null) throw new ArgumentNullException(nameof(model));
 
@@ -142,7 +144,7 @@ internal class MappingRegistry
             .Select(p => PropertyMeta.FromProperty(p))
             .ToArray();
 
-        return Register(model.EntityType, keyMeta, valueMeta, model.GetTopicName(), genericKey, genericValue);
+        return Register(model.EntityType, keyMeta, valueMeta, model.GetTopicName(), genericKey, genericValue, overrideNamespace);
     }
 
     /// <summary>
@@ -156,7 +158,8 @@ internal class MappingRegistry
         PropertyInfo[] keyProperties,
         string? topicName = null,
         bool genericKey = false,
-        bool genericValue = false)
+        bool genericValue = false,
+        string? overrideNamespace = null)
     {
         if (resultType == null) throw new ArgumentNullException(nameof(resultType));
         if (model == null) throw new ArgumentNullException(nameof(model));
@@ -175,7 +178,7 @@ internal class MappingRegistry
             .ToArray();
         var keyMeta = keyProperties.Select(p => PropertyMeta.FromProperty(p)).ToArray();
 
-        return Register(resultType, keyMeta, valueProps, topicName ?? resultType.Name.ToLowerInvariant(), genericKey, genericValue);
+        return Register(resultType, keyMeta, valueProps, topicName ?? resultType.Name.ToLowerInvariant(), genericKey, genericValue, overrideNamespace);
     }
 
     private static List<PropertyInfo> ExtractProjectionProperties(LambdaExpression? projection, Type resultType)

--- a/src/Query/Adapters/EntityModelAdapter.cs
+++ b/src/Query/Adapters/EntityModelAdapter.cs
@@ -3,6 +3,7 @@ using Kafka.Ksql.Linq.Query.Analysis;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Kafka.Ksql.Linq.Query.Adapters;
 
@@ -37,6 +38,12 @@ internal static class EntityModelAdapter
             if (e.SyncHint != null) model.AdditionalSettings[$"sync"] = e.SyncHint;
             if (e.InputHint != null) model.AdditionalSettings[$"input"] = e.InputHint;
             if (e.TopicHint != null) model.AdditionalSettings[$"topicCandidate"] = e.TopicHint;
+            var nsSource = e.TopicHint ?? e.Id;
+            if (!string.IsNullOrWhiteSpace(nsSource))
+            {
+                var ns = Regex.Replace(nsSource.ToLowerInvariant(), "[^a-z0-9_]", "_");
+                model.AdditionalSettings["namespace"] = ns;
+            }
             if (e.Role == Role.Hb) model.AdditionalSettings["forceStream"] = true;
             list.Add(model);
         }

--- a/src/Query/Adapters/EntityModelRegistrar.cs
+++ b/src/Query/Adapters/EntityModelRegistrar.cs
@@ -18,7 +18,8 @@ internal static class EntityModelRegistrar
                 m.SetStreamTableType(StreamTableType.Table);
             else
                 m.SetStreamTableType(StreamTableType.Stream);
-            registry.RegisterEntityModel(m, genericValue: m.StreamTableType == StreamTableType.Table);
+            var ns = m.AdditionalSettings.TryGetValue("namespace", out var n) ? n?.ToString() : null;
+            registry.RegisterEntityModel(m, genericValue: m.StreamTableType == StreamTableType.Table, overrideNamespace: ns);
         }
     }
 }

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -3,6 +3,7 @@ using Kafka.Ksql.Linq.Query.Adapters;
 using Kafka.Ksql.Linq.Query.Builders;
 using Kafka.Ksql.Linq.Query.Dsl;
 using Kafka.Ksql.Linq.Query.Abstractions;
+using Kafka.Ksql.Linq.Mapping;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -17,6 +18,7 @@ internal static class DerivedTumblingPipeline
         KsqlQueryModel queryModel,
         Func<string, Task> execute,
         Func<string, Type> resolveType,
+        MappingRegistry mapping,
         IDictionary<Type, EntityModel> registry,
         ILogger logger)
     {
@@ -27,7 +29,7 @@ internal static class DerivedTumblingPipeline
             var role = Enum.Parse<Role>((string)m.AdditionalSettings["role"]);
             var qm = queryModel.Clone();
             qm.IsFinal = role is Role.Final or Role.AggFinal;
-            await BuildDdlAndRegister(qao.BaseTopicName, qm, m, role, execute, resolveType, registry, logger);
+            await BuildDdlAndRegister(qao.BaseTopicName, qm, m, role, execute, resolveType, mapping, registry, logger);
         }
     }
 
@@ -44,6 +46,7 @@ internal static class DerivedTumblingPipeline
         Role role,
         Func<string, Task> execute,
         Func<string, Type> resolveType,
+        MappingRegistry mapping,
         IDictionary<Type, EntityModel> registry,
         ILogger logger)
     {
@@ -64,6 +67,8 @@ internal static class DerivedTumblingPipeline
         model.EntityType = dt;
         model.TopicName = name;
         model.SetStreamTableType(StreamTableType.Table);
+        var ns = model.AdditionalSettings.TryGetValue("namespace", out var nsObj) ? nsObj?.ToString() : null;
+        mapping.RegisterEntityModel(model, genericValue: true, overrideNamespace: ns);
         registry[dt] = model;
     }
 }

--- a/tests/Mapping/MappingRegistryTests.cs
+++ b/tests/Mapping/MappingRegistryTests.cs
@@ -1,4 +1,5 @@
 using Avro.Generic;
+using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Models;
 using Kafka.Ksql.Linq.Mapping;
 using System.Linq;
@@ -89,5 +90,26 @@ public class MappingRegistryTests
 
         Assert.Equal(typeof(GenericRecord), mapping.AvroValueType);
         Assert.NotNull(mapping.AvroValueSchema);
+    }
+
+    [Fact]
+    public void RegisterEntityModel_OverrideNamespace_UsesOverride()
+    {
+        var model = new EntityModel
+        {
+            EntityType = typeof(object),
+            TopicName = "sample",
+            KeyProperties = new[] { typeof(Sample).GetProperty(nameof(Sample.Id))! },
+            AllProperties = typeof(Sample).GetProperties()
+        };
+
+        var r1 = new MappingRegistry();
+        var m1 = r1.RegisterEntityModel(model);
+        Assert.Equal("system", m1.KeyType.Namespace);
+
+        var r2 = new MappingRegistry();
+        var m2 = r2.RegisterEntityModel(model, overrideNamespace: "custom_ns");
+        Assert.Equal("custom_ns", m2.KeyType.Namespace);
+        Assert.Equal("custom_ns", m2.ValueType.Namespace);
     }
 }

--- a/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
@@ -3,6 +3,7 @@ using Kafka.Ksql.Linq.Core.Attributes;
 using Kafka.Ksql.Linq.Query.Analysis;
 using Kafka.Ksql.Linq.Query.Dsl;
 using Microsoft.Extensions.Logging;
+using Kafka.Ksql.Linq.Mapping;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -41,6 +42,7 @@ public class DerivedTumblingPipelineTests
             Windows = { "5m" }
         };
         var registry = new Dictionary<Type, EntityModel>();
+        var mapping = new MappingRegistry();
         var asm = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("dyn"), AssemblyBuilderAccess.Run);
         var mod = asm.DefineDynamicModule("m");
         Type Resolver(string n) => mod.DefineType("T" + Guid.NewGuid().ToString("N")).CreateType()!;
@@ -49,6 +51,7 @@ public class DerivedTumblingPipelineTests
             model,
             _ => Task.CompletedTask,
             Resolver,
+            mapping,
             registry,
             new LoggerFactory().CreateLogger("test"));
         var topics = new List<string>();


### PR DESCRIPTION
## Summary
- build namespace hints into EntityModelAdapter
- allow MappingRegistry.RegisterEntityModel to override type namespace
- ensure DerivedTumblingPipeline registers derived models with namespace override
- add tests for namespace override

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bdae36f8588327a00746837689022d