### PR TITLE
Add query type inference

### DIFF
--- a/docs/diff_log/diff_determine_type_20250907.md
+++ b/docs/diff_log/diff_determine_type_20250907.md
@@ -1,0 +1,5 @@
+- KsqlQueryModel gains DetermineType(), HasGroupBy(), HasTumbling(), HasAggregates(), IsAggregateQuery().
+- Removed external IsAggregateQuery/HasTumbling flags; inference is internal.
+- KsqlCreateStatementBuilder and windowed builder rely on DetermineType.
+- KsqlContext.SchemaRegistration and DerivedTumblingPipeline use DetermineType instead of local isTable/forceTable logic.
+- Added tests verifying type inference.

--- a/src/KsqlContext.SchemaRegistration.cs
+++ b/src/KsqlContext.SchemaRegistration.cs
@@ -317,7 +317,7 @@ public abstract partial class KsqlContext
         if (model.QueryModel != null)
             RegisterQueryModelMapping(model);
 
-        if (model.QueryModel?.HasTumbling == true && model.QueryModel.Windows.Count > 0)
+        if (model.QueryModel?.HasTumbling() == true)
         {
             var qao = BuildQao(model);
             await DerivedTumblingPipeline.RunAsync(
@@ -331,9 +331,10 @@ public abstract partial class KsqlContext
             return;
         }
 
-        var isTable = model.GetExplicitStreamTableType() == StreamTableType.Table || model.QueryModel?.IsAggregateQuery == true;
+        var isTable = model.GetExplicitStreamTableType() == StreamTableType.Table ||
+            model.QueryModel?.DetermineType() == StreamTableType.Table;
 
-        if (model.QueryModel?.IsAggregateQuery == true)
+        if (model.QueryModel?.DetermineType() == StreamTableType.Table)
 
         {
             Func<Type, string> resolver = t =>
@@ -465,7 +466,8 @@ public abstract partial class KsqlContext
         if (model.QueryModel == null)
             return;
 
-        var isTable = model.GetExplicitStreamTableType() == StreamTableType.Table || model.QueryModel!.IsAggregateQuery;
+        var isTable = model.GetExplicitStreamTableType() == StreamTableType.Table ||
+            model.QueryModel!.DetermineType() == StreamTableType.Table;
         _mappingRegistry.RegisterQueryModel(
             model.EntityType,
             model.QueryModel!,

--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -294,7 +294,7 @@ public abstract partial class KsqlContext : IKsqlContext
     public async Task StartHeartbeatRunnerAsync(CancellationToken appStopping)
     {
         if (_hbRunner != null) return;
-        if (!_entityModels.Values.Any(m => m.QueryModel?.HasTumbling == true)) return;
+        if (!_entityModels.Values.Any(m => m.QueryModel?.HasTumbling() == true)) return;
 
         var scheduleType = _entityModels.Values
             .Select(m => m.QueryModel?.BasedOnType)

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -66,7 +66,7 @@ internal static class DerivedTumblingPipeline
         var dt = resolveType(name);
         model.EntityType = dt;
         model.TopicName = name;
-        model.SetStreamTableType(StreamTableType.Table);
+        model.SetStreamTableType(queryModel.DetermineType());
         var ns = model.AdditionalSettings.TryGetValue("namespace", out var nsObj) ? nsObj?.ToString() : null;
         mapping.RegisterEntityModel(model, genericValue: true, overrideNamespace: ns);
         registry[dt] = model;

--- a/src/Query/Builders/KsqlCreateStatementBuilder.cs
+++ b/src/Query/Builders/KsqlCreateStatementBuilder.cs
@@ -1,5 +1,6 @@
 using Kafka.Ksql.Linq.Core.Attributes;
 using Kafka.Ksql.Linq.Query.Dsl;
+using Kafka.Ksql.Linq.Query.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -59,7 +60,7 @@ public static class KsqlCreateStatementBuilder
         whereClause = ApplyKeyStyle(whereClause, keyMap);
         havingClause = ApplyKeyStyle(havingClause, keyMap);
 
-        var createType = model.IsAggregateQuery ? "CREATE TABLE" : "CREATE STREAM";
+        var createType = model.DetermineType() == StreamTableType.Table ? "CREATE TABLE" : "CREATE STREAM";
 
         var sb = new StringBuilder();
         sb.Append($"{createType} {streamName}");

--- a/src/Query/Builders/KsqlCreateWindowedStatementBuilder.cs
+++ b/src/Query/Builders/KsqlCreateWindowedStatementBuilder.cs
@@ -16,8 +16,6 @@ internal static class KsqlCreateWindowedStatementBuilder
         if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("name required", nameof(name));
         if (model is null) throw new ArgumentNullException(nameof(model));
         if (string.IsNullOrWhiteSpace(timeframe)) throw new ArgumentException("timeframe required", nameof(timeframe));
-        // Tumbling queries always represent aggregations; force table generation
-        model.IsAggregateQuery = true;
         var baseSql = KsqlCreateStatementBuilder.Build(name, model);
         if (model.IsFinal)
         {

--- a/src/Query/Dsl/KsqlGroupedQueryable.cs
+++ b/src/Query/Dsl/KsqlGroupedQueryable.cs
@@ -37,8 +37,6 @@ public class KsqlGroupedQueryable<T, TKey> : IKsqlQueryable
         _stage = QueryBuildStage.Select;
         var visitor = new Kafka.Ksql.Linq.Query.Builders.AggregateDetectionVisitor();
         visitor.Visit(projection.Body);
-        if (visitor.HasAggregates)
-            _model.IsAggregateQuery = true;
         return this;
     }
 

--- a/src/Query/Dsl/KsqlQueryModel.cs
+++ b/src/Query/Dsl/KsqlQueryModel.cs
@@ -1,4 +1,6 @@
 using Kafka.Ksql.Linq.Query.Pipeline;
+using Kafka.Ksql.Linq.Query.Builders;
+using Kafka.Ksql.Linq.Query.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,9 +16,7 @@ public class KsqlQueryModel
     public LambdaExpression? SelectProjection { get; set; }
     public LambdaExpression? GroupByExpression { get; set; }
     public LambdaExpression? HavingCondition { get; set; }
-    public bool IsAggregateQuery { get; set; }
     public QueryExecutionMode ExecutionMode { get; set; } = QueryExecutionMode.Unspecified;
-    public bool HasTumbling { get; set; }
     public Type? BasedOnType { get; set; }
     public LambdaExpression? BasedOnDayKey { get; set; }
     public List<string> Windows { get; } = new();
@@ -37,9 +37,7 @@ public class KsqlQueryModel
             SelectProjection = SelectProjection,
             GroupByExpression = GroupByExpression,
             HavingCondition = HavingCondition,
-            IsAggregateQuery = IsAggregateQuery,
             ExecutionMode = ExecutionMode,
-            HasTumbling = HasTumbling,
             BasedOnType = BasedOnType,
             BasedOnDayKey = BasedOnDayKey,
             WeekAnchor = WeekAnchor,
@@ -60,6 +58,22 @@ public class KsqlQueryModel
     public string Dump()
     {
         var sources = string.Join(",", SourceTypes.Select(t => t.Name));
-        return $"Sources:[{sources}] Join:{JoinCondition} Where:{WhereCondition} Select:{SelectProjection} Aggregate:{IsAggregateQuery} Mode:{ExecutionMode}";
+        return $"Sources:[{sources}] Join:{JoinCondition} Where:{WhereCondition} Select:{SelectProjection} Aggregate:{IsAggregateQuery()} Mode:{ExecutionMode}";
     }
+
+    public bool HasGroupBy() => GroupByExpression != null;
+
+    public bool HasTumbling() => Windows.Count > 0;
+
+    public bool HasAggregates()
+    {
+        if (SelectProjection == null) return false;
+        var visitor = new AggregateDetectionVisitor();
+        visitor.Visit(SelectProjection.Body);
+        return visitor.HasAggregates;
+    }
+
+    public bool IsAggregateQuery() => HasGroupBy() || HasTumbling() || HasAggregates();
+
+    public StreamTableType DetermineType() => IsAggregateQuery() ? StreamTableType.Table : StreamTableType.Stream;
 }

--- a/src/Query/Dsl/KsqlQueryable.cs
+++ b/src/Query/Dsl/KsqlQueryable.cs
@@ -44,8 +44,6 @@ public class KsqlQueryable<T1> : IKsqlQueryable, IScheduledScope<T1>
         _model.SelectProjection = projection;
         var visitor = new Kafka.Ksql.Linq.Query.Builders.AggregateDetectionVisitor();
         visitor.Visit(projection.Body);
-        if (visitor.HasAggregates)
-            _model.IsAggregateQuery = true;
         return this;
     }
 
@@ -56,7 +54,6 @@ public class KsqlQueryable<T1> : IKsqlQueryable, IScheduledScope<T1>
 
         _model.GroupByExpression = keySelector;
         _stage = QueryBuildStage.GroupBy;
-        _model.IsAggregateQuery = true;
         return new KsqlGroupedQueryable<T1, TKey>(_model);
     }
 
@@ -69,7 +66,6 @@ public class KsqlQueryable<T1> : IKsqlQueryable, IScheduledScope<T1>
         DayOfWeek? week = null,
         TimeSpan? grace = null)
     {
-        _model.HasTumbling = true;
         if (minutes != null) foreach (var m in minutes) _model.Windows.Add($"{m}m");
         if (hours != null) foreach (var h in hours) _model.Windows.Add($"{h}h");
         if (days != null) foreach (var d in days) _model.Windows.Add($"{d}d");
@@ -155,8 +151,7 @@ public class KsqlQueryable<T1> : IKsqlQueryable, IScheduledScope<T1>
             SourceTypes = new[] { typeof(T1), typeof(T2) },
             JoinCondition = condition,
             WhereCondition = _model.WhereCondition,
-            SelectProjection = _model.SelectProjection,
-            IsAggregateQuery = _model.IsAggregateQuery
+            SelectProjection = _model.SelectProjection
         };
         return new KsqlQueryable2<T1, T2>(newModel);
     }

--- a/src/Query/Dsl/KsqlQueryable2.cs
+++ b/src/Query/Dsl/KsqlQueryable2.cs
@@ -50,10 +50,6 @@ public class KsqlQueryable2<T1, T2> : IKsqlQueryable
 
         var visitor = new Kafka.Ksql.Linq.Query.Builders.AggregateDetectionVisitor();
         visitor.Visit(projection.Body);
-        if (visitor.HasAggregates)
-        {
-            _model.IsAggregateQuery = true;
-        }
 
         return this;
     }
@@ -67,7 +63,6 @@ public class KsqlQueryable2<T1, T2> : IKsqlQueryable
         DayOfWeek? week = null,
         TimeSpan? grace = null)
     {
-        _model.HasTumbling = true;
         if (minutes != null) foreach (var m in minutes) _model.Windows.Add($"{m}m");
         if (hours != null) foreach (var h in hours) _model.Windows.Add($"{h}h");
         if (days != null) foreach (var d in days) _model.Windows.Add($"{d}d");

--- a/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
@@ -38,7 +38,6 @@ public class DerivedTumblingPipelineTests
         var model = new KsqlQueryModel
         {
             SourceTypes = new[] { typeof(TestSource) },
-            HasTumbling = true,
             Windows = { "5m" }
         };
         var registry = new Dictionary<Type, EntityModel>();

--- a/tests/Query/Builders/KsqlCreateWindowedStatementBuilderTests.cs
+++ b/tests/Query/Builders/KsqlCreateWindowedStatementBuilderTests.cs
@@ -1,6 +1,7 @@
 using Kafka.Ksql.Linq.Core.Attributes;
 using Kafka.Ksql.Linq.Query.Dsl;
 using Kafka.Ksql.Linq.Query.Pipeline;
+using Kafka.Ksql.Linq.Query.Abstractions;
 using System;
 using System.Linq.Expressions;
 using Xunit;
@@ -119,8 +120,6 @@ public class KsqlCreateWindowedStatementBuilderTests
             WhereCondition = (Expression<Func<RateTable, Rate, bool>>)((t, s) => t.Broker != string.Empty && s.Symbol != string.Empty),
             GroupByExpression = (Expression<Func<RateTable, Rate, object>>)((t, s) => new { t.Broker, s.Symbol }),
             SelectProjection = (Expression<Func<RateTable, Rate, object>>)((t, s) => new { t.Broker, s.Symbol }),
-            IsAggregateQuery = true,
-            HasTumbling = true,
             IsFinal = true,
             ExecutionMode = QueryExecutionMode.PushQuery
         };
@@ -132,6 +131,30 @@ public class KsqlCreateWindowedStatementBuilderTests
         Assert.Contains("WHERE ((KEY->BROKER != Empty) AND (i.Symbol != Empty))", sql);
         Assert.DoesNotContain("KEY->SYMBOL", sql);
         Assert.DoesNotContain("COMPOSE(", sql);
+    }
+
+    [Fact]
+    public void DetermineType_Tumbling_Returns_Table()
+    {
+        var model = new KsqlQueryRoot()
+            .From<Rate>()
+            .Tumbling(r => r.Timestamp, minutes: new[] { 1 })
+            .GroupBy(r => new { r.Broker, r.Symbol, BucketStart = r.Timestamp })
+            .Select(g => new { g.Key.Broker, g.Key.Symbol, g.Key.BucketStart })
+            .AsPush()
+            .Build();
+        Assert.Equal(StreamTableType.Table, model.DetermineType());
+    }
+
+    [Fact]
+    public void DetermineType_NoAggregation_Returns_Stream()
+    {
+        var model = new KsqlQueryRoot()
+            .From<Rate>()
+            .Select(r => r)
+            .AsPush()
+            .Build();
+        Assert.Equal(StreamTableType.Stream, model.DetermineType());
     }
 }
 

--- a/tests/Query/Dsl/KsqlQueryable2Tests.cs
+++ b/tests/Query/Dsl/KsqlQueryable2Tests.cs
@@ -27,7 +27,7 @@ public class KsqlQueryable2Tests
         Expression<Func<Order, Payment, object>> projection = (o, p) => new { Total = o.Amount + p.Paid, Sum = Enumerable.Sum(new[] { o.Amount, p.Paid }) };
         var queryable = new KsqlQueryable2<Order, Payment>().Select(projection);
         var model = queryable.Build();
-        Assert.True(model.IsAggregateQuery);
+        Assert.True(model.IsAggregateQuery());
     }
 
     [Fact(Skip = "Requires join condition setup")]

--- a/tests/Query/Dsl/ToQueryDslTests.cs
+++ b/tests/Query/Dsl/ToQueryDslTests.cs
@@ -343,8 +343,7 @@ public class ToQueryDslTests
             WhereCondition = (Expression<Func<OrderTable, Customer, bool>>)((o, c) => o.Id > 0 && c.Id > 0),
             GroupByExpression = (Expression<Func<OrderTable, Customer, object>>)((o, c) => new { o.Id, c.Name }),
             SelectProjection = (Expression<Func<OrderTable, Customer, object>>)((o, c) => new { o.Id, c.Name }),
-            WithinSeconds = 300,
-            IsAggregateQuery = true
+            WithinSeconds = 300
         };
 
         var sql = KsqlCreateStatementBuilder.Build("view", model);


### PR DESCRIPTION
## Summary
- infer query Stream/Table type inside KsqlQueryModel
- build CREATE statements based on inferred type
- validate new inference with unit tests

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68bdb2215fa0832787382d6f338f41fb