### PR TITLE
Add role-based derivation tests

### DIFF
--- a/docs/diff_log/diff_query_role_tests_20250907.md
+++ b/docs/diff_log/diff_query_role_tests_20250907.md
@@ -1,0 +1,3 @@
+- add unit tests verifying DerivationPlanner creates role-specific entities
+- verify CREATE STREAM/TABLE generation with and without windows
+- ensure DerivedTumblingPipeline emits distinct DDL per role

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -6,24 +6,39 @@ namespace Kafka.Ksql.Linq.Tests.Query.Analysis;
 
 public class DerivationPlannerTests
 {
-    [Fact]
-    public void PlanReturnsDerivedEntities()
+    private static TumblingQao Create(Timeframe tf) => new()
     {
-        var qao = new TumblingQao
-        {
-            BaseTopicName = "bar",
-            TimeKey = "Timestamp",
-            Windows = new[] { new Timeframe(5, "m") },
-            Keys = new[] { "Id" },
-            Projection = new[] { "Id" },
-            PocoShape = new[] { new ColumnShape("Id", typeof(int), false) },
-            BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, string.Empty, string.Empty),
-            WeekAnchor = DayOfWeek.Monday
-        };
+        BaseTopicName = "bar",
+        TimeKey = "Timestamp",
+        Windows = new[] { tf },
+        Keys = new[] { "Id" },
+        Projection = new[] { "Id" },
+        PocoShape = new[] { new ColumnShape("Id", typeof(int), false) },
+        BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, string.Empty, string.Empty),
+        WeekAnchor = DayOfWeek.Monday
+    };
 
-        var entities = DerivationPlanner.Plan(qao);
+    [Fact]
+    public void Plan_1m_Includes_All_Roles()
+    {
+        var entities = DerivationPlanner.Plan(Create(new Timeframe(1, "m")));
 
-        Assert.Equal(3, entities.Count);
-        Assert.Contains(entities, e => e.Id == "bar_5m_final");
+        Assert.Contains(entities, e => e.Id == "bar_1m_agg_final" && e.Role == Role.AggFinal);
+        Assert.Contains(entities, e => e.Id == "bar_1m_live" && e.Role == Role.Live);
+        Assert.Contains(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
+        Assert.Contains(entities, e => e.Id == "bar_prev_1m" && e.Role == Role.Prev1m);
+        Assert.Contains(entities, e => e.Id == "bar_hb_1m" && e.Role == Role.Hb);
+    }
+
+    [Fact]
+    public void Plan_5m_Excludes_Prev_And_Hb()
+    {
+        var entities = DerivationPlanner.Plan(Create(new Timeframe(5, "m")));
+
+        Assert.Contains(entities, e => e.Id == "bar_5m_agg_final" && e.Role == Role.AggFinal);
+        Assert.Contains(entities, e => e.Id == "bar_5m_live" && e.Role == Role.Live);
+        Assert.Contains(entities, e => e.Id == "bar_5m_final" && e.Role == Role.Final);
+        Assert.DoesNotContain(entities, e => e.Role == Role.Prev1m);
+        Assert.DoesNotContain(entities, e => e.Role == Role.Hb);
     }
 }

--- a/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
@@ -2,10 +2,11 @@ using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Attributes;
 using Kafka.Ksql.Linq.Query.Analysis;
 using Kafka.Ksql.Linq.Query.Dsl;
-using Microsoft.Extensions.Logging;
 using Kafka.Ksql.Linq.Mapping;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Threading.Tasks;
@@ -22,13 +23,13 @@ class TestSource
 public class DerivedTumblingPipelineTests
 {
     [Fact]
-    public async Task DerivedTopicsUseBaseTopicName()
+    public async Task Live_and_Final_emit_different_ddl()
     {
         var qao = new TumblingQao
         {
             BaseTopicName = typeof(TestSource).GetCustomAttribute<KsqlTopicAttribute>()!.Name,
             TimeKey = "Timestamp",
-            Windows = new[] { new Timeframe(5, "m") },
+            Windows = new[] { new Timeframe(1, "m") },
             Keys = new[] { "Id" },
             Projection = new[] { "Id" },
             PocoShape = new[] { new ColumnShape("Id", typeof(int), false) },
@@ -38,25 +39,27 @@ public class DerivedTumblingPipelineTests
         var model = new KsqlQueryModel
         {
             SourceTypes = new[] { typeof(TestSource) },
-            Windows = { "5m" }
+            Windows = { "1m" }
         };
-        var registry = new Dictionary<Type, EntityModel>();
+
+        var ddls = new List<string>();
+        Task Exec(string sql)
+        {
+            ddls.Add(sql);
+            return Task.CompletedTask;
+        }
+
         var mapping = new MappingRegistry();
+        var registry = new Dictionary<Type, EntityModel>();
         var asm = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("dyn"), AssemblyBuilderAccess.Run);
         var mod = asm.DefineDynamicModule("m");
-        Type Resolver(string n) => mod.DefineType("T" + Guid.NewGuid().ToString("N")).CreateType()!;
-        await DerivedTumblingPipeline.RunAsync(
-            qao,
-            model,
-            _ => Task.CompletedTask,
-            Resolver,
-            mapping,
-            registry,
-            new LoggerFactory().CreateLogger("test"));
-        var topics = new List<string>();
-        foreach (var em in registry.Values)
-            topics.Add(em.TopicName!);
-        Assert.Contains("test-topic_5m_live", topics);
-        Assert.Contains("test-topic_5m_final", topics);
+        Type Resolver(string _) => mod.DefineType("T" + Guid.NewGuid().ToString("N")).CreateType()!;
+
+        await DerivedTumblingPipeline.RunAsync(qao, model, Exec, Resolver, mapping, registry, new LoggerFactory().CreateLogger("test"));
+
+        var live = ddls.Single(s => s.Contains("_1m_live"));
+        var final = ddls.Single(s => s.Contains("_1m_final"));
+        Assert.Contains("EMIT CHANGES", live);
+        Assert.Contains("EMIT FINAL", final);
     }
 }

--- a/tests/Query/Builders/KsqlCreateWindowedStatementBuilderTests.cs
+++ b/tests/Query/Builders/KsqlCreateWindowedStatementBuilderTests.cs
@@ -134,6 +134,35 @@ public class KsqlCreateWindowedStatementBuilderTests
     }
 
     [Fact]
+    public void Build_NoWindow_Creates_Stream()
+    {
+        var model = new KsqlQueryRoot()
+            .From<Rate>()
+            .Select(r => r)
+            .AsPush()
+            .Build();
+
+        var sql = Kafka.Ksql.Linq.Query.Builders.KsqlCreateStatementBuilder.Build("rates", model);
+        Assert.StartsWith("CREATE STREAM rates", sql);
+    }
+
+    [Fact]
+    public void Build_WithWindow_Creates_Table()
+    {
+        var model = new KsqlQueryRoot()
+            .From<Rate>()
+            .Tumbling(r => r.Timestamp, minutes: new[] { 1 })
+            .GroupBy(r => new { r.Broker, r.Symbol, BucketStart = r.Timestamp })
+            .Select(g => new { g.Key.Broker, g.Key.Symbol, g.Key.BucketStart, Open = g.EarliestByOffset(x => x.Bid) })
+            .AsPush()
+            .Build();
+
+        var sql = Kafka.Ksql.Linq.Query.Builders.KsqlCreateWindowedStatementBuilder.Build("bar_1m", model, "1m");
+        Assert.StartsWith("CREATE TABLE bar_1m", sql);
+        Assert.Contains("WINDOW TUMBLING", sql);
+    }
+
+    [Fact]
     public void DetermineType_Tumbling_Returns_Table()
     {
         var model = new KsqlQueryRoot()


### PR DESCRIPTION
## Summary
- cover role-specific derived entities in DerivationPlanner
- verify CREATE STREAM/TABLE generation with and without windowing
- assert derived tumbling pipeline outputs distinct DDL per role

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68bdb3f3aad4832790a72a4c560d219f