### PR TITLE
Derive tumbling topics from entity model

### DIFF
--- a/src/KsqlContext.SchemaRegistration.cs
+++ b/src/KsqlContext.SchemaRegistration.cs
@@ -322,6 +322,7 @@ public abstract partial class KsqlContext
             var qao = BuildQao(model);
             await DerivedTumblingPipeline.RunAsync(
                 qao,
+                model,
                 model.QueryModel,
                 ExecuteWithRetryAsync,
                 n => GetDerivedType(n),
@@ -432,10 +433,8 @@ public abstract partial class KsqlContext
             var shape = m.AllProperties.Select(p => new ColumnShape(p.Name, p.PropertyType, ctx.Create(p).WriteState == NullabilityState.Nullable)).ToArray();
             var frames = m.QueryModel!.Windows.Select(ParseWindow).ToList();
             var keys = m.KeyProperties.Select(p => p.Name).ToArray();
-            var baseName = type.GetCustomAttribute<KsqlTopicAttribute>()?.Name ?? m.GetTopicName();
             return new TumblingQao
             {
-                BaseTopicName = baseName,
                 TimeKey = "Timestamp",
                 Windows = frames,
                 Keys = keys,

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Attributes;
 
 namespace Kafka.Ksql.Linq.Query.Analysis;
 
 internal static class DerivationPlanner
 {
-    public static IReadOnlyList<DerivedEntity> Plan(TumblingQao qao)
+    public static IReadOnlyList<DerivedEntity> Plan(TumblingQao qao, EntityModel model)
     {
         var entities = new List<DerivedEntity>();
 
@@ -22,7 +25,8 @@ internal static class DerivationPlanner
         foreach (var tf in qao.Windows)
         {
             var tfStr = $"{tf.Value}{tf.Unit}";
-            var baseId = qao.BaseTopicName;
+            var topicAttr = model.EntityType.GetCustomAttribute<KsqlTopicAttribute>();
+            var baseId = (topicAttr?.Name ?? model.TopicName ?? model.EntityType.Name).ToLowerInvariant();
             var aggId = $"{baseId}_{tfStr}_agg_final";
             var liveId = $"{baseId}_{tfStr}_live";
             var finalId = $"{baseId}_{tfStr}_final";

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -1,4 +1,5 @@
 using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Attributes;
 using Kafka.Ksql.Linq.Query.Adapters;
 using Kafka.Ksql.Linq.Query.Builders;
 using Kafka.Ksql.Linq.Query.Dsl;
@@ -8,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Kafka.Ksql.Linq.Query.Analysis;
@@ -16,6 +18,7 @@ internal static class DerivedTumblingPipeline
 {
     public static async Task RunAsync(
         TumblingQao qao,
+        EntityModel baseModel,
         KsqlQueryModel queryModel,
         Func<string, Task> execute,
         Func<string, Type> resolveType,
@@ -23,14 +26,16 @@ internal static class DerivedTumblingPipeline
         ConcurrentDictionary<Type, EntityModel> registry,
         ILogger logger)
     {
-        var entities = PlanDerivedEntities(qao);
+        var baseAttr = baseModel.EntityType.GetCustomAttribute<KsqlTopicAttribute>();
+        var baseName = (baseAttr?.Name ?? baseModel.TopicName ?? baseModel.EntityType.Name).ToLowerInvariant();
+        var entities = PlanDerivedEntities(qao, baseModel);
         var models = AdaptModels(entities);
         await Parallel.ForEachAsync(models, async (m, _) =>
         {
             var role = Enum.Parse<Role>((string)m.AdditionalSettings["role"]);
             var qm = queryModel.Clone();
             qm.IsFinal = role is Role.Final or Role.AggFinal;
-            var (ddl, dt, ns) = BuildDdlAndRegister(qao.BaseTopicName, qm, m, role, resolveType);
+            var (ddl, dt, ns) = BuildDdlAndRegister(baseName, qm, m, role, resolveType);
             logger.LogInformation("KSQL DDL (derived {Entity}): {Sql}", m.TopicName, ddl);
             await execute(ddl);
             mapping.RegisterEntityModel(m, genericValue: true, overrideNamespace: ns);
@@ -38,8 +43,8 @@ internal static class DerivedTumblingPipeline
         });
     }
 
-    public static IReadOnlyList<DerivedEntity> PlanDerivedEntities(TumblingQao qao)
-        => DerivationPlanner.Plan(qao);
+    public static IReadOnlyList<DerivedEntity> PlanDerivedEntities(TumblingQao qao, EntityModel model)
+        => DerivationPlanner.Plan(qao, model);
 
     public static IReadOnlyList<EntityModel> AdaptModels(IReadOnlyList<DerivedEntity> entities)
         => EntityModelAdapter.Adapt(entities);

--- a/src/Query/Analysis/TumblingQao.cs
+++ b/src/Query/Analysis/TumblingQao.cs
@@ -15,7 +15,6 @@ internal record BasedOnSpec(
 
 internal class TumblingQao
 {
-    public string BaseTopicName { get; init; } = string.Empty;
     public string TimeKey { get; init; } = string.Empty;
     public IReadOnlyList<Timeframe> Windows { get; init; } = new List<Timeframe>();
     public IReadOnlyList<string> Keys { get; init; } = new List<string>();

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -1,3 +1,5 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Attributes;
 using Kafka.Ksql.Linq.Query.Analysis;
 using System;
 using Xunit;
@@ -6,9 +8,14 @@ namespace Kafka.Ksql.Linq.Tests.Query.Analysis;
 
 public class DerivationPlannerTests
 {
+    [KsqlTopic("bar")]
+    private class Source
+    {
+        public int Id { get; set; }
+    }
+
     private static TumblingQao Create(Timeframe tf) => new()
     {
-        BaseTopicName = "bar",
         TimeKey = "Timestamp",
         Windows = new[] { tf },
         Keys = new[] { "Id" },
@@ -21,7 +28,8 @@ public class DerivationPlannerTests
     [Fact]
     public void Plan_1m_Includes_All_Roles()
     {
-        var entities = DerivationPlanner.Plan(Create(new Timeframe(1, "m")));
+        var model = new EntityModel { EntityType = typeof(Source) };
+        var entities = DerivationPlanner.Plan(Create(new Timeframe(1, "m")), model);
 
         Assert.Contains(entities, e => e.Id == "bar_1m_agg_final" && e.Role == Role.AggFinal);
         Assert.Contains(entities, e => e.Id == "bar_1m_live" && e.Role == Role.Live);
@@ -33,7 +41,8 @@ public class DerivationPlannerTests
     [Fact]
     public void Plan_5m_Excludes_Prev_And_Hb()
     {
-        var entities = DerivationPlanner.Plan(Create(new Timeframe(5, "m")));
+        var model = new EntityModel { EntityType = typeof(Source) };
+        var entities = DerivationPlanner.Plan(Create(new Timeframe(5, "m")), model);
 
         Assert.Contains(entities, e => e.Id == "bar_5m_agg_final" && e.Role == Role.AggFinal);
         Assert.Contains(entities, e => e.Id == "bar_5m_live" && e.Role == Role.Live);

--- a/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
@@ -26,7 +26,6 @@ public class DerivedTumblingPipelineConcurrencyTests
     {
         var qao = new TumblingQao
         {
-            BaseTopicName = typeof(ConcurrencySource).GetCustomAttribute<KsqlTopicAttribute>()!.Name,
             TimeKey = "Timestamp",
             Windows = new[] { new Timeframe(1, "m"), new Timeframe(5, "m") },
             Keys = new[] { "Id" },
@@ -35,6 +34,7 @@ public class DerivedTumblingPipelineConcurrencyTests
             BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, string.Empty, string.Empty),
             WeekAnchor = DayOfWeek.Monday
         };
+        var baseModel = new EntityModel { EntityType = typeof(ConcurrencySource) };
         var model = new KsqlQueryModel
         {
             SourceTypes = new[] { typeof(ConcurrencySource) },
@@ -52,7 +52,7 @@ public class DerivedTumblingPipelineConcurrencyTests
         var mod = asm.DefineDynamicModule("m");
         Type Resolver(string _) => mod.DefineType("T" + Guid.NewGuid().ToString("N")).CreateType()!;
 
-        await DerivedTumblingPipeline.RunAsync(qao, model, Exec, Resolver, mapping, registry, new LoggerFactory().CreateLogger("test"));
+        await DerivedTumblingPipeline.RunAsync(qao, baseModel, model, Exec, Resolver, mapping, registry, new LoggerFactory().CreateLogger("test"));
 
         var expected = 8; // 2 windows -> AggFinal/Live/Final each + Prev1m/Hb
         Assert.Equal(expected, registry.Count);

--- a/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
@@ -27,7 +27,6 @@ public class DerivedTumblingPipelineTests
     {
         var qao = new TumblingQao
         {
-            BaseTopicName = typeof(TestSource).GetCustomAttribute<KsqlTopicAttribute>()!.Name,
             TimeKey = "Timestamp",
             Windows = new[] { new Timeframe(1, "m") },
             Keys = new[] { "Id" },
@@ -36,6 +35,7 @@ public class DerivedTumblingPipelineTests
             BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, string.Empty, string.Empty),
             WeekAnchor = DayOfWeek.Monday
         };
+        var baseModel = new EntityModel { EntityType = typeof(TestSource) };
         var model = new KsqlQueryModel
         {
             SourceTypes = new[] { typeof(TestSource) },
@@ -55,7 +55,7 @@ public class DerivedTumblingPipelineTests
         var mod = asm.DefineDynamicModule("m");
         Type Resolver(string _) => mod.DefineType("T" + Guid.NewGuid().ToString("N")).CreateType()!;
 
-        await DerivedTumblingPipeline.RunAsync(qao, model, Exec, Resolver, mapping, registry, new LoggerFactory().CreateLogger("test"));
+        await DerivedTumblingPipeline.RunAsync(qao, baseModel, model, Exec, Resolver, mapping, registry, new LoggerFactory().CreateLogger("test"));
 
         var live = ddls.Single(s => s.Contains("_1m_live"));
         var final = ddls.Single(s => s.Contains("_1m_final"));


### PR DESCRIPTION
## Summary
- derive base topic name from entity model or KsqlTopic attribute
- propagate entity model through tumbling pipeline
- update tumbling QAO and analysis tests for new topic naming

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter "FullyQualifiedName~Query.Analysis"`


------
https://chatgpt.com/codex/tasks/task_e_68bdbcb9786c8327a78d9f22789a5675