### PR TITLE
Clone query model per derived role

### DIFF
--- a/docs/diff_log/diff_derived_tumbling_pipeline_clone_in_build_20250926.md
+++ b/docs/diff_log/diff_derived_tumbling_pipeline_clone_in_build_20250926.md
@@ -1,0 +1,5 @@
+# Derived tumbling pipeline query model clone in BuildDdlAndRegister
+
+- `BuildDdlAndRegister` now clones `KsqlQueryModel` internally per role
+- `RunAsync` passes the shared model without mutating flags
+- Test ensures original `KsqlQueryModel` remains unchanged

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -33,9 +33,7 @@ internal static class DerivedTumblingPipeline
         await Parallel.ForEachAsync(models, async (m, _) =>
         {
             var role = Enum.Parse<Role>((string)m.AdditionalSettings["role"]);
-            var qm = queryModel.Clone();
-            qm.IsFinal = role is Role.Final or Role.AggFinal;
-            var (ddl, dt, ns) = BuildDdlAndRegister(baseName, qm, m, role, resolveType);
+            var (ddl, dt, ns) = BuildDdlAndRegister(baseName, queryModel, m, role, resolveType);
             logger.LogInformation("KSQL DDL (derived {Entity}): {Sql}", m.TopicName, ddl);
             await execute(ddl);
             mapping.RegisterEntityModel(m, genericValue: true, overrideNamespace: ns);
@@ -56,6 +54,8 @@ internal static class DerivedTumblingPipeline
         Role role,
         Func<string, Type> resolveType)
     {
+        var qm = queryModel.Clone();
+        qm.IsFinal = role is Role.Final or Role.AggFinal;
         var tf = (string)model.AdditionalSettings["timeframe"];
         var name = role switch
         {
@@ -66,11 +66,11 @@ internal static class DerivedTumblingPipeline
             Role.Hb => $"{baseName}_hb_1m",
             _ => $"{baseName}_{tf}"
         };
-        var ddl = KsqlCreateWindowedStatementBuilder.Build(name, queryModel, tf);
+        var ddl = KsqlCreateWindowedStatementBuilder.Build(name, qm, tf);
         var dt = resolveType(name);
         model.EntityType = dt;
         model.TopicName = name;
-        model.SetStreamTableType(queryModel.DetermineType());
+        model.SetStreamTableType(qm.DetermineType());
         var ns = model.AdditionalSettings.TryGetValue("namespace", out var nsObj) ? nsObj?.ToString() : null;
         return (ddl, dt, ns);
     }

--- a/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
@@ -23,7 +23,7 @@ class TestSource
 public class DerivedTumblingPipelineTests
 {
     [Fact]
-    public async Task Live_and_Final_emit_different_ddl()
+    public async Task Live_and_Final_emit_different_ddl_without_mutating_model()
     {
         var qao = new TumblingQao
         {
@@ -61,5 +61,6 @@ public class DerivedTumblingPipelineTests
         var final = ddls.Single(s => s.Contains("_1m_final"));
         Assert.Contains("EMIT CHANGES", live);
         Assert.Contains("EMIT FINAL", final);
+        Assert.False(model.IsFinal);
     }
 }


### PR DESCRIPTION
## Summary
- clone KsqlQueryModel inside DerivedTumblingPipeline.BuildDdlAndRegister
- test ensures original query model remains unchanged
- document cloning change in diff log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter 'FullyQualifiedName!~Kafka.Ksql.Linq.Tests.Integration'`


------
https://chatgpt.com/codex/tasks/task_e_68bdbe50cb1c8327bb5d627ed5d28ac0