### PR TITLE
Sanitize namespace for derived models

### DIFF
--- a/docs/diff_log/diff_sanitized_namespace_20250914.md
+++ b/docs/diff_log/diff_sanitized_namespace_20250914.md
@@ -1,0 +1,6 @@
+# diff: sanitized namespace generation
+
+- EntityModelAdapter strips timeframe and role from derived IDs and appends `_ksql`.
+- MappingRegistry.RegisterEntityModel honored overrideNamespace for derived models.
+- Added test ensuring derived namespace `bar_5m_live` registers as `bar_ksql`.
+

--- a/src/Query/Adapters/EntityModelAdapter.cs
+++ b/src/Query/Adapters/EntityModelAdapter.cs
@@ -40,7 +40,20 @@ internal static class EntityModelAdapter
             var nsSource = e.TopicHint ?? e.Id;
             if (!string.IsNullOrWhiteSpace(nsSource))
             {
-                var ns = Regex.Replace(nsSource.ToLowerInvariant(), "[^a-z0-9_]", "_");
+                var baseNs = e.TopicHint ?? e.Id;
+                if (e.TopicHint == null)
+                {
+                    baseNs = e.Role switch
+                    {
+                        Role.AggFinal => TrimSuffix(baseNs, $"_{e.Timeframe.Value}{e.Timeframe.Unit}_agg_final"),
+                        Role.Live => TrimSuffix(baseNs, $"_{e.Timeframe.Value}{e.Timeframe.Unit}_live"),
+                        Role.Final => TrimSuffix(baseNs, $"_{e.Timeframe.Value}{e.Timeframe.Unit}_final"),
+                        Role.Prev1m => TrimSuffix(baseNs, "_prev_1m"),
+                        Role.Hb => TrimSuffix(baseNs, "_hb_1m"),
+                        _ => baseNs
+                    };
+                }
+                var ns = Regex.Replace($"{baseNs}_ksql".ToLowerInvariant(), "[^a-z0-9_]", "_");
                 model.AdditionalSettings["namespace"] = ns;
             }
             if (e.Role == Role.Hb) model.AdditionalSettings["forceStream"] = true;
@@ -48,4 +61,7 @@ internal static class EntityModelAdapter
         }
         return list;
     }
+
+    private static string TrimSuffix(string value, string suffix)
+        => value.EndsWith(suffix, StringComparison.Ordinal) ? value[..^suffix.Length] : value;
 }

--- a/tests/Mapping/MappingRegistryTests.cs
+++ b/tests/Mapping/MappingRegistryTests.cs
@@ -2,6 +2,8 @@ using Avro.Generic;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Models;
 using Kafka.Ksql.Linq.Mapping;
+using Kafka.Ksql.Linq.Query.Adapters;
+using Kafka.Ksql.Linq.Query.Analysis;
 using System.Linq;
 using Xunit;
 
@@ -111,5 +113,35 @@ public class MappingRegistryTests
         var m2 = r2.RegisterEntityModel(model, overrideNamespace: "custom_ns");
         Assert.Equal("custom_ns", m2.KeyType.Namespace);
         Assert.Equal("custom_ns", m2.ValueType.Namespace);
+    }
+
+    [Fact]
+    public void RegisterDerivedModel_UsesSanitizedNamespace()
+    {
+        var derived = new DerivedEntity
+        {
+            Id = "bar_5m_live",
+            Role = Role.Live,
+            Timeframe = new Timeframe(5, "m"),
+            KeyShape = new[] { new ColumnShape("Id", typeof(int), false) },
+            ValueShape = new[] { new ColumnShape("Name", typeof(string), true) },
+            BasedOnSpec = new BasedOnSpec(new[] { "Id" }, string.Empty, string.Empty, string.Empty)
+        };
+        var model = EntityModelAdapter.Adapt(new[] { derived })[0];
+        model.EntityType = typeof(Sample);
+        model.TopicName = derived.Id;
+        model.KeyProperties = new[] { typeof(Sample).GetProperty(nameof(Sample.Id))! };
+        model.AllProperties = typeof(Sample).GetProperties();
+
+        Assert.Equal("bar_ksql", model.AdditionalSettings["namespace"]);
+
+        var registry = new MappingRegistry();
+        var mapping = registry.RegisterEntityModel(
+            model,
+            genericValue: true,
+            overrideNamespace: model.AdditionalSettings["namespace"]?.ToString());
+
+        Assert.Equal("bar_ksql", mapping.KeyType.Namespace);
+        Assert.Equal("bar_ksql", mapping.ValueType.Namespace);
     }
 }


### PR DESCRIPTION
## Summary
- strip timeframe and role from derived topic ids and append `_ksql` namespace
- ensure MappingRegistry honors overrideNamespace for derived models
- cover namespace override with tests

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bdc002f468832782eb015b0d76d62b