### PR TITLE
docs: log removal of obsolete query helpers

### DIFF
--- a/docs/diff_log/diff_remove_obsolete_query_classes_20250907.md
+++ b/docs/diff_log/diff_remove_obsolete_query_classes_20250907.md
@@ -1,0 +1,6 @@
+# diff_remove_obsolete_query_classes_20250907
+- Confirmed deletion of legacy query helpers:
+  - `src/Query/Adapters/EntityModelRegistrar.cs`
+  - `src/Query/Adapters/TopicNameResolver.cs`
+  - `src/Query/Analysis/TumblingAnalyzer.cs`
+- Removed remaining project and test references to these classes.


### PR DESCRIPTION
## Summary
- document removal of legacy query helpers

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --verbosity minimal`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68bdc152bb948327a16080cd4df74ca9