### PR TITLE
Handle alias when injecting window clause

### DIFF
--- a/src/Query/Builders/KsqlCreateWindowedStatementBuilder.cs
+++ b/src/Query/Builders/KsqlCreateWindowedStatementBuilder.cs
@@ -91,8 +91,12 @@ internal static class KsqlCreateWindowedStatementBuilder
 
     private static string InjectWindowAfterFrom(string sql, string windowClause)
     {
-        // naive injection: replace first occurrence of "FROM <ident>" with "FROM <ident> {window}"
-        var pattern = new Regex(@"\bFROM\s+([A-Za-z_][\w]*)", RegexOptions.IgnoreCase);
-        return pattern.Replace(sql, m => $"FROM {m.Groups[1].Value} {windowClause}", 1);
+        // Replace first occurrence of "FROM <ident> [alias]" with "FROM <ident> [alias] {window}"
+        var pattern = new Regex(@"\bFROM\s+([A-Za-z_][\w]*)(\s+[A-Za-z_][\w]*)?", RegexOptions.IgnoreCase);
+        return pattern.Replace(sql, m =>
+        {
+            var alias = m.Groups[2].Value;
+            return $"FROM {m.Groups[1].Value}{alias} {windowClause}";
+        }, 1);
     }
 }

--- a/tests/Query/Builders/KsqlCreateWindowedStatementBuilderTests.cs
+++ b/tests/Query/Builders/KsqlCreateWindowedStatementBuilderTests.cs
@@ -27,6 +27,15 @@ public class KsqlCreateWindowedStatementBuilderTests
         public double Bid { get; set; }
     }
 
+    [KsqlTopic("deduprates")]
+    private class DedupRate
+    {
+        public string Broker { get; set; } = string.Empty;
+        public string Symbol { get; set; } = string.Empty;
+        public DateTime Ts { get; set; }
+        public double Bid { get; set; }
+    }
+
     [Fact]
     public void Build_Includes_Window_Tumbling_1m()
     {
@@ -41,6 +50,21 @@ public class KsqlCreateWindowedStatementBuilderTests
         var sql = Kafka.Ksql.Linq.Query.Builders.KsqlCreateWindowedStatementBuilder.Build("bar_1m_live", model, "1m");
         Assert.Contains("WINDOW TUMBLING (SIZE 1 MINUTES)", sql);
         Assert.Contains("CREATE TABLE bar_1m_live", sql);
+    }
+
+    [Fact]
+    public void Build_From_With_Alias_Inserts_Window_After_Alias()
+    {
+        var model = new KsqlQueryRoot()
+            .From<DedupRate>()
+            .Tumbling(r => r.Ts, minutes: new[] { 1 })
+            .GroupBy(r => new { r.Broker, r.Symbol, BucketStart = r.Ts })
+            .Select(g => new { g.Key.Broker, g.Key.Symbol, g.Key.BucketStart, Open = g.EarliestByOffset(x => x.Bid) })
+            .AsPush()
+            .Build();
+
+        var sql = Kafka.Ksql.Linq.Query.Builders.KsqlCreateWindowedStatementBuilder.Build("bar_1m_live", model, "1m");
+        Assert.Contains("FROM DEDUPRATES o WINDOW TUMBLING", sql);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- ensure InjectWindowAfterFrom preserves alias when adding WINDOW clause
- test alias preservation after FROM

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter FullyQualifiedName~KsqlCreateWindowedStatementBuilderTests`


------
https://chatgpt.com/codex/tasks/task_e_68be28cf103083279a8f9d9c635d9a0b