### PR TITLE
feat: create Prev1m as static table

### DIFF
--- a/docs/diff_log/diff_prev1m_static_ddl_20250908.md
+++ b/docs/diff_log/diff_prev1m_static_ddl_20250908.md
@@ -1,0 +1,5 @@
+# diff: Prev1m static table DDL (2025-09-08)
+- Role.Prev1m generates simple `CREATE TABLE` instead of windowed DDL.
+- Prev1m entity schema reduced to `Close` column only.
+- EntityModelAdapter maps Prev1m projection to `Close`.
+- Tests verify static DDL and `Close`-only projection.

--- a/src/Query/Adapters/EntityModelAdapter.cs
+++ b/src/Query/Adapters/EntityModelAdapter.cs
@@ -15,15 +15,26 @@ internal static class EntityModelAdapter
         foreach (var e in entities)
         {
             var keys = e.KeyShape.Select(k => k.Name).ToArray();
+            var keyTypes = e.KeyShape.Select(k => k.Type).ToArray();
+            var keyNulls = e.KeyShape.Select(k => k.IsNullable).ToArray();
             var values = e.ValueShape.Select(v => v.Name).ToArray();
             var types = e.ValueShape.Select(v => v.Type).ToArray();
             var nulls = e.ValueShape.Select(v => v.IsNullable).ToArray();
+            if (e.Role == Role.Prev1m)
+            {
+                var close = e.ValueShape.First(v => v.Name == "Close");
+                values = new[] { "Close" };
+                types = new[] { close.Type };
+                nulls = new[] { close.IsNullable };
+            }
             if (keys.Length == 0 || (values.Length == 0 && e.Role != Role.Hb))
                 throw new InvalidOperationException("Key and value must not be empty");
 
             var model = new EntityModel { EntityType = typeof(object) };
             model.AdditionalSettings["id"] = e.Id;
             model.AdditionalSettings["keys"] = keys;
+            model.AdditionalSettings["keys/types"] = keyTypes;
+            model.AdditionalSettings["keys/nulls"] = keyNulls;
             model.AdditionalSettings["projection"] = values;
             model.AdditionalSettings["projection/types"] = types;
             model.AdditionalSettings["projection/nulls"] = nulls;

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -79,7 +79,7 @@ internal static class DerivationPlanner
                     Role = Role.Prev1m,
                     Timeframe = tf,
                     KeyShape = keyShapes,
-                    ValueShape = valueShapes,
+                    ValueShape = qao.PocoShape.Where(p => p.Name == "Close").ToArray(),
                     BasedOnSpec = qao.BasedOn,
                     WeekAnchor = qao.WeekAnchor
                 };

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -66,12 +66,34 @@ internal static class DerivedTumblingPipeline
             Role.Hb => $"{baseName}_hb_1m",
             _ => $"{baseName}_{tf}"
         };
-        var ddl = KsqlCreateWindowedStatementBuilder.Build(name, qm, tf);
+        string ddl;
+        if (role == Role.Prev1m)
+        {
+            var keys = (string[])model.AdditionalSettings["keys"];
+            var keyTypes = (Type[])model.AdditionalSettings["keys/types"];
+            var proj = (string[])model.AdditionalSettings["projection"];
+            var projTypes = (Type[])model.AdditionalSettings["projection/types"];
+            var cols = new List<string>();
+            for (var i = 0; i < keys.Length; i++) cols.Add($"{keys[i]} {Map(keyTypes[i])}");
+            for (var i = 0; i < proj.Length; i++) cols.Add($"{proj[i]} {Map(projTypes[i])}");
+            var pk = string.Join(", ", keys);
+            ddl = $"CREATE TABLE {name} ({string.Join(", ", cols)}, PRIMARY KEY ({pk})) WITH (KAFKA_TOPIC='{name}', KEY_FORMAT='AVRO', VALUE_FORMAT='AVRO');";
+        }
+        else
+        {
+            ddl = KsqlCreateWindowedStatementBuilder.Build(name, qm, tf);
+        }
         var dt = resolveType(name);
         model.EntityType = dt;
         model.TopicName = name;
         model.SetStreamTableType(qm.DetermineType());
         var ns = model.AdditionalSettings.TryGetValue("namespace", out var nsObj) ? nsObj?.ToString() : null;
         return (ddl, dt, ns);
+
+        static string Map(Type t) => t == typeof(int) ? "INT"
+            : t == typeof(long) ? "BIGINT"
+            : t == typeof(bool) ? "BOOLEAN"
+            : t == typeof(string) ? "VARCHAR"
+            : "DOUBLE";
     }
 }

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -1,7 +1,11 @@
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Attributes;
 using Kafka.Ksql.Linq.Query.Analysis;
+using Kafka.Ksql.Linq.Query.Adapters;
+using Kafka.Ksql.Linq.Query.Dsl;
 using System;
+using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Query.Analysis;
@@ -12,6 +16,16 @@ public class DerivationPlannerTests
     private class Source
     {
         public int Id { get; set; }
+    }
+
+    [KsqlTopic("bar")]
+    private class SourceOhlc
+    {
+        public int Id { get; set; }
+        public double Open { get; set; }
+        public double High { get; set; }
+        public double Low { get; set; }
+        public double Close { get; set; }
     }
 
     private static TumblingQao Create(Timeframe tf) => new()
@@ -49,5 +63,38 @@ public class DerivationPlannerTests
         Assert.Contains(entities, e => e.Id == "bar_5m_final" && e.Role == Role.Final);
         Assert.DoesNotContain(entities, e => e.Role == Role.Prev1m);
         Assert.DoesNotContain(entities, e => e.Role == Role.Hb);
+    }
+
+    [Fact]
+    public void Prev1m_Static_Table_Close_Only()
+    {
+        var qao = new TumblingQao
+        {
+            TimeKey = "Timestamp",
+            Windows = new[] { new Timeframe(1, "m") },
+            Keys = new[] { "Id" },
+            Projection = new[] { "Id", "Open", "High", "Low", "Close" },
+            PocoShape = new[]
+            {
+                new ColumnShape("Id", typeof(int), false),
+                new ColumnShape("Open", typeof(double), false),
+                new ColumnShape("High", typeof(double), false),
+                new ColumnShape("Low", typeof(double), false),
+                new ColumnShape("Close", typeof(double), false)
+            },
+            BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, string.Empty, string.Empty),
+            WeekAnchor = DayOfWeek.Monday
+        };
+        var baseModel = new EntityModel { EntityType = typeof(SourceOhlc) };
+        var entities = DerivationPlanner.Plan(qao, baseModel);
+        var models = EntityModelAdapter.Adapt(entities);
+        var prev = models.Single(m => (string)m.AdditionalSettings["role"] == Role.Prev1m.ToString());
+        Assert.Equal(new[] { "Close" }, (string[])prev.AdditionalSettings["projection"]);
+        var method = typeof(DerivedTumblingPipeline).GetMethod("BuildDdlAndRegister", BindingFlags.NonPublic | BindingFlags.Static);
+        var qm = new KsqlQueryModel { SourceTypes = new[] { typeof(SourceOhlc) } };
+        var res = ((string ddl, Type _, string? ns))method!.Invoke(null, new object[] { "bar", qm, prev, Role.Prev1m, (Func<string, Type>)(_ => typeof(object)) })!;
+        Assert.StartsWith("CREATE TABLE bar_prev_1m", res.ddl);
+        Assert.DoesNotContain("AS SELECT", res.ddl);
+        Assert.Contains("Close", res.ddl);
     }
 }

--- a/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
@@ -29,8 +29,12 @@ public class DerivedTumblingPipelineConcurrencyTests
             TimeKey = "Timestamp",
             Windows = new[] { new Timeframe(1, "m"), new Timeframe(5, "m") },
             Keys = new[] { "Id" },
-            Projection = new[] { "Id" },
-            PocoShape = new[] { new ColumnShape("Id", typeof(int), false) },
+            Projection = new[] { "Id", "Close" },
+            PocoShape = new[]
+            {
+                new ColumnShape("Id", typeof(int), false),
+                new ColumnShape("Close", typeof(double), false)
+            },
             BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, string.Empty, string.Empty),
             WeekAnchor = DayOfWeek.Monday
         };

--- a/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
@@ -30,8 +30,12 @@ public class DerivedTumblingPipelineTests
             TimeKey = "Timestamp",
             Windows = new[] { new Timeframe(1, "m") },
             Keys = new[] { "Id" },
-            Projection = new[] { "Id" },
-            PocoShape = new[] { new ColumnShape("Id", typeof(int), false) },
+            Projection = new[] { "Id", "Close" },
+            PocoShape = new[]
+            {
+                new ColumnShape("Id", typeof(int), false),
+                new ColumnShape("Close", typeof(double), false)
+            },
             BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, string.Empty, string.Empty),
             WeekAnchor = DayOfWeek.Monday
         };


### PR DESCRIPTION
## Summary
- build Prev1m tables via simple CREATE TABLE instead of windowed CTAS
- drop OHLC columns and keep Close only for Prev1m entities
- verify Prev1m DDL is static and Close-only

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68be2ced9728832783c5ee58aeb32a4d