### PR TITLE
feat: create Prev1m as static table

### DIFF
--- a/docs/diff_log/diff_prev1m_static_ddl_20250908.md
+++ b/docs/diff_log/diff_prev1m_static_ddl_20250908.md
@@ -1,0 +1,6 @@
+# diff: Prev1m static table DDL (2025-09-08)
+- Role.Prev1m generates simple `CREATE TABLE` instead of windowed DDL.
+- Prev1m entity schema reduced to a single value column named `KsqlTimeFrameClose`.
+- EntityModelAdapter maps Prev1m projection to the configured close column.
+- Tests verify static DDL and single-column projection.
+- Close column is derived from the `[KsqlTimeFrameClose]` attribute on the entity.

--- a/physicalTests/OssSamples/BarDslExplainTests.cs
+++ b/physicalTests/OssSamples/BarDslExplainTests.cs
@@ -33,7 +33,7 @@ public class BarDslExplainTests
         public double Open { get; set; }
         public double High { get; set; }
         public double Low { get; set; }
-        public double Close { get; set; }
+        [KsqlTimeFrameClose] public double KsqlTimeFrameClose { get; set; }
     }
 
 
@@ -70,7 +70,7 @@ public class BarDslExplainTests
                         Open = g.EarliestByOffset(x => x.Bid),
                         High = g.Max(x => x.Bid),
                         Low = g.Min(x => x.Bid),
-                        Close = g.LatestByOffset(x => x.Bid)
+                        KsqlTimeFrameClose = g.LatestByOffset(x => x.Bid)
                     }));
 
         }
@@ -127,7 +127,7 @@ public class BarDslExplainTests
         var bs00 = Ms(t0);
         var bs01 = Ms(t0.AddMinutes(1));
 
-        var rows1m = await ctx.QueryRowsAsync("SELECT BucketStart, Open, High, Low, Close FROM bar_1m_live WHERE Broker='B1' AND Symbol='S1';", TimeSpan.FromSeconds(30));
+        var rows1m = await ctx.QueryRowsAsync("SELECT BucketStart, Open, High, Low, KsqlTimeFrameClose FROM bar_1m_live WHERE Broker='B1' AND Symbol='S1';", TimeSpan.FromSeconds(30));
         bool ok1 = false, ok2 = false;
         foreach (var r in rows1m)
         {
@@ -142,7 +142,7 @@ public class BarDslExplainTests
         Assert.True(ok1, "1m OHLC for 00:00 mismatch");
         Assert.True(ok2, "1m OHLC for 00:01 mismatch");
 
-        var rows5m = await ctx.QueryRowsAsync("SELECT BucketStart, Open, High, Low, Close FROM bar_5m_live WHERE Broker='B1' AND Symbol='S1';", TimeSpan.FromSeconds(30));
+        var rows5m = await ctx.QueryRowsAsync("SELECT BucketStart, Open, High, Low, KsqlTimeFrameClose FROM bar_5m_live WHERE Broker='B1' AND Symbol='S1';", TimeSpan.FromSeconds(30));
         bool ok5 = false;
         foreach (var r in rows5m)
         {

--- a/physicalTests/OssSamples/BarScheduleAnchorTests.cs
+++ b/physicalTests/OssSamples/BarScheduleAnchorTests.cs
@@ -29,7 +29,7 @@ public class BarScheduleAnchorTests
         public double Open { get; set; }
         public double High { get; set; }
         public double Low { get; set; }
-        public double Close { get; set; }
+        [KsqlTimeFrameClose] public double KsqlTimeFrameClose { get; set; }
     }
 
     private sealed class TestContext : KsqlContext
@@ -51,7 +51,7 @@ public class BarScheduleAnchorTests
                         Open = g.EarliestByOffset(x => x.Bid),
                         High = g.Max(x => x.Bid),
                         Low = g.Min(x => x.Bid),
-                        Close = g.LatestByOffset(x => x.Bid)
+                        KsqlTimeFrameClose = g.LatestByOffset(x => x.Bid)
                     })
                     .AsPush());
         }

--- a/physicalTests/OssSamples/BarScheduleDataTests.cs
+++ b/physicalTests/OssSamples/BarScheduleDataTests.cs
@@ -38,7 +38,7 @@ public class BarScheduleDataTests
         public double Open { get; set; }
         public double High { get; set; }
         public double Low { get; set; }
-        public double Close { get; set; }
+        [KsqlTimeFrameClose] public double KsqlTimeFrameClose { get; set; }
     }
 
     private class Bar1wkFinal
@@ -49,7 +49,7 @@ public class BarScheduleDataTests
         public double Open { get; set; }
         public double High { get; set; }
         public double Low { get; set; }
-        public double Close { get; set; }
+        [KsqlTimeFrameClose] public double KsqlTimeFrameClose { get; set; }
     }
 
     private sealed class TestContext : KsqlContext
@@ -77,7 +77,7 @@ public class BarScheduleDataTests
                         Open = g.EarliestByOffset(x => x.Bid),
                         High = g.Max(x => x.Bid),
                         Low = g.Min(x => x.Bid),
-                        Close = g.LatestByOffset(x => x.Bid)
+                        KsqlTimeFrameClose = g.LatestByOffset(x => x.Bid)
                     })
                     .AsPush());
 
@@ -98,7 +98,7 @@ public class BarScheduleDataTests
                         Open = g.EarliestByOffset(x => x.Bid),
                         High = g.Max(x => x.Bid),
                         Low = g.Min(x => x.Bid),
-                        Close = g.LatestByOffset(x => x.Bid)
+                        KsqlTimeFrameClose = g.LatestByOffset(x => x.Bid)
                     })); // Final系の具体的モードはビルダー側で扱う
         }
     }

--- a/physicalTests/OssSamples/BarScheduleExplainTests.cs
+++ b/physicalTests/OssSamples/BarScheduleExplainTests.cs
@@ -39,7 +39,7 @@ public class BarScheduleExplainTests
         public double Open { get; set; }
         public double High { get; set; }
         public double Low { get; set; }
-        public double Close { get; set; }
+        [KsqlTimeFrameClose] public double KsqlTimeFrameClose { get; set; }
     }
 
     private class Bar1wkLive
@@ -50,7 +50,7 @@ public class BarScheduleExplainTests
         public double Open { get; set; }
         public double High { get; set; }
         public double Low { get; set; }
-        public double Close { get; set; }
+        [KsqlTimeFrameClose] public double KsqlTimeFrameClose { get; set; }
     }
 
     private sealed class TestContext : KsqlContext
@@ -78,7 +78,7 @@ public class BarScheduleExplainTests
                         Open = g.EarliestByOffset(x => x.Bid),
                         High = g.Max(x => x.Bid),
                         Low = g.Min(x => x.Bid),
-                        Close = g.LatestByOffset(x => x.Bid)
+                        KsqlTimeFrameClose = g.LatestByOffset(x => x.Bid)
                     })
                     .AsPush());
 
@@ -99,7 +99,7 @@ public class BarScheduleExplainTests
                         Open = g.EarliestByOffset(x => x.Bid),
                         High = g.Max(x => x.Bid),
                         Low = g.Min(x => x.Bid),
-                        Close = g.LatestByOffset(x => x.Bid)
+                        KsqlTimeFrameClose = g.LatestByOffset(x => x.Bid)
                     })
                     .AsPush());
         }
@@ -114,7 +114,7 @@ public class BarScheduleExplainTests
         Assert.Equal(typeof(MarketSchedule), em.QueryModel!.BasedOnType);
         var sql = KsqlCreateStatementBuilder.Build("bar_1d_live", em.QueryModel!);
         Assert.Contains("EARLIEST_BY_OFFSET(Bid) AS Open", sql);
-        Assert.Contains("LATEST_BY_OFFSET(Bid) AS Close", sql);
+        Assert.Contains("LATEST_BY_OFFSET(Bid) AS KsqlTimeFrameClose", sql);
         Assert.Contains("CREATE TABLE bar_1d_live", sql);
     }
 

--- a/src/Core/Attributes/KsqlTimeFrameCloseAttribute.cs
+++ b/src/Core/Attributes/KsqlTimeFrameCloseAttribute.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Kafka.Ksql.Linq.Core.Attributes;
+
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+public sealed class KsqlTimeFrameCloseAttribute : Attribute
+{
+}

--- a/src/Query/Adapters/EntityModelAdapter.cs
+++ b/src/Query/Adapters/EntityModelAdapter.cs
@@ -15,15 +15,26 @@ internal static class EntityModelAdapter
         foreach (var e in entities)
         {
             var keys = e.KeyShape.Select(k => k.Name).ToArray();
+            var keyTypes = e.KeyShape.Select(k => k.Type).ToArray();
+            var keyNulls = e.KeyShape.Select(k => k.IsNullable).ToArray();
             var values = e.ValueShape.Select(v => v.Name).ToArray();
             var types = e.ValueShape.Select(v => v.Type).ToArray();
             var nulls = e.ValueShape.Select(v => v.IsNullable).ToArray();
+            if (e.Role == Role.Prev1m)
+            {
+                var close = e.ValueShape.First(v => v.Name == e.BasedOnSpec.CloseProp);
+                values = new[] { close.Name };
+                types = new[] { close.Type };
+                nulls = new[] { close.IsNullable };
+            }
             if (keys.Length == 0 || (values.Length == 0 && e.Role != Role.Hb))
                 throw new InvalidOperationException("Key and value must not be empty");
 
             var model = new EntityModel { EntityType = typeof(object) };
             model.AdditionalSettings["id"] = e.Id;
             model.AdditionalSettings["keys"] = keys;
+            model.AdditionalSettings["keys/types"] = keyTypes;
+            model.AdditionalSettings["keys/nulls"] = keyNulls;
             model.AdditionalSettings["projection"] = values;
             model.AdditionalSettings["projection/types"] = types;
             model.AdditionalSettings["projection/nulls"] = nulls;

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -21,6 +21,18 @@ internal static class DerivationPlanner
         }).ToArray();
         var valueShapes = qao.PocoShape.ToArray();
 
+        var basedOn = qao.BasedOn;
+        if (string.IsNullOrEmpty(basedOn.CloseProp))
+        {
+            var close = model.EntityType
+                .GetProperties()
+                .FirstOrDefault(p => p.GetCustomAttribute<KsqlTimeFrameCloseAttribute>() != null);
+            if (close != null)
+            {
+                basedOn = basedOn with { CloseProp = close.Name };
+            }
+        }
+
         DerivedEntity? prev = null;
         foreach (var tf in qao.Windows)
         {
@@ -38,7 +50,7 @@ internal static class DerivationPlanner
                 Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
-                BasedOnSpec = qao.BasedOn,
+                BasedOnSpec = basedOn,
                 WeekAnchor = qao.WeekAnchor
             };
             entities.Add(agg);
@@ -52,7 +64,7 @@ internal static class DerivationPlanner
                 ValueShape = valueShapes,
                 InputHint = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? $"{baseId}_1m_final" : $"{baseId}_1m_live",
                 SyncHint = tf.Unit == "m" && tf.Value == 1 ? $"{baseId}_hb_1m".ToUpperInvariant() : null,
-                BasedOnSpec = qao.BasedOn,
+                BasedOnSpec = basedOn,
                 WeekAnchor = qao.WeekAnchor
             };
             entities.Add(live);
@@ -66,7 +78,7 @@ internal static class DerivationPlanner
                 ValueShape = valueShapes,
                 InputHint = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? $"{baseId}_1m_final" : $"{baseId}_1m_live",
                 SyncHint = tf.Unit == "m" && tf.Value == 1 ? $"{baseId}_hb_1m".ToUpperInvariant() : null,
-                BasedOnSpec = qao.BasedOn,
+                BasedOnSpec = basedOn,
                 WeekAnchor = qao.WeekAnchor
             };
             entities.Add(final);
@@ -79,8 +91,8 @@ internal static class DerivationPlanner
                     Role = Role.Prev1m,
                     Timeframe = tf,
                     KeyShape = keyShapes,
-                    ValueShape = valueShapes,
-                    BasedOnSpec = qao.BasedOn,
+                    ValueShape = qao.PocoShape.Where(p => p.Name == basedOn.CloseProp).ToArray(),
+                    BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor
                 };
                 entities.Add(prev);
@@ -93,7 +105,7 @@ internal static class DerivationPlanner
                     KeyShape = keyShapes,
                     ValueShape = Array.Empty<ColumnShape>(),
                     MaterializationHint = MaterializationHint.Stream,
-                    BasedOnSpec = qao.BasedOn,
+                    BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor
                 };
                 entities.Add(hb);

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -66,12 +66,34 @@ internal static class DerivedTumblingPipeline
             Role.Hb => $"{baseName}_hb_1m",
             _ => $"{baseName}_{tf}"
         };
-        var ddl = KsqlCreateWindowedStatementBuilder.Build(name, qm, tf);
+        string ddl;
+        if (role == Role.Prev1m)
+        {
+            var keys = (string[])model.AdditionalSettings["keys"];
+            var keyTypes = (Type[])model.AdditionalSettings["keys/types"];
+            var proj = (string[])model.AdditionalSettings["projection"];
+            var projTypes = (Type[])model.AdditionalSettings["projection/types"];
+            var cols = new List<string>();
+            for (var i = 0; i < keys.Length; i++) cols.Add($"{keys[i]} {Map(keyTypes[i])}");
+            for (var i = 0; i < proj.Length; i++) cols.Add($"{proj[i]} {Map(projTypes[i])}");
+            var pk = string.Join(", ", keys);
+            ddl = $"CREATE TABLE {name} ({string.Join(", ", cols)}, PRIMARY KEY ({pk})) WITH (KAFKA_TOPIC='{name}', KEY_FORMAT='AVRO', VALUE_FORMAT='AVRO');";
+        }
+        else
+        {
+            ddl = KsqlCreateWindowedStatementBuilder.Build(name, qm, tf);
+        }
         var dt = resolveType(name);
         model.EntityType = dt;
         model.TopicName = name;
         model.SetStreamTableType(qm.DetermineType());
         var ns = model.AdditionalSettings.TryGetValue("namespace", out var nsObj) ? nsObj?.ToString() : null;
         return (ddl, dt, ns);
+
+        static string Map(Type t) => t == typeof(int) ? "INT"
+            : t == typeof(long) ? "BIGINT"
+            : t == typeof(bool) ? "BOOLEAN"
+            : t == typeof(string) ? "VARCHAR"
+            : "DOUBLE";
     }
 }

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -1,7 +1,11 @@
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Attributes;
 using Kafka.Ksql.Linq.Query.Analysis;
+using Kafka.Ksql.Linq.Query.Adapters;
+using Kafka.Ksql.Linq.Query.Dsl;
 using System;
+using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Query.Analysis;
@@ -14,6 +18,17 @@ public class DerivationPlannerTests
         public int Id { get; set; }
     }
 
+    [KsqlTopic("bar")]
+    private class SourceOhlc
+    {
+        public int Id { get; set; }
+        public double Open { get; set; }
+        public double High { get; set; }
+        public double Low { get; set; }
+        [KsqlTimeFrameClose]
+        public double KsqlTimeFrameClose { get; set; }
+    }
+
     private static TumblingQao Create(Timeframe tf) => new()
     {
         TimeKey = "Timestamp",
@@ -21,7 +36,7 @@ public class DerivationPlannerTests
         Keys = new[] { "Id" },
         Projection = new[] { "Id" },
         PocoShape = new[] { new ColumnShape("Id", typeof(int), false) },
-        BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, string.Empty, string.Empty),
+        BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, "KsqlTimeFrameClose", string.Empty),
         WeekAnchor = DayOfWeek.Monday
     };
 
@@ -49,5 +64,39 @@ public class DerivationPlannerTests
         Assert.Contains(entities, e => e.Id == "bar_5m_final" && e.Role == Role.Final);
         Assert.DoesNotContain(entities, e => e.Role == Role.Prev1m);
         Assert.DoesNotContain(entities, e => e.Role == Role.Hb);
+    }
+
+    [Fact]
+    public void Prev1m_Static_Table_Single_Value()
+    {
+        var qao = new TumblingQao
+        {
+            TimeKey = "Timestamp",
+            Windows = new[] { new Timeframe(1, "m") },
+            Keys = new[] { "Id" },
+            Projection = new[] { "Id", "Open", "High", "Low", "KsqlTimeFrameClose" },
+            PocoShape = new[]
+            {
+                new ColumnShape("Id", typeof(int), false),
+                new ColumnShape("Open", typeof(double), false),
+                new ColumnShape("High", typeof(double), false),
+                new ColumnShape("Low", typeof(double), false),
+                new ColumnShape("KsqlTimeFrameClose", typeof(double), false)
+            },
+            BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, string.Empty, string.Empty),
+            WeekAnchor = DayOfWeek.Monday
+        };
+        var baseModel = new EntityModel { EntityType = typeof(SourceOhlc) };
+        var entities = DerivationPlanner.Plan(qao, baseModel);
+        var models = EntityModelAdapter.Adapt(entities);
+        var prev = models.Single(m => (string)m.AdditionalSettings["role"] == Role.Prev1m.ToString());
+        var close = (string)prev.AdditionalSettings["basedOn/closeProp"];
+        Assert.Equal(new[] { close }, (string[])prev.AdditionalSettings["projection"]);
+        var method = typeof(DerivedTumblingPipeline).GetMethod("BuildDdlAndRegister", BindingFlags.NonPublic | BindingFlags.Static);
+        var qm = new KsqlQueryModel { SourceTypes = new[] { typeof(SourceOhlc) } };
+        var res = ((string ddl, Type _, string? ns))method!.Invoke(null, new object[] { "bar", qm, prev, Role.Prev1m, (Func<string, Type>)(_ => typeof(object)) })!;
+        Assert.StartsWith("CREATE TABLE bar_prev_1m", res.ddl);
+        Assert.DoesNotContain("AS SELECT", res.ddl);
+        Assert.Contains(close, res.ddl);
     }
 }

--- a/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
@@ -29,9 +29,13 @@ public class DerivedTumblingPipelineConcurrencyTests
             TimeKey = "Timestamp",
             Windows = new[] { new Timeframe(1, "m"), new Timeframe(5, "m") },
             Keys = new[] { "Id" },
-            Projection = new[] { "Id" },
-            PocoShape = new[] { new ColumnShape("Id", typeof(int), false) },
-            BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, string.Empty, string.Empty),
+            Projection = new[] { "Id", "KsqlTimeFrameClose" },
+            PocoShape = new[]
+            {
+                new ColumnShape("Id", typeof(int), false),
+                new ColumnShape("KsqlTimeFrameClose", typeof(double), false)
+            },
+            BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, "KsqlTimeFrameClose", string.Empty),
             WeekAnchor = DayOfWeek.Monday
         };
         var baseModel = new EntityModel { EntityType = typeof(ConcurrencySource) };

--- a/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
@@ -30,9 +30,13 @@ public class DerivedTumblingPipelineTests
             TimeKey = "Timestamp",
             Windows = new[] { new Timeframe(1, "m") },
             Keys = new[] { "Id" },
-            Projection = new[] { "Id" },
-            PocoShape = new[] { new ColumnShape("Id", typeof(int), false) },
-            BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, string.Empty, string.Empty),
+            Projection = new[] { "Id", "KsqlTimeFrameClose" },
+            PocoShape = new[]
+            {
+                new ColumnShape("Id", typeof(int), false),
+                new ColumnShape("KsqlTimeFrameClose", typeof(double), false)
+            },
+            BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, "KsqlTimeFrameClose", string.Empty),
             WeekAnchor = DayOfWeek.Monday
         };
         var baseModel = new EntityModel { EntityType = typeof(TestSource) };

--- a/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
+++ b/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
@@ -11,7 +11,7 @@ public class WindowedQueryBuilderCoreTests
         new QueryMetadata(DateTime.UtcNow, "cat")
             .WithProperty("basedOn/joinKeys", new[] { "Broker" })
             .WithProperty("basedOn/openProp", "Open")
-            .WithProperty("basedOn/closeProp", "Close")
+            .WithProperty("basedOn/closeProp", "KsqlTimeFrameClose")
             .WithProperty("basedOn/dayKey", "MarketDate")
             .WithProperty("timeKey", "Ts");
 


### PR DESCRIPTION
## Summary
- build Prev1m tables via simple CREATE TABLE instead of windowed CTAS
- drop OHLC columns and keep only close-prop field for Prev1m entities
- verify Prev1m DDL is static and single-column
- use KsqlTimeFrameClose as designated close column via attribute
- align physical integration tests with KsqlTimeFrameClose column

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet build physicalTests/Kafka.Ksql.Linq.Tests.Integration.csproj` *(fails: The type or namespace name 'Task' could not be found)*


------
https://chatgpt.com/codex/tasks/task_e_68be2ced9728832783c5ee58aeb32a4d