### PR TITLE
Exclude window start from prev1m primary key

### DIFF
--- a/docs/diff_log/diff_prev1m_primary_key_20250908.md
+++ b/docs/diff_log/diff_prev1m_primary_key_20250908.md
@@ -1,0 +1,3 @@
+# diff: Prev1m primary key (2025-09-08)
+- Prev1m table drops BucketStart from the primary key.
+- BucketStart remains as a value column alongside KsqlTimeFrameClose.

--- a/src/Query/Adapters/EntityModelAdapter.cs
+++ b/src/Query/Adapters/EntityModelAdapter.cs
@@ -23,9 +23,10 @@ internal static class EntityModelAdapter
             if (e.Role == Role.Prev1m)
             {
                 var close = e.ValueShape.First(v => v.Name == e.BasedOnSpec.CloseProp);
-                values = new[] { close.Name };
-                types = new[] { close.Type };
-                nulls = new[] { close.IsNullable };
+                var timeKey = e.ValueShape.First(v => v.Name != close.Name);
+                values = new[] { timeKey.Name, close.Name };
+                types = new[] { timeKey.Type, close.Type };
+                nulls = new[] { timeKey.IsNullable, close.IsNullable };
             }
             if (keys.Length == 0 || (values.Length == 0 && e.Role != Role.Hb))
                 throw new InvalidOperationException("Key and value must not be empty");

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -85,13 +85,16 @@ internal static class DerivationPlanner
 
             if (tf.Unit == "m" && tf.Value == 1 && prev == null)
             {
+                var prevKeys = keyShapes[..^1];
+                var timeKey = keyShapes[^1];
+                var close = qao.PocoShape.First(p => p.Name == basedOn.CloseProp);
                 prev = new DerivedEntity
                 {
                     Id = $"{baseId}_prev_1m",
                     Role = Role.Prev1m,
                     Timeframe = tf,
-                    KeyShape = keyShapes,
-                    ValueShape = qao.PocoShape.Where(p => p.Name == basedOn.CloseProp).ToArray(),
+                    KeyShape = prevKeys,
+                    ValueShape = new[] { timeKey, close },
                     BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor
                 };

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -33,10 +33,15 @@ public class DerivationPlannerTests
     {
         TimeKey = "Timestamp",
         Windows = new[] { tf },
-        Keys = new[] { "Id" },
-        Projection = new[] { "Id" },
-        PocoShape = new[] { new ColumnShape("Id", typeof(int), false) },
-        BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, "KsqlTimeFrameClose", string.Empty),
+        Keys = new[] { "Id", "BucketStart" },
+        Projection = new[] { "Id", "BucketStart", "KsqlTimeFrameClose" },
+        PocoShape = new[]
+        {
+            new ColumnShape("Id", typeof(int), false),
+            new ColumnShape("BucketStart", typeof(long), false),
+            new ColumnShape("KsqlTimeFrameClose", typeof(double), false)
+        },
+        BasedOn = new BasedOnSpec(new[] { "Id", "BucketStart" }, string.Empty, "KsqlTimeFrameClose", string.Empty),
         WeekAnchor = DayOfWeek.Monday
     };
 
@@ -67,36 +72,34 @@ public class DerivationPlannerTests
     }
 
     [Fact]
-    public void Prev1m_Static_Table_Single_Value()
+    public void Prev1m_Table_Excludes_TimeKey_From_PrimaryKey()
     {
         var qao = new TumblingQao
         {
-            TimeKey = "Timestamp",
+            TimeKey = "BucketStart",
             Windows = new[] { new Timeframe(1, "m") },
-            Keys = new[] { "Id" },
-            Projection = new[] { "Id", "Open", "High", "Low", "KsqlTimeFrameClose" },
+            Keys = new[] { "Id", "BucketStart" },
+            Projection = new[] { "Id", "BucketStart", "KsqlTimeFrameClose" },
             PocoShape = new[]
             {
                 new ColumnShape("Id", typeof(int), false),
-                new ColumnShape("Open", typeof(double), false),
-                new ColumnShape("High", typeof(double), false),
-                new ColumnShape("Low", typeof(double), false),
+                new ColumnShape("BucketStart", typeof(long), false),
                 new ColumnShape("KsqlTimeFrameClose", typeof(double), false)
             },
-            BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, string.Empty, string.Empty),
+            BasedOn = new BasedOnSpec(new[] { "Id", "BucketStart" }, string.Empty, "KsqlTimeFrameClose", string.Empty),
             WeekAnchor = DayOfWeek.Monday
         };
         var baseModel = new EntityModel { EntityType = typeof(SourceOhlc) };
         var entities = DerivationPlanner.Plan(qao, baseModel);
         var models = EntityModelAdapter.Adapt(entities);
         var prev = models.Single(m => (string)m.AdditionalSettings["role"] == Role.Prev1m.ToString());
-        var close = (string)prev.AdditionalSettings["basedOn/closeProp"];
-        Assert.Equal(new[] { close }, (string[])prev.AdditionalSettings["projection"]);
+        Assert.Equal(new[] { "Id" }, (string[])prev.AdditionalSettings["keys"]);
+        Assert.Equal(new[] { "BucketStart", "KsqlTimeFrameClose" }, (string[])prev.AdditionalSettings["projection"]);
         var method = typeof(DerivedTumblingPipeline).GetMethod("BuildDdlAndRegister", BindingFlags.NonPublic | BindingFlags.Static);
         var qm = new KsqlQueryModel { SourceTypes = new[] { typeof(SourceOhlc) } };
         var res = ((string ddl, Type _, string? ns))method!.Invoke(null, new object[] { "bar", qm, prev, Role.Prev1m, (Func<string, Type>)(_ => typeof(object)) })!;
         Assert.StartsWith("CREATE TABLE bar_prev_1m", res.ddl);
-        Assert.DoesNotContain("AS SELECT", res.ddl);
-        Assert.Contains(close, res.ddl);
+        Assert.Contains("PRIMARY KEY (Id)", res.ddl);
+        Assert.Contains("BucketStart", res.ddl);
     }
 }

--- a/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
@@ -28,14 +28,15 @@ public class DerivedTumblingPipelineConcurrencyTests
         {
             TimeKey = "Timestamp",
             Windows = new[] { new Timeframe(1, "m"), new Timeframe(5, "m") },
-            Keys = new[] { "Id" },
-            Projection = new[] { "Id", "KsqlTimeFrameClose" },
+            Keys = new[] { "Id", "BucketStart" },
+            Projection = new[] { "Id", "BucketStart", "KsqlTimeFrameClose" },
             PocoShape = new[]
             {
                 new ColumnShape("Id", typeof(int), false),
+                new ColumnShape("BucketStart", typeof(long), false),
                 new ColumnShape("KsqlTimeFrameClose", typeof(double), false)
             },
-            BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, "KsqlTimeFrameClose", string.Empty),
+            BasedOn = new BasedOnSpec(new[] { "Id", "BucketStart" }, string.Empty, "KsqlTimeFrameClose", string.Empty),
             WeekAnchor = DayOfWeek.Monday
         };
         var baseModel = new EntityModel { EntityType = typeof(ConcurrencySource) };

--- a/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
@@ -29,14 +29,15 @@ public class DerivedTumblingPipelineTests
         {
             TimeKey = "Timestamp",
             Windows = new[] { new Timeframe(1, "m") },
-            Keys = new[] { "Id" },
-            Projection = new[] { "Id", "KsqlTimeFrameClose" },
+            Keys = new[] { "Id", "BucketStart" },
+            Projection = new[] { "Id", "BucketStart", "KsqlTimeFrameClose" },
             PocoShape = new[]
             {
                 new ColumnShape("Id", typeof(int), false),
+                new ColumnShape("BucketStart", typeof(long), false),
                 new ColumnShape("KsqlTimeFrameClose", typeof(double), false)
             },
-            BasedOn = new BasedOnSpec(new[] { "Id" }, string.Empty, "KsqlTimeFrameClose", string.Empty),
+            BasedOn = new BasedOnSpec(new[] { "Id", "BucketStart" }, string.Empty, "KsqlTimeFrameClose", string.Empty),
             WeekAnchor = DayOfWeek.Monday
         };
         var baseModel = new EntityModel { EntityType = typeof(TestSource) };


### PR DESCRIPTION
## Summary
- exclude window start from prev1m primary key and keep it as value column
- adapt model builder to output time key and close for prev1m tables
- adjust derivation tests for new prev1m schema

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68be3c965f58832787e16c7e219294e8