### PR TITLE
Add datetime mapping to derived tumbling pipeline

### DIFF
--- a/docs/diff_log/diff_derived_tumbling_pipeline_datetime_20250908.md
+++ b/docs/diff_log/diff_derived_tumbling_pipeline_datetime_20250908.md
@@ -1,0 +1,1 @@
+- Expanded DerivedTumblingPipeline type mapping to explicitly handle DateTime, DateTimeOffset, decimal and other CLR types for correct KSQL DDL generation.

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -5,6 +5,7 @@ using Kafka.Ksql.Linq.Query.Builders;
 using Kafka.Ksql.Linq.Query.Dsl;
 using Kafka.Ksql.Linq.Query.Abstractions;
 using Kafka.Ksql.Linq.Mapping;
+using Kafka.Ksql.Linq.Configuration;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
@@ -90,10 +91,22 @@ internal static class DerivedTumblingPipeline
         var ns = model.AdditionalSettings.TryGetValue("namespace", out var nsObj) ? nsObj?.ToString() : null;
         return (ddl, dt, ns);
 
-        static string Map(Type t) => t == typeof(int) ? "INT"
-            : t == typeof(long) ? "BIGINT"
-            : t == typeof(bool) ? "BOOLEAN"
-            : t == typeof(string) ? "VARCHAR"
-            : "DOUBLE";
+        static string Map(Type t) => t switch
+        {
+            Type x when x == typeof(int) => "INT",
+            Type x when x == typeof(short) => "INT",
+            Type x when x == typeof(long) => "BIGINT",
+            Type x when x == typeof(double) => "DOUBLE",
+            Type x when x == typeof(float) => "DOUBLE",
+            Type x when x == typeof(decimal) => $"DECIMAL({DecimalPrecisionConfig.DecimalPrecision}, {DecimalPrecisionConfig.DecimalScale})",
+            Type x when x == typeof(string) => "VARCHAR",
+            Type x when x == typeof(char) => "VARCHAR",
+            Type x when x == typeof(bool) => "BOOLEAN",
+            Type x when x == typeof(DateTime) => "TIMESTAMP",
+            Type x when x == typeof(DateTimeOffset) => "TIMESTAMP",
+            Type x when x == typeof(Guid) => "VARCHAR",
+            Type x when x == typeof(byte[]) => "BYTES",
+            _ => "DOUBLE"
+        };
     }
 }


### PR DESCRIPTION
## Summary
- map DateTime and additional CLR types to explicit KSQL types in derived tumbling pipeline
- log derived tumbling pipeline type mapping update

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68be46c1e37083279629bb02a61abc7e