### PR TITLE
Remove Prev1m special handling

### DIFF
--- a/docs/diff_log/diff_prev1m_primary_key_20250908.md
+++ b/docs/diff_log/diff_prev1m_primary_key_20250908.md
@@ -1,3 +1,0 @@
-# diff: Prev1m primary key (2025-09-08)
-- Prev1m table drops BucketStart from the primary key.
-- BucketStart remains as a value column alongside KsqlTimeFrameClose.

--- a/docs/diff_log/diff_prev1m_role_unification_20250908.md
+++ b/docs/diff_log/diff_prev1m_role_unification_20250908.md
@@ -1,0 +1,4 @@
+# diff: Prev1m role unification (2025-09-08)
+- Removed special-case Prev1m table DDL and schema projection.
+- Derivation planner no longer emits Prev1m entities; only Hb remains for 1m windows.
+- Updated tests accordingly.

--- a/docs/diff_log/diff_prev1m_static_ddl_20250908.md
+++ b/docs/diff_log/diff_prev1m_static_ddl_20250908.md
@@ -1,6 +1,0 @@
-# diff: Prev1m static table DDL (2025-09-08)
-- Role.Prev1m generates simple `CREATE TABLE` instead of windowed DDL.
-- Prev1m entity schema reduced to a single value column named `KsqlTimeFrameClose`.
-- EntityModelAdapter maps Prev1m projection to the configured close column.
-- Tests verify static DDL and single-column projection.
-- Close column is derived from the `[KsqlTimeFrameClose]` attribute on the entity.

--- a/src/Query/Adapters/EntityModelAdapter.cs
+++ b/src/Query/Adapters/EntityModelAdapter.cs
@@ -20,14 +20,6 @@ internal static class EntityModelAdapter
             var values = e.ValueShape.Select(v => v.Name).ToArray();
             var types = e.ValueShape.Select(v => v.Type).ToArray();
             var nulls = e.ValueShape.Select(v => v.IsNullable).ToArray();
-            if (e.Role == Role.Prev1m)
-            {
-                var close = e.ValueShape.First(v => v.Name == e.BasedOnSpec.CloseProp);
-                var timeKey = e.ValueShape.First(v => v.Name != close.Name);
-                values = new[] { timeKey.Name, close.Name };
-                types = new[] { timeKey.Type, close.Type };
-                nulls = new[] { timeKey.IsNullable, close.IsNullable };
-            }
             if (keys.Length == 0 || (values.Length == 0 && e.Role != Role.Hb))
                 throw new InvalidOperationException("Key and value must not be empty");
 

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -33,7 +33,6 @@ internal static class DerivationPlanner
             }
         }
 
-        DerivedEntity? prev = null;
         foreach (var tf in qao.Windows)
         {
             var tfStr = $"{tf.Value}{tf.Unit}";
@@ -83,23 +82,8 @@ internal static class DerivationPlanner
             };
             entities.Add(final);
 
-            if (tf.Unit == "m" && tf.Value == 1 && prev == null)
+            if (tf.Unit == "m" && tf.Value == 1)
             {
-                var prevKeys = keyShapes[..^1];
-                var timeKey = keyShapes[^1];
-                var close = qao.PocoShape.First(p => p.Name == basedOn.CloseProp);
-                prev = new DerivedEntity
-                {
-                    Id = $"{baseId}_prev_1m",
-                    Role = Role.Prev1m,
-                    Timeframe = tf,
-                    KeyShape = prevKeys,
-                    ValueShape = new[] { timeKey, close },
-                    BasedOnSpec = basedOn,
-                    WeekAnchor = qao.WeekAnchor
-                };
-                entities.Add(prev);
-
                 var hb = new DerivedEntity
                 {
                     Id = $"{baseId}_hb_1m",

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -5,7 +5,6 @@ using Kafka.Ksql.Linq.Query.Builders;
 using Kafka.Ksql.Linq.Query.Dsl;
 using Kafka.Ksql.Linq.Query.Abstractions;
 using Kafka.Ksql.Linq.Mapping;
-using Kafka.Ksql.Linq.Configuration;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
@@ -67,46 +66,12 @@ internal static class DerivedTumblingPipeline
             Role.Hb => $"{baseName}_hb_1m",
             _ => $"{baseName}_{tf}"
         };
-        string ddl;
-        if (role == Role.Prev1m)
-        {
-            var keys = (string[])model.AdditionalSettings["keys"];
-            var keyTypes = (Type[])model.AdditionalSettings["keys/types"];
-            var proj = (string[])model.AdditionalSettings["projection"];
-            var projTypes = (Type[])model.AdditionalSettings["projection/types"];
-            var cols = new List<string>();
-            for (var i = 0; i < keys.Length; i++) cols.Add($"{keys[i]} {Map(keyTypes[i])}");
-            for (var i = 0; i < proj.Length; i++) cols.Add($"{proj[i]} {Map(projTypes[i])}");
-            var pk = string.Join(", ", keys);
-            ddl = $"CREATE TABLE {name} ({string.Join(", ", cols)}, PRIMARY KEY ({pk})) WITH (KAFKA_TOPIC='{name}', KEY_FORMAT='AVRO', VALUE_FORMAT='AVRO');";
-        }
-        else
-        {
-            ddl = KsqlCreateWindowedStatementBuilder.Build(name, qm, tf);
-        }
+        var ddl = KsqlCreateWindowedStatementBuilder.Build(name, qm, tf);
         var dt = resolveType(name);
         model.EntityType = dt;
         model.TopicName = name;
         model.SetStreamTableType(qm.DetermineType());
         var ns = model.AdditionalSettings.TryGetValue("namespace", out var nsObj) ? nsObj?.ToString() : null;
         return (ddl, dt, ns);
-
-        static string Map(Type t) => t switch
-        {
-            Type x when x == typeof(int) => "INT",
-            Type x when x == typeof(short) => "INT",
-            Type x when x == typeof(long) => "BIGINT",
-            Type x when x == typeof(double) => "DOUBLE",
-            Type x when x == typeof(float) => "DOUBLE",
-            Type x when x == typeof(decimal) => $"DECIMAL({DecimalPrecisionConfig.DecimalPrecision}, {DecimalPrecisionConfig.DecimalScale})",
-            Type x when x == typeof(string) => "VARCHAR",
-            Type x when x == typeof(char) => "VARCHAR",
-            Type x when x == typeof(bool) => "BOOLEAN",
-            Type x when x == typeof(DateTime) => "TIMESTAMP",
-            Type x when x == typeof(DateTimeOffset) => "TIMESTAMP",
-            Type x when x == typeof(Guid) => "VARCHAR",
-            Type x when x == typeof(byte[]) => "BYTES",
-            _ => "DOUBLE"
-        };
     }
 }

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -46,7 +46,7 @@ public class DerivationPlannerTests
     };
 
     [Fact]
-    public void Plan_1m_Includes_All_Roles()
+    public void Plan_1m_Includes_Agg_Live_Final_Hb()
     {
         var model = new EntityModel { EntityType = typeof(Source) };
         var entities = DerivationPlanner.Plan(Create(new Timeframe(1, "m")), model);
@@ -54,12 +54,12 @@ public class DerivationPlannerTests
         Assert.Contains(entities, e => e.Id == "bar_1m_agg_final" && e.Role == Role.AggFinal);
         Assert.Contains(entities, e => e.Id == "bar_1m_live" && e.Role == Role.Live);
         Assert.Contains(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
-        Assert.Contains(entities, e => e.Id == "bar_prev_1m" && e.Role == Role.Prev1m);
+        Assert.DoesNotContain(entities, e => e.Role == Role.Prev1m);
         Assert.Contains(entities, e => e.Id == "bar_hb_1m" && e.Role == Role.Hb);
     }
 
     [Fact]
-    public void Plan_5m_Excludes_Prev_And_Hb()
+    public void Plan_5m_Excludes_Hb()
     {
         var model = new EntityModel { EntityType = typeof(Source) };
         var entities = DerivationPlanner.Plan(Create(new Timeframe(5, "m")), model);
@@ -67,39 +67,6 @@ public class DerivationPlannerTests
         Assert.Contains(entities, e => e.Id == "bar_5m_agg_final" && e.Role == Role.AggFinal);
         Assert.Contains(entities, e => e.Id == "bar_5m_live" && e.Role == Role.Live);
         Assert.Contains(entities, e => e.Id == "bar_5m_final" && e.Role == Role.Final);
-        Assert.DoesNotContain(entities, e => e.Role == Role.Prev1m);
         Assert.DoesNotContain(entities, e => e.Role == Role.Hb);
-    }
-
-    [Fact]
-    public void Prev1m_Table_Excludes_TimeKey_From_PrimaryKey()
-    {
-        var qao = new TumblingQao
-        {
-            TimeKey = "BucketStart",
-            Windows = new[] { new Timeframe(1, "m") },
-            Keys = new[] { "Id", "BucketStart" },
-            Projection = new[] { "Id", "BucketStart", "KsqlTimeFrameClose" },
-            PocoShape = new[]
-            {
-                new ColumnShape("Id", typeof(int), false),
-                new ColumnShape("BucketStart", typeof(long), false),
-                new ColumnShape("KsqlTimeFrameClose", typeof(double), false)
-            },
-            BasedOn = new BasedOnSpec(new[] { "Id", "BucketStart" }, string.Empty, "KsqlTimeFrameClose", string.Empty),
-            WeekAnchor = DayOfWeek.Monday
-        };
-        var baseModel = new EntityModel { EntityType = typeof(SourceOhlc) };
-        var entities = DerivationPlanner.Plan(qao, baseModel);
-        var models = EntityModelAdapter.Adapt(entities);
-        var prev = models.Single(m => (string)m.AdditionalSettings["role"] == Role.Prev1m.ToString());
-        Assert.Equal(new[] { "Id" }, (string[])prev.AdditionalSettings["keys"]);
-        Assert.Equal(new[] { "BucketStart", "KsqlTimeFrameClose" }, (string[])prev.AdditionalSettings["projection"]);
-        var method = typeof(DerivedTumblingPipeline).GetMethod("BuildDdlAndRegister", BindingFlags.NonPublic | BindingFlags.Static);
-        var qm = new KsqlQueryModel { SourceTypes = new[] { typeof(SourceOhlc) } };
-        var res = ((string ddl, Type _, string? ns))method!.Invoke(null, new object[] { "bar", qm, prev, Role.Prev1m, (Func<string, Type>)(_ => typeof(object)) })!;
-        Assert.StartsWith("CREATE TABLE bar_prev_1m", res.ddl);
-        Assert.Contains("PRIMARY KEY (Id)", res.ddl);
-        Assert.Contains("BucketStart", res.ddl);
     }
 }

--- a/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
@@ -59,7 +59,7 @@ public class DerivedTumblingPipelineConcurrencyTests
 
         await DerivedTumblingPipeline.RunAsync(qao, baseModel, model, Exec, Resolver, mapping, registry, new LoggerFactory().CreateLogger("test"));
 
-        var expected = 8; // 2 windows -> AggFinal/Live/Final each + Prev1m/Hb
+        var expected = 7; // 1m: AggFinal/Live/Final + Hb, 5m: AggFinal/Live/Final
         Assert.Equal(expected, registry.Count);
         Assert.Equal(expected, ddls.Count);
     }


### PR DESCRIPTION
## Summary
- simplify derived tumbling pipeline by always generating windowed DDL
- drop Prev1m-specific projection and planning; only heartbeat remains for 1m windows
- align tests and docs with unified role behavior

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68be4d3b5ee48327927246ecda175b56