### PR TITLE
Capture tumbling time key and grace

### DIFF
--- a/docs/diff_log/diff_tumbling_timekey_grace_20250908.md
+++ b/docs/diff_log/diff_tumbling_timekey_grace_20250908.md
@@ -1,0 +1,6 @@
+# Tumbling TimeKey and Grace persistence
+
+- Tumbling DSL records the timestamp property name in `KsqlQueryModel.TimeKey`.
+- Optional grace periods set `KsqlQueryModel.GraceSeconds`.
+- `BuildQao` forwards `TimeKey` and `GraceSeconds` to `TumblingQao`.
+

--- a/src/KsqlContext.SchemaRegistration.cs
+++ b/src/KsqlContext.SchemaRegistration.cs
@@ -435,13 +435,14 @@ public abstract partial class KsqlContext
             var keys = m.KeyProperties.Select(p => p.Name).ToArray();
             return new TumblingQao
             {
-                TimeKey = "Timestamp",
+                TimeKey = m.QueryModel!.TimeKey ?? "Timestamp",
                 Windows = frames,
                 Keys = keys,
                 Projection = keys,
                 PocoShape = shape,
                 BasedOn = new BasedOnSpec(keys, string.Empty, string.Empty, string.Empty),
-                WeekAnchor = m.QueryModel!.WeekAnchor
+                WeekAnchor = m.QueryModel!.WeekAnchor,
+                GraceSeconds = m.QueryModel!.GraceSeconds
             };
         }
 

--- a/src/Query/Analysis/TumblingQao.cs
+++ b/src/Query/Analysis/TumblingQao.cs
@@ -22,4 +22,5 @@ internal class TumblingQao
     public IReadOnlyList<ColumnShape> PocoShape { get; init; } = new List<ColumnShape>();
     public BasedOnSpec BasedOn { get; init; } = new(new List<string>(), string.Empty, string.Empty, string.Empty);
     public DayOfWeek WeekAnchor { get; init; } = DayOfWeek.Monday;
+    public int? GraceSeconds { get; init; }
 }

--- a/src/Query/Dsl/KsqlQueryModel.cs
+++ b/src/Query/Dsl/KsqlQueryModel.cs
@@ -21,6 +21,7 @@ public class KsqlQueryModel
     public LambdaExpression? BasedOnDayKey { get; set; }
     public List<string> Windows { get; } = new();
     public DayOfWeek WeekAnchor { get; set; } = DayOfWeek.Monday;
+    public string? TimeKey { get; set; }
     public int? WithinSeconds { get; set; }
     public bool ForbidDefaultWithin { get; set; }
     public bool IsFinal { get; set; }
@@ -41,6 +42,7 @@ public class KsqlQueryModel
             BasedOnType = BasedOnType,
             BasedOnDayKey = BasedOnDayKey,
             WeekAnchor = WeekAnchor,
+            TimeKey = TimeKey,
             WithinSeconds = WithinSeconds,
             ForbidDefaultWithin = ForbidDefaultWithin,
             IsFinal = IsFinal,

--- a/src/Query/Dsl/KsqlQueryable.cs
+++ b/src/Query/Dsl/KsqlQueryable.cs
@@ -66,6 +66,9 @@ public class KsqlQueryable<T1> : IKsqlQueryable, IScheduledScope<T1>
         DayOfWeek? week = null,
         TimeSpan? grace = null)
     {
+        _model.TimeKey = ExtractPropertyName(time);
+        if (grace.HasValue)
+            _model.GraceSeconds = (int)Math.Ceiling(grace.Value.TotalSeconds);
         if (minutes != null) foreach (var m in minutes) _model.Windows.Add($"{m}m");
         if (hours != null) foreach (var h in hours) _model.Windows.Add($"{h}h");
         if (days != null) foreach (var d in days) _model.Windows.Add($"{d}d");


### PR DESCRIPTION
## Summary
- store tumbling timestamp property name in query model
- persist optional grace seconds and expose via TumblingQao
- document change

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68be62cc80648327a8f476b2f5ee65f2