### PR TITLE
Capture schedule boundaries in TimeFrame

### DIFF
--- a/docs/diff_log/diff_timeframe_schedule_parse_20250908.md
+++ b/docs/diff_log/diff_timeframe_schedule_parse_20250908.md
@@ -1,0 +1,6 @@
+# 差分履歴: TimeFrame schedule parse
+
+## Capture join and boundary metadata
+- `KsqlQueryable.TimeFrame` now parses the predicate to record schedule join keys and open/close boundaries with inclusivity flags.
+- `KsqlQueryModel` stores these fields and `BuildQao` forwards them into `BasedOnSpec`.
+- `QueryBuilderUtils.ApplyTimeFrame` uses the recorded inclusivity flags when rendering join SQL.

--- a/src/KsqlContext.SchemaRegistration.cs
+++ b/src/KsqlContext.SchemaRegistration.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using System.Linq.Expressions;
 using ConfluentSchemaRegistry = Confluent.SchemaRegistry;
 
 namespace Kafka.Ksql.Linq;
@@ -433,6 +434,8 @@ public abstract partial class KsqlContext
             var shape = m.AllProperties.Select(p => new ColumnShape(p.Name, p.PropertyType, ctx.Create(p).WriteState == NullabilityState.Nullable)).ToArray();
             var frames = m.QueryModel!.Windows.Select(ParseWindow).ToList();
             var keys = m.KeyProperties.Select(p => p.Name).ToArray();
+            var basedOnKeys = m.QueryModel.BasedOnJoinKeys.Count > 0 ? m.QueryModel.BasedOnJoinKeys.ToArray() : keys;
+            var dayKey = PropertyName(m.QueryModel.BasedOnDayKey);
             return new TumblingQao
             {
                 TimeKey = m.QueryModel!.TimeKey ?? "Timestamp",
@@ -440,7 +443,13 @@ public abstract partial class KsqlContext
                 Keys = keys,
                 Projection = keys,
                 PocoShape = shape,
-                BasedOn = new BasedOnSpec(keys, string.Empty, string.Empty, string.Empty),
+                BasedOn = new BasedOnSpec(
+                    basedOnKeys,
+                    m.QueryModel.BasedOnOpen ?? string.Empty,
+                    m.QueryModel.BasedOnClose ?? string.Empty,
+                    dayKey,
+                    m.QueryModel.BasedOnOpenInclusive,
+                    m.QueryModel.BasedOnCloseInclusive),
                 WeekAnchor = m.QueryModel!.WeekAnchor,
                 GraceSeconds = m.QueryModel!.GraceSeconds
             };
@@ -456,6 +465,9 @@ public abstract partial class KsqlContext
             var value = int.Parse(w[..^1]);
             return new Timeframe(value, unit);
         }
+
+        static string PropertyName(LambdaExpression? e) =>
+            e?.Body is MemberExpression m ? m.Member.Name : string.Empty;
     }
 
     /// <summary>

--- a/src/Query/Builders/Utils/QueryBuilderUtils.cs
+++ b/src/Query/Builders/Utils/QueryBuilderUtils.cs
@@ -14,8 +14,12 @@ internal static class QueryBuilderUtils
         var openProp = md.GetProperty<string>("basedOn/openProp");
         var closeProp = md.GetProperty<string>("basedOn/closeProp");
         var timeKey = md.GetProperty<string>("timeKey");
+        var openInc = md.GetProperty<bool?>("basedOn/openInclusive") ?? true;
+        var closeInc = md.GetProperty<bool?>("basedOn/closeInclusive") ?? false;
+        var openOp = openInc ? "<=" : "<";
+        var closeOp = closeInc ? "<=" : "<";
         var join = string.Join(" AND ", joinKeys.Select(k => $"r.{k} = s.{k}"));
-        return $"JOIN ON {join} AND s.{openProp} <= r.{timeKey} AND r.{timeKey} < s.{closeProp}";
+        return $"JOIN ON {join} AND s.{openProp} {openOp} r.{timeKey} AND r.{timeKey} {closeOp} s.{closeProp}"; 
     }
 
     public static string ApplyWindowTumbling(string timeframe) => $"WINDOW TUMBLING({timeframe})";

--- a/src/Query/Dsl/KsqlQueryModel.cs
+++ b/src/Query/Dsl/KsqlQueryModel.cs
@@ -19,6 +19,11 @@ public class KsqlQueryModel
     public QueryExecutionMode ExecutionMode { get; set; } = QueryExecutionMode.Unspecified;
     public Type? BasedOnType { get; set; }
     public LambdaExpression? BasedOnDayKey { get; set; }
+    public List<string> BasedOnJoinKeys { get; } = new();
+    public string? BasedOnOpen { get; set; }
+    public string? BasedOnClose { get; set; }
+    public bool BasedOnOpenInclusive { get; set; } = true;
+    public bool BasedOnCloseInclusive { get; set; } = false;
     public List<string> Windows { get; } = new();
     public DayOfWeek WeekAnchor { get; set; } = DayOfWeek.Monday;
     public string? TimeKey { get; set; }
@@ -41,6 +46,10 @@ public class KsqlQueryModel
             ExecutionMode = ExecutionMode,
             BasedOnType = BasedOnType,
             BasedOnDayKey = BasedOnDayKey,
+            BasedOnOpen = BasedOnOpen,
+            BasedOnClose = BasedOnClose,
+            BasedOnOpenInclusive = BasedOnOpenInclusive,
+            BasedOnCloseInclusive = BasedOnCloseInclusive,
             WeekAnchor = WeekAnchor,
             TimeKey = TimeKey,
             WithinSeconds = WithinSeconds,
@@ -49,6 +58,7 @@ public class KsqlQueryModel
             GraceSeconds = GraceSeconds
         };
         clone.Windows.AddRange(Windows);
+        clone.BasedOnJoinKeys.AddRange(BasedOnJoinKeys);
         foreach (var kv in Extras)
             clone.Extras[kv.Key] = kv.Value;
         return clone;

--- a/src/Query/Dsl/KsqlQueryable.cs
+++ b/src/Query/Dsl/KsqlQueryable.cs
@@ -109,7 +109,57 @@ public class KsqlQueryable<T1> : IKsqlQueryable, IScheduledScope<T1>
     {
         _model.BasedOnType = typeof(TSchedule);
         _model.BasedOnDayKey = dayKey;
+        Parse(predicate.Body);
         return this;
+
+        void Parse(Expression expr)
+        {
+            switch (expr)
+            {
+                case BinaryExpression be when be.NodeType == ExpressionType.AndAlso:
+                    Parse(be.Left);
+                    Parse(be.Right);
+                    break;
+                case BinaryExpression be when be.NodeType == ExpressionType.Equal:
+                    if (be.Left is MemberExpression lm && be.Right is MemberExpression rm)
+                    {
+                        if (lm.Expression is ParameterExpression lp && lp.Type == typeof(T1) &&
+                            rm.Expression is ParameterExpression rp && rp.Type == typeof(TSchedule))
+                            _model.BasedOnJoinKeys.Add(lm.Member.Name);
+                        else if (rm.Expression is ParameterExpression rp2 && rp2.Type == typeof(T1) &&
+                                 lm.Expression is ParameterExpression lp2 && lp2.Type == typeof(TSchedule))
+                            _model.BasedOnJoinKeys.Add(rm.Member.Name);
+                    }
+                    break;
+                case BinaryExpression be when be.NodeType is ExpressionType.LessThan or ExpressionType.LessThanOrEqual or ExpressionType.GreaterThan or ExpressionType.GreaterThanOrEqual:
+                    HandleBoundary(be);
+                    break;
+            }
+        }
+
+        void HandleBoundary(BinaryExpression be)
+        {
+            if (be.Left is not MemberExpression l || be.Right is not MemberExpression r) return;
+            if (l.Expression is not ParameterExpression lp || r.Expression is not ParameterExpression rp) return;
+            var lSched = lp.Type == typeof(TSchedule);
+            var rSched = rp.Type == typeof(TSchedule);
+            if (lSched == rSched) return;
+            var schedProp = lSched ? l.Member.Name : r.Member.Name;
+            var inclusive = be.NodeType is ExpressionType.LessThanOrEqual or ExpressionType.GreaterThanOrEqual;
+            var isOpen = lSched
+                ? be.NodeType is ExpressionType.LessThan or ExpressionType.LessThanOrEqual
+                : be.NodeType is ExpressionType.GreaterThan or ExpressionType.GreaterThanOrEqual;
+            if (isOpen)
+            {
+                _model.BasedOnOpen = schedProp;
+                _model.BasedOnOpenInclusive = inclusive;
+            }
+            else
+            {
+                _model.BasedOnClose = schedProp;
+                _model.BasedOnCloseInclusive = inclusive;
+            }
+        }
     }
 
     public KsqlQueryable<T1> AsPush()


### PR DESCRIPTION
## Summary
- parse TimeFrame predicate to track join keys and boundary inclusivity
- carry schedule fields in KsqlQueryModel and propagate to planning and SQL builders
- record change in diff log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68be690f0a14832787e32038e81047ae