### PR TITLE
Derive time key and projection for tumbling

### DIFF
--- a/docs/diff_log/diff_buildqao_timekey_projection_basedon_20250908.md
+++ b/docs/diff_log/diff_buildqao_timekey_projection_basedon_20250908.md
@@ -1,0 +1,5 @@
+# BuildQao time key and based-on propagation
+
+- `BuildQao` derives `TimeKey` from the entity's stored timestamp column with `[KsqlTimestamp]` fallback to model.
+- `Projection` now lists non-key columns for aggregation outputs.
+- `BasedOnSpec` populated with schedule boundaries (open/close/day key) from `KsqlQueryModel`.

--- a/src/KsqlContext.SchemaRegistration.cs
+++ b/src/KsqlContext.SchemaRegistration.cs
@@ -436,17 +436,23 @@ public abstract partial class KsqlContext
             var keys = m.KeyProperties.Select(p => p.Name).ToArray();
             var basedOnKeys = m.QueryModel.BasedOnJoinKeys.Count > 0 ? m.QueryModel.BasedOnJoinKeys.ToArray() : keys;
             var dayKey = PropertyName(m.QueryModel.BasedOnDayKey);
+            var timeKey = m.AllProperties.FirstOrDefault(p => p.GetCustomAttribute<KsqlTimestampAttribute>() != null)?.Name
+                ?? m.QueryModel!.TimeKey
+                ?? "Timestamp";
+            var projection = m.AllProperties.Select(p => p.Name).Where(n => !keys.Contains(n)).ToArray();
+            var basedOnOpen = m.QueryModel.BasedOnOpen ?? string.Empty;
+            var basedOnClose = m.QueryModel.BasedOnClose ?? string.Empty;
             return new TumblingQao
             {
-                TimeKey = m.QueryModel!.TimeKey ?? "Timestamp",
+                TimeKey = timeKey,
                 Windows = frames,
                 Keys = keys,
-                Projection = keys,
+                Projection = projection,
                 PocoShape = shape,
                 BasedOn = new BasedOnSpec(
                     basedOnKeys,
-                    m.QueryModel.BasedOnOpen ?? string.Empty,
-                    m.QueryModel.BasedOnClose ?? string.Empty,
+                    basedOnOpen,
+                    basedOnClose,
                     dayKey,
                     m.QueryModel.BasedOnOpenInclusive,
                     m.QueryModel.BasedOnCloseInclusive),


### PR DESCRIPTION
## Summary
- resolve time key from stored timestamp or model
- include non-key aggregation columns in projection
- propagate schedule boundaries into BasedOnSpec

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68be704b7048832791011eb60bc711cd