### PR TITLE
Add prev1m role planning and sync hints

### DIFF
--- a/docs/diff_log/diff_prev1m_topic_hints_20251030.md
+++ b/docs/diff_log/diff_prev1m_topic_hints_20251030.md
@@ -1,0 +1,2 @@
+- detect 1m window and register bar_prev_1m derived entity
+- final entities sync to bar_prev_1m for fallback

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -54,6 +54,8 @@ internal static class DerivationPlanner
             };
             entities.Add(agg);
 
+            var liveInput = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? $"{baseId}_1m_final" : $"{baseId}_1m_live";
+            var liveSync = tf.Unit == "m" && tf.Value == 1 ? $"{baseId}_hb_1m".ToUpperInvariant() : null;
             var live = new DerivedEntity
             {
                 Id = liveId,
@@ -61,13 +63,14 @@ internal static class DerivationPlanner
                 Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
-                InputHint = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? $"{baseId}_1m_final" : $"{baseId}_1m_live",
-                SyncHint = tf.Unit == "m" && tf.Value == 1 ? $"{baseId}_hb_1m".ToUpperInvariant() : null,
+                InputHint = liveInput,
+                SyncHint = liveSync,
                 BasedOnSpec = basedOn,
                 WeekAnchor = qao.WeekAnchor
             };
             entities.Add(live);
 
+            var finalInput = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? $"{baseId}_1m_final" : $"{baseId}_1m_live";
             var final = new DerivedEntity
             {
                 Id = finalId,
@@ -75,8 +78,8 @@ internal static class DerivationPlanner
                 Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
-                InputHint = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? $"{baseId}_1m_final" : $"{baseId}_1m_live",
-                SyncHint = tf.Unit == "m" && tf.Value == 1 ? $"{baseId}_hb_1m".ToUpperInvariant() : null,
+                InputHint = finalInput,
+                SyncHint = $"{baseId}_prev_1m",
                 BasedOnSpec = basedOn,
                 WeekAnchor = qao.WeekAnchor
             };
@@ -96,6 +99,20 @@ internal static class DerivationPlanner
                     WeekAnchor = qao.WeekAnchor
                 };
                 entities.Add(hb);
+
+                var prev = new DerivedEntity
+                {
+                    Id = $"{baseId}_prev_1m",
+                    Role = Role.Prev1m,
+                    Timeframe = tf,
+                    KeyShape = keyShapes,
+                    ValueShape = valueShapes,
+                    InputHint = $"{baseId}_1m_final",
+                    SyncHint = $"{baseId}_hb_1m".ToUpperInvariant(),
+                    BasedOnSpec = basedOn,
+                    WeekAnchor = qao.WeekAnchor
+                };
+                entities.Add(prev);
             }
         }
         return entities;

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -46,15 +46,18 @@ public class DerivationPlannerTests
     };
 
     [Fact]
-    public void Plan_1m_Includes_Agg_Live_Final_Hb()
+    public void Plan_1m_Includes_Agg_Live_Final_Hb_Prev()
     {
         var model = new EntityModel { EntityType = typeof(Source) };
         var entities = DerivationPlanner.Plan(Create(new Timeframe(1, "m")), model);
 
         Assert.Contains(entities, e => e.Id == "bar_1m_agg_final" && e.Role == Role.AggFinal);
         Assert.Contains(entities, e => e.Id == "bar_1m_live" && e.Role == Role.Live);
-        Assert.Contains(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
-        Assert.DoesNotContain(entities, e => e.Role == Role.Prev1m);
+        var final = Assert.Single(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
+        Assert.Equal("bar_prev_1m", final.SyncHint);
+        var prev = Assert.Single(entities, e => e.Id == "bar_prev_1m" && e.Role == Role.Prev1m);
+        Assert.Equal("bar_1m_final", prev.InputHint);
+        Assert.Equal("BAR_HB_1M", prev.SyncHint);
         Assert.Contains(entities, e => e.Id == "bar_hb_1m" && e.Role == Role.Hb);
     }
 
@@ -66,7 +69,9 @@ public class DerivationPlannerTests
 
         Assert.Contains(entities, e => e.Id == "bar_5m_agg_final" && e.Role == Role.AggFinal);
         Assert.Contains(entities, e => e.Id == "bar_5m_live" && e.Role == Role.Live);
-        Assert.Contains(entities, e => e.Id == "bar_5m_final" && e.Role == Role.Final);
+        var final = Assert.Single(entities, e => e.Id == "bar_5m_final" && e.Role == Role.Final);
+        Assert.Equal("bar_prev_1m", final.SyncHint);
         Assert.DoesNotContain(entities, e => e.Role == Role.Hb);
+        Assert.DoesNotContain(entities, e => e.Role == Role.Prev1m);
     }
 }

--- a/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
@@ -59,7 +59,7 @@ public class DerivedTumblingPipelineConcurrencyTests
 
         await DerivedTumblingPipeline.RunAsync(qao, baseModel, model, Exec, Resolver, mapping, registry, new LoggerFactory().CreateLogger("test"));
 
-        var expected = 7; // 1m: AggFinal/Live/Final + Hb, 5m: AggFinal/Live/Final
+        var expected = 8; // 1m: AggFinal/Live/Final + Hb + Prev, 5m: AggFinal/Live/Final
         Assert.Equal(expected, registry.Count);
         Assert.Equal(expected, ddls.Count);
     }

--- a/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
@@ -64,6 +64,7 @@ public class DerivedTumblingPipelineTests
 
         var live = ddls.Single(s => s.Contains("_1m_live"));
         var final = ddls.Single(s => s.Contains("_1m_final"));
+        Assert.Contains(ddls, s => s.Contains("_prev_1m"));
         Assert.Contains("EMIT CHANGES", live);
         Assert.Contains("EMIT FINAL", final);
         Assert.False(model.IsFinal);


### PR DESCRIPTION
## Summary
- plan prev_1m derived entity when 1m window present
- sync final entities against prev_1m
- document prev_1m topic planning

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68be7216fdc8832797842bbac47ccc98