### PR TITLE
Use agg_final inputs and heartbeat topics in derived pipeline

### DIFF
--- a/docs/diff_log/diff_derivationplanner_heartbeat_20250908.md
+++ b/docs/diff_log/diff_derivationplanner_heartbeat_20250908.md
@@ -1,0 +1,4 @@
+- finals now source from agg_final and sync on prev_1m instead of live
+- heartbeat topics generated for all timeframes and linked via SyncHint
+- pipeline tests assert finals avoid live dependencies
+- heartbeat runner honors configurable grace before emitting signals

--- a/src/Configuration/Messaging/HeartbeatOptions.cs
+++ b/src/Configuration/Messaging/HeartbeatOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 
 namespace Kafka.Ksql.Linq.Configuration.Messaging;
@@ -18,4 +19,9 @@ public class HeartbeatOptions
 
     [DefaultValue(typeof(LeaderElectionOptions))]
     public LeaderElectionOptions LeaderElection { get; init; } = new();
+
+    /// <summary>
+    /// Additional delay after each bucket before emitting a heartbeat.
+    /// </summary>
+    public TimeSpan Grace { get; init; } = TimeSpan.Zero;
 }

--- a/src/KsqlContext.cs
+++ b/src/KsqlContext.cs
@@ -319,7 +319,7 @@ public abstract partial class KsqlContext : IKsqlContext
             BootstrapServers = _dslOptions.Common.BootstrapServers
         }).Build();
         var sender = new KafkaHeartbeatSender(producer, _leaderFlag, _dslOptions.Heartbeat.Topic);
-        var planner = new HeartbeatPlanner(TimeSpan.Zero, Array.Empty<HeartbeatItem>(), _marketScheduleProvider);
+        var planner = new HeartbeatPlanner(_dslOptions.Heartbeat.Grace, Array.Empty<HeartbeatItem>(), _marketScheduleProvider);
         _hbRunner = new HeartbeatRunner(planner, sender, 0);
         _hbRunner.Start(appStopping);
     }

--- a/src/Query/Adapters/EntityModelAdapter.cs
+++ b/src/Query/Adapters/EntityModelAdapter.cs
@@ -53,7 +53,7 @@ internal static class EntityModelAdapter
                         Role.Live => TrimSuffix(baseNs, $"_{e.Timeframe.Value}{e.Timeframe.Unit}_live"),
                         Role.Final => TrimSuffix(baseNs, $"_{e.Timeframe.Value}{e.Timeframe.Unit}_final"),
                         Role.Prev1m => TrimSuffix(baseNs, "_prev_1m"),
-                        Role.Hb => TrimSuffix(baseNs, "_hb_1m"),
+                        Role.Hb => TrimSuffix(baseNs, $"_hb_{e.Timeframe.Value}{e.Timeframe.Unit}"),
                         _ => baseNs
                     };
                 }

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -41,6 +41,7 @@ internal static class DerivationPlanner
             var aggId = $"{baseId}_{tfStr}_agg_final";
             var liveId = $"{baseId}_{tfStr}_live";
             var finalId = $"{baseId}_{tfStr}_final";
+            var hbId = $"{baseId}_hb_{tfStr}";
 
             var agg = new DerivedEntity
             {
@@ -55,7 +56,7 @@ internal static class DerivationPlanner
             entities.Add(agg);
 
             var liveInput = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? $"{baseId}_1m_final" : $"{baseId}_1m_live";
-            var liveSync = tf.Unit == "m" && tf.Value == 1 ? $"{baseId}_hb_1m".ToUpperInvariant() : null;
+            var liveSync = hbId.ToUpperInvariant();
             var live = new DerivedEntity
             {
                 Id = liveId,
@@ -70,7 +71,7 @@ internal static class DerivationPlanner
             };
             entities.Add(live);
 
-            var finalInput = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? $"{baseId}_1m_final" : $"{baseId}_1m_live";
+            var finalInput = aggId;
             var final = new DerivedEntity
             {
                 Id = finalId,
@@ -85,21 +86,21 @@ internal static class DerivationPlanner
             };
             entities.Add(final);
 
+            var hb = new DerivedEntity
+            {
+                Id = hbId,
+                Role = Role.Hb,
+                Timeframe = tf,
+                KeyShape = keyShapes,
+                ValueShape = Array.Empty<ColumnShape>(),
+                MaterializationHint = MaterializationHint.Stream,
+                BasedOnSpec = basedOn,
+                WeekAnchor = qao.WeekAnchor
+            };
+            entities.Add(hb);
+
             if (tf.Unit == "m" && tf.Value == 1)
             {
-                var hb = new DerivedEntity
-                {
-                    Id = $"{baseId}_hb_1m",
-                    Role = Role.Hb,
-                    Timeframe = tf,
-                    KeyShape = keyShapes,
-                    ValueShape = Array.Empty<ColumnShape>(),
-                    MaterializationHint = MaterializationHint.Stream,
-                    BasedOnSpec = basedOn,
-                    WeekAnchor = qao.WeekAnchor
-                };
-                entities.Add(hb);
-
                 var prev = new DerivedEntity
                 {
                     Id = $"{baseId}_prev_1m",
@@ -108,7 +109,7 @@ internal static class DerivationPlanner
                     KeyShape = keyShapes,
                     ValueShape = valueShapes,
                     InputHint = $"{baseId}_1m_final",
-                    SyncHint = $"{baseId}_hb_1m".ToUpperInvariant(),
+                    SyncHint = hbId.ToUpperInvariant(),
                     BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor
                 };

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -63,7 +63,7 @@ internal static class DerivedTumblingPipeline
             Role.Live => $"{baseName}_{tf}_live",
             Role.Final => $"{baseName}_{tf}_final",
             Role.Prev1m => $"{baseName}_prev_1m",
-            Role.Hb => $"{baseName}_hb_1m",
+            Role.Hb => $"{baseName}_hb_{tf}",
             _ => $"{baseName}_{tf}"
         };
         var ddl = KsqlCreateWindowedStatementBuilder.Build(name, qm, tf);

--- a/src/Query/Builders/Core/RoleTraits.cs
+++ b/src/Query/Builders/Core/RoleTraits.cs
@@ -11,12 +11,11 @@ internal static class RoleTraits
 {
     public static OperationSpec For(Role role, Timeframe tf)
     {
-        var is1m = tf.Unit == "m" && tf.Value == 1;
         return role switch
         {
-            Role.Live => new(true, "CHANGES", false, false, is1m),
+            Role.Live => new(true, "CHANGES", false, false, true),
             Role.AggFinal => new(true, "FINAL GRACE", true, false, false),
-            Role.Final => new(true, "FINAL", true, false, is1m),
+            Role.Final => new(true, "FINAL", true, false, true),
             _ => new(false, null, false, false, false)
         };
     }

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -52,8 +52,10 @@ public class DerivationPlannerTests
         var entities = DerivationPlanner.Plan(Create(new Timeframe(1, "m")), model);
 
         Assert.Contains(entities, e => e.Id == "bar_1m_agg_final" && e.Role == Role.AggFinal);
-        Assert.Contains(entities, e => e.Id == "bar_1m_live" && e.Role == Role.Live);
+        var live = Assert.Single(entities, e => e.Id == "bar_1m_live" && e.Role == Role.Live);
+        Assert.Equal("BAR_HB_1M", live.SyncHint);
         var final = Assert.Single(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
+        Assert.Equal("bar_1m_agg_final", final.InputHint);
         Assert.Equal("bar_prev_1m", final.SyncHint);
         var prev = Assert.Single(entities, e => e.Id == "bar_prev_1m" && e.Role == Role.Prev1m);
         Assert.Equal("bar_1m_final", prev.InputHint);
@@ -62,16 +64,18 @@ public class DerivationPlannerTests
     }
 
     [Fact]
-    public void Plan_5m_Excludes_Hb()
+    public void Plan_5m_Includes_Hb()
     {
         var model = new EntityModel { EntityType = typeof(Source) };
         var entities = DerivationPlanner.Plan(Create(new Timeframe(5, "m")), model);
 
         Assert.Contains(entities, e => e.Id == "bar_5m_agg_final" && e.Role == Role.AggFinal);
-        Assert.Contains(entities, e => e.Id == "bar_5m_live" && e.Role == Role.Live);
+        var live5 = Assert.Single(entities, e => e.Id == "bar_5m_live" && e.Role == Role.Live);
+        Assert.Equal("BAR_HB_5M", live5.SyncHint);
         var final = Assert.Single(entities, e => e.Id == "bar_5m_final" && e.Role == Role.Final);
+        Assert.Equal("bar_5m_agg_final", final.InputHint);
         Assert.Equal("bar_prev_1m", final.SyncHint);
-        Assert.DoesNotContain(entities, e => e.Role == Role.Hb);
+        Assert.Contains(entities, e => e.Id == "bar_hb_5m" && e.Role == Role.Hb);
         Assert.DoesNotContain(entities, e => e.Role == Role.Prev1m);
     }
 }

--- a/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
@@ -59,7 +59,7 @@ public class DerivedTumblingPipelineConcurrencyTests
 
         await DerivedTumblingPipeline.RunAsync(qao, baseModel, model, Exec, Resolver, mapping, registry, new LoggerFactory().CreateLogger("test"));
 
-        var expected = 8; // 1m: AggFinal/Live/Final + Hb + Prev, 5m: AggFinal/Live/Final
+        var expected = 9; // 1m: AggFinal/Live/Final + Hb + Prev, 5m: AggFinal/Live/Final + Hb
         Assert.Equal(expected, registry.Count);
         Assert.Equal(expected, ddls.Count);
     }

--- a/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
@@ -67,6 +67,7 @@ public class DerivedTumblingPipelineTests
         Assert.Contains(ddls, s => s.Contains("_prev_1m"));
         Assert.Contains("EMIT CHANGES", live);
         Assert.Contains("EMIT FINAL", final);
+        Assert.DoesNotContain("_1m_live", final);
         Assert.False(model.IsFinal);
     }
 }

--- a/tests/Query/Builders/RollupBuilderTests.cs
+++ b/tests/Query/Builders/RollupBuilderTests.cs
@@ -135,6 +135,6 @@ public class RollupBuilderTests
         var specFinal = RoleTraits.For(Role.Final, new Timeframe(5, "m"));
         Assert.True(specFinal.Window);
         Assert.Equal("FINAL", specFinal.Emit);
-        Assert.False(specFinal.SyncHb1m);
+        Assert.True(specFinal.SyncHb1m);
     }
 }

--- a/tests/Runtime/Heartbeat/KsqlContextRunnerTests.cs
+++ b/tests/Runtime/Heartbeat/KsqlContextRunnerTests.cs
@@ -1,18 +1,21 @@
 using Confluent.SchemaRegistry;
 using Kafka.Ksql.Linq;
 using Kafka.Ksql.Linq.Configuration;
+using Kafka.Ksql.Linq.Configuration.Messaging;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Dlq;
 using Kafka.Ksql.Linq.Core.Modeling;
 using Kafka.Ksql.Linq.Mapping;
 using Kafka.Ksql.Linq.Messaging.Consumers;
 using Kafka.Ksql.Linq.Messaging.Producers;
+using Kafka.Ksql.Linq.Query.Dsl;
 using Kafka.Ksql.Linq.Runtime.Heartbeat;
 using Microsoft.Extensions.Options;
 using Moq;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -47,23 +50,13 @@ public class KsqlContextRunnerTests
 
     private class TumblingContext : KsqlContext
     {
-        public TumblingContext() : base(new KsqlDslOptions())
+        public TumblingContext(KsqlDslOptions? options = null) : base(options ?? new KsqlDslOptions())
         {
             typeof(KsqlContext).GetField("_schemaRegistryClient", BindingFlags.NonPublic | BindingFlags.Instance)!
                 .SetValue(this, new Lazy<ISchemaRegistryClient>(() => new Mock<ISchemaRegistryClient>().Object));
         }
         protected override bool SkipSchemaRegistration => true;
-        protected override void OnModelCreating(IModelBuilder builder)
-        {
-            builder.Entity<MarketSchedule>();
-            builder.Entity<TickView>().ToQuery(q => q.From<Tick>()
-                .TimeFrame<MarketSchedule>(
-                    (r, s) => r.Broker == s.Broker && r.Symbol == s.Symbol && s.Open <= r.Timestamp && r.Timestamp < s.Close,
-                    s => s.MarketDate)
-                .Tumbling(t => t.Timestamp, minutes: new[] { 1 })
-                .GroupBy(t => new { t.Broker, t.Symbol, BucketStart = t.Timestamp })
-                .Select(g => new TickView { Broker = g.Key.Broker, Symbol = g.Key.Symbol, BucketStart = g.Key.BucketStart }));
-        }
+        protected override void OnModelCreating(IModelBuilder builder) { }
     }
 
     private class FakeManager : KafkaConsumerManager
@@ -164,5 +157,44 @@ public class KsqlContextRunnerTests
 
         ctx.StartHeartbeatRunnerAsync(CancellationToken.None).GetAwaiter().GetResult();
         setMock.Verify(s => s.ToListAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public void StartHeartbeatRunner_Uses_Grace_From_Options()
+    {
+        var opts = new KsqlDslOptions { Heartbeat = new HeartbeatOptions { Grace = TimeSpan.FromSeconds(5) } };
+        var ctx = new TumblingContext(opts);
+        var fake = new FakeManager();
+        typeof(KsqlContext).GetField("_consumerManager", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(ctx, fake);
+
+        var setMock = new Mock<IEntitySet<MarketSchedule>>();
+        setMock.Setup(s => s.ToListAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<MarketSchedule>());
+        typeof(KsqlContext).GetField("_entitySets", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(ctx, new Dictionary<Type, object> { { typeof(MarketSchedule), setMock.Object } });
+
+        var qm = new KsqlQueryModel { BasedOnType = typeof(MarketSchedule) };
+        qm.Windows.Add("1");
+        var model = new EntityModel { EntityType = typeof(Tick), QueryModel = qm };
+        var models = new ConcurrentDictionary<Type, EntityModel>();
+        models[typeof(Tick)] = model;
+        typeof(KsqlContext).GetField("_entityModels", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(ctx, models);
+
+        var provider = new Mock<IMarketScheduleProvider>();
+        provider.Setup(p => p.InitializeAsync(typeof(MarketSchedule), It.IsAny<IEnumerable>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        typeof(KsqlContext).GetField("_marketScheduleProvider", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(ctx, provider.Object);
+
+        ctx.StartHeartbeatRunnerAsync(CancellationToken.None).GetAwaiter().GetResult();
+
+        var runner = (HeartbeatRunner)typeof(KsqlContext).GetField("_hbRunner", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(ctx)!;
+        var planner = (HeartbeatPlanner)typeof(HeartbeatRunner).GetField("_planner", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(runner)!;
+        var grace = (TimeSpan)typeof(HeartbeatPlanner).GetField("_grace", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(planner)!;
+        Assert.Equal(TimeSpan.FromSeconds(5), grace);
     }
 }


### PR DESCRIPTION
## Summary
- plan finals from agg_final and prev_1m instead of live topics
- emit heartbeat entities for all timeframes and sync live streams to them
- adjust planning/build tests to cover new heartbeat wiring
- allow configurable heartbeat grace when starting the runner

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter 'FullyQualifiedName!~Integration'`

------
https://chatgpt.com/codex/tasks/task_e_68be7479a9e48327be2b88dfdcb0c2cd