### PR TITLE
feat: parse select for windowstart alias

### DIFF
--- a/docs/diff_log/diff_windowstart_parser_20250908.md
+++ b/docs/diff_log/diff_windowstart_parser_20250908.md
@@ -1,0 +1,4 @@
+# diff_windowstart_parser_20250908
+
+- replace regex with parser for BucketStart injection
+- add tests for complex SELECT clauses

--- a/docs/diff_log/diff_windowstart_parser_20250910.md
+++ b/docs/diff_log/diff_windowstart_parser_20250910.md
@@ -1,0 +1,4 @@
+# diff_windowstart_parser_20250910
+
+- allow custom alias from WindowStart() instead of fixed BucketStart
+- add tests for custom alias handling

--- a/features/windowstart_parser/instruction.md
+++ b/features/windowstart_parser/instruction.md
@@ -1,0 +1,4 @@
+# windowstart_parser
+
+Replace regex-based BucketStart injection with parser-aware logic.
+Use the alias provided via `WindowStart()` instead of a fixed `BucketStart`.

--- a/src/Query/Builders/KsqlCreateWindowedStatementBuilder.cs
+++ b/src/Query/Builders/KsqlCreateWindowedStatementBuilder.cs
@@ -1,6 +1,7 @@
 using Kafka.Ksql.Linq.Query.Dsl;
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Kafka.Ksql.Linq.Query.Builders;
@@ -18,12 +19,7 @@ internal static class KsqlCreateWindowedStatementBuilder
         if (string.IsNullOrWhiteSpace(timeframe)) throw new ArgumentException("timeframe required", nameof(timeframe));
         var baseSql = KsqlCreateStatementBuilder.Build(name, model);
         if (model.IsFinal)
-        {
-            // remove any existing BucketStart alias from the SELECT list; regex scope is limited to SELECT
-            // TODO: anchor to the SELECT segment explicitly if the builder ever rewrites other clauses
-            baseSql = Regex.Replace(baseSql, @",\s*[^,]*?AS BucketStart", string.Empty, RegexOptions.IgnoreCase);
-            baseSql = baseSql.Replace("SELECT ", "SELECT WINDOWSTART AS BucketStart, ");
-        }
+            baseSql = InjectWindowStart(baseSql);
         var window = FormatWindow(model, timeframe);
         var sql = InjectWindowAfterFrom(baseSql, window);
         sql = InjectEmitMode(sql, model);
@@ -41,6 +37,87 @@ internal static class KsqlCreateWindowedStatementBuilder
             result[tf] = Build(name, model, tf);
         }
         return result;
+    }
+
+    internal static string InjectWindowStart(string sql)
+    {
+        var selectIdx = sql.IndexOf("SELECT", StringComparison.OrdinalIgnoreCase);
+        if (selectIdx < 0) return sql;
+        var fromIdx = FindFrom(sql, selectIdx + 6);
+        var body = sql.Substring(selectIdx + 6, fromIdx - (selectIdx + 6));
+        var items = Split(body);
+        string? alias = null;
+        for (var i = 0; i < items.Count; i++)
+        {
+            var trimmed = items[i].TrimStart();
+            if (trimmed.StartsWith("WINDOWSTART", StringComparison.OrdinalIgnoreCase))
+            {
+                alias = ExtractAlias(trimmed);
+                items.RemoveAt(i);
+                break;
+            }
+        }
+        alias ??= "BucketStart";
+        items.Insert(0, $"WINDOWSTART AS {alias}");
+        var rebuilt = string.Join(", ", items);
+        return sql.Substring(0, selectIdx + 6) + " " + rebuilt + " " + sql.Substring(fromIdx);
+    }
+
+    private static string ExtractAlias(string item)
+    {
+        var idx = item.IndexOf("AS", StringComparison.OrdinalIgnoreCase);
+        return idx >= 0 ? item[(idx + 2)..].Trim() : "BucketStart";
+    }
+
+    private static int FindFrom(string sql, int start)
+    {
+        var depth = 0; var single = false; var dbl = false;
+        for (var i = start; i < sql.Length - 3; i++)
+        {
+            var c = sql[i];
+            if (c == '\'' && !dbl) single = !single;
+            else if (c == '"' && !single) dbl = !dbl;
+            else if (!single && !dbl)
+            {
+                if (c == '(') depth++;
+                else if (c == ')') depth--;
+                else if (depth == 0 && (c == 'F' || c == 'f') &&
+                         sql.AsSpan(i, 4).Equals("from", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (i == 0 || char.IsWhiteSpace(sql[i - 1])) return i;
+                }
+            }
+        }
+        return sql.Length;
+    }
+
+    private static List<string> Split(string body)
+    {
+        var list = new List<string>();
+        var sb = new StringBuilder();
+        var depth = 0; var single = false; var dbl = false;
+        foreach (var c in body)
+        {
+            if (c == ',' && depth == 0 && !single && !dbl)
+            {
+                list.Add(sb.ToString().Trim());
+                sb.Clear();
+            }
+            else
+            {
+                sb.Append(c);
+                if (c == '\'' && !dbl) single = !single;
+                else if (c == '"' && !single) dbl = !dbl;
+                else if (!single && !dbl)
+                {
+                    if (c == '(') depth++;
+                    else if (c == ')') depth--;
+                }
+            }
+        }
+        var last = sb.ToString().Trim();
+        if (last.Length > 0) list.Add(last);
+        return list;
     }
 
     private static string FormatWindow(KsqlQueryModel model, string timeframe)

--- a/tests/Query/Builders/KsqlCreateWindowedStatementBuilderTests.cs
+++ b/tests/Query/Builders/KsqlCreateWindowedStatementBuilderTests.cs
@@ -158,6 +158,21 @@ public class KsqlCreateWindowedStatementBuilderTests
     }
 
     [Fact]
+    public void Build_Final_Uses_Custom_WindowStart_Alias()
+    {
+        var model = new KsqlQueryRoot()
+            .From<RateTable>()
+            .Tumbling(r => r.Timestamp, minutes: new[] { 1 })
+            .GroupBy(r => new { r.Broker, r.Symbol, StartAt = r.Timestamp })
+            .Select(g => new { g.Key.Broker, g.Key.Symbol, StartAt = g.WindowStart(), Open = g.EarliestByOffset(x => x.Bid) })
+            .AsFinal()
+            .AsPush()
+            .Build();
+        var sql = Kafka.Ksql.Linq.Query.Builders.KsqlCreateWindowedStatementBuilder.Build("bar_1m_final", model, "1m");
+        Assert.Contains("SELECT WINDOWSTART AS StartAt", sql);
+    }
+
+    [Fact]
     public void Build_NoWindow_Creates_Stream()
     {
         var model = new KsqlQueryRoot()
@@ -168,6 +183,30 @@ public class KsqlCreateWindowedStatementBuilderTests
 
         var sql = Kafka.Ksql.Linq.Query.Builders.KsqlCreateStatementBuilder.Build("rates", model);
         Assert.StartsWith("CREATE STREAM rates", sql);
+    }
+
+    [Fact]
+    public void InjectWindowStart_Handles_Complex_Select()
+    {
+        var sql = "SELECT Price, CONCAT('BucketStart', Symbol) AS Label, Value AS BucketStartValue FROM Rates GROUP BY BucketStart";
+        var result = Kafka.Ksql.Linq.Query.Builders.KsqlCreateWindowedStatementBuilder.InjectWindowStart(sql);
+        Assert.Equal("SELECT WINDOWSTART AS BucketStart, Price, CONCAT('BucketStart', Symbol) AS Label, Value AS BucketStartValue FROM Rates GROUP BY BucketStart", result);
+    }
+
+    [Fact]
+    public void InjectWindowStart_Does_Not_Duplicate()
+    {
+        var sql = "SELECT WINDOWSTART AS StartAt, Price FROM Rates";
+        var result = Kafka.Ksql.Linq.Query.Builders.KsqlCreateWindowedStatementBuilder.InjectWindowStart(sql);
+        Assert.Equal(sql, result);
+    }
+
+    [Fact]
+    public void InjectWindowStart_Uses_Custom_Alias()
+    {
+        var sql = "SELECT Price, WINDOWSTART AS StartAt FROM Rates";
+        var result = Kafka.Ksql.Linq.Query.Builders.KsqlCreateWindowedStatementBuilder.InjectWindowStart(sql);
+        Assert.Equal("SELECT WINDOWSTART AS StartAt, Price FROM Rates", result);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- replace regex with parser-aware SELECT rewrite
- allow custom alias from `WindowStart()` and ensure single injection
- add tests for custom alias and complex SELECT clauses

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68be7af728388327b810731dae1eb27c