### PR TITLE
Capture tumbling time key in query model

### DIFF
--- a/src/KsqlContext.SchemaRegistration.cs
+++ b/src/KsqlContext.SchemaRegistration.cs
@@ -436,9 +436,9 @@ public abstract partial class KsqlContext
             var keys = m.KeyProperties.Select(p => p.Name).ToArray();
             var basedOnKeys = m.QueryModel.BasedOnJoinKeys.Count > 0 ? m.QueryModel.BasedOnJoinKeys.ToArray() : keys;
             var dayKey = PropertyName(m.QueryModel.BasedOnDayKey);
-            var timeKey = m.AllProperties.FirstOrDefault(p => p.GetCustomAttribute<KsqlTimestampAttribute>() != null)?.Name
-                ?? m.QueryModel!.TimeKey
-                ?? "Timestamp";
+            var timeKey = m.QueryModel!.TimeKey
+                ?? m.AllProperties.FirstOrDefault(p => p.GetCustomAttribute<KsqlTimestampAttribute>() != null)?.Name
+                ?? string.Empty;
             var projection = m.AllProperties.Select(p => p.Name).Where(n => !keys.Contains(n)).ToArray();
             var basedOnOpen = m.QueryModel.BasedOnOpen ?? string.Empty;
             var basedOnClose = m.QueryModel.BasedOnClose ?? string.Empty;

--- a/src/Query/Dsl/KsqlQueryable.cs
+++ b/src/Query/Dsl/KsqlQueryable.cs
@@ -66,7 +66,10 @@ public class KsqlQueryable<T1> : IKsqlQueryable, IScheduledScope<T1>
         DayOfWeek? week = null,
         TimeSpan? grace = null)
     {
-        _ = time;
+        if (time.Body is MemberExpression me)
+            _model.TimeKey = me.Member.Name;
+        else if (time.Body is UnaryExpression ue && ue.Operand is MemberExpression me2)
+            _model.TimeKey = me2.Member.Name;
         if (grace.HasValue)
             _model.GraceSeconds = (int)Math.Ceiling(grace.Value.TotalSeconds);
         if (minutes != null) foreach (var m in minutes) _model.Windows.Add($"{m}m");

--- a/tests/Query/Dsl/PropertyNameParsingTests.cs
+++ b/tests/Query/Dsl/PropertyNameParsingTests.cs
@@ -44,6 +44,15 @@ public class PropertyNameParsingTests
     }
 
     [Fact]
+    public void Tumbling_Sets_TimeKey_On_Model()
+    {
+        var model = new KsqlQueryable<Rate>()
+            .Tumbling(r => r.Timestamp, minutes: new[] { 1 })
+            .Build();
+        Assert.Equal("Timestamp", model.TimeKey);
+    }
+
+    [Fact]
     public void TimeFrame_Extracts_DayKey()
     {
         var q = Expression.Parameter(typeof(KsqlQueryable<Rate>), "q");


### PR DESCRIPTION
## Summary
- record time key from tumbling expression into query model
- use query model's time key when building tumbling QAO
- verify tumbling assigns time key to query model

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -c Release`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68be91de69f883278e90786d2f3322ec