### PR TITLE
Handle prev fallback via dedicated hints

### DIFF
--- a/docs/diff_log/diff_prevhint_20250908.md
+++ b/docs/diff_log/diff_prevhint_20250908.md
@@ -1,0 +1,2 @@
+- final entities now sync on heartbeat topics
+- added PrevHint for prev_1m fallback and propagated to builders

--- a/docs/diff_log/diff_prevhint_20250909.md
+++ b/docs/diff_log/diff_prevhint_20250909.md
@@ -1,0 +1,1 @@
+- derive prev and heartbeat topics from POCO's KsqlTopic attribute

--- a/src/Query/Adapters/EntityModelAdapter.cs
+++ b/src/Query/Adapters/EntityModelAdapter.cs
@@ -41,6 +41,7 @@ internal static class EntityModelAdapter
             model.AdditionalSettings["timeframe"] = $"{e.Timeframe.Value}{e.Timeframe.Unit}";
             if (e.SyncHint != null) model.AdditionalSettings[$"sync"] = e.SyncHint;
             if (e.InputHint != null) model.AdditionalSettings[$"input"] = e.InputHint;
+            if (e.PrevHint != null) model.AdditionalSettings[$"prev"] = e.PrevHint;
             var nsSource = e.TopicHint ?? e.Id;
             if (!string.IsNullOrWhiteSpace(nsSource))
             {

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -80,7 +80,8 @@ internal static class DerivationPlanner
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
                 InputHint = finalInput,
-                SyncHint = $"{baseId}_prev_1m",
+                SyncHint = hbId.ToUpperInvariant(),
+                PrevHint = $"{baseId}_prev_1m",
                 BasedOnSpec = basedOn,
                 WeekAnchor = qao.WeekAnchor
             };

--- a/src/Query/Analysis/DerivedEntity.cs
+++ b/src/Query/Analysis/DerivedEntity.cs
@@ -31,6 +31,7 @@ internal class DerivedEntity
     public string? TopicHint { get; init; }
     public string? InputHint { get; init; }
     public string? SyncHint { get; init; }
+    public string? PrevHint { get; init; }
     public BasedOnSpec BasedOnSpec { get; init; } = new(new List<string>(), string.Empty, string.Empty, string.Empty);
     public DayOfWeek WeekAnchor { get; init; } = DayOfWeek.Monday;
 }

--- a/src/Query/Builders/Core/WindowedQueryBuilder.cs
+++ b/src/Query/Builders/Core/WindowedQueryBuilder.cs
@@ -34,6 +34,12 @@ internal static class WindowedQueryBuilder
             if (sync != null)
                 sb.Append(' ').Append(QueryBuilderUtils.ApplySync_HB1m(sync));
         }
+        if (role == Role.Final)
+        {
+            var prev = md.GetProperty<string>($"prev/{tfStr}{roleName}");
+            if (prev != null)
+                sb.Append(' ').Append(QueryBuilderUtils.ApplyPrev_1m(prev));
+        }
         sb.Append(' ').Append(QueryBuilderUtils.ApplyTimeFrame(md));
         var sql = sb.ToString().Trim();
         if (role == Role.Final && sql.Contains("COMPOSE(", System.StringComparison.OrdinalIgnoreCase))

--- a/src/Query/Builders/Utils/QueryBuilderUtils.cs
+++ b/src/Query/Builders/Utils/QueryBuilderUtils.cs
@@ -27,4 +27,6 @@ internal static class QueryBuilderUtils
     public static string ApplyProjector_BucketStartFromWindowStart() => "SELECT WINDOWSTART AS BucketStart";
 
     public static string ApplySync_HB1m(string sync) => $"SYNC {sync}";
+
+    public static string ApplyPrev_1m(string prev) => $"PREV {prev}";
 }

--- a/src/Query/Pipeline/DDLQueryGenerator.cs
+++ b/src/Query/Pipeline/DDLQueryGenerator.cs
@@ -398,6 +398,9 @@ internal class DDLQueryGenerator : GeneratorBase, IDDLQueryGenerator
         var visitor = new MethodCallCollectorVisitor();
         visitor.Visit(expression);
         var result = visitor.Result;
+        var type = expression.Type.IsGenericType ? expression.Type.GetGenericArguments().FirstOrDefault() : null;
+        if (type != null)
+            result.PocoType = type;
         if (result.Windows.Count > 0)
         {
             if (result.TimeKey == null)

--- a/src/Query/Pipeline/DMLQueryGenerator.cs
+++ b/src/Query/Pipeline/DMLQueryGenerator.cs
@@ -408,6 +408,9 @@ internal class DMLQueryGenerator : GeneratorBase, IDMLQueryGenerator
         var visitor = new MethodCallCollectorVisitor();
         visitor.Visit(expression);
         var result = visitor.Result;
+        var type = expression.Type.IsGenericType ? expression.Type.GetGenericArguments().FirstOrDefault() : null;
+        if (type != null)
+            result.PocoType = type;
         if (result.Windows.Count > 0)
         {
             if (result.TimeKey == null)

--- a/src/Query/Pipeline/ExpressionAnalysisResult.cs
+++ b/src/Query/Pipeline/ExpressionAnalysisResult.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
+using Kafka.Ksql.Linq.Core.Attributes;
 
 namespace Kafka.Ksql.Linq.Query.Pipeline;
 
@@ -25,6 +27,7 @@ internal class ExpressionAnalysisResult
     public bool BasedOnOpenInclusive { get; set; } = true;
     public bool BasedOnCloseInclusive { get; set; } = false;
     public string? BasedOnDayKey { get; set; }
+    public Type? PocoType { get; set; }
 
     private static bool IsAggregateMethod(string methodName)
     {
@@ -48,18 +51,28 @@ internal class ExpressionAnalysisResult
         md = md.WithProperty("roles/final", Windows.ToArray());
         md = md.WithProperty("roles/prev", new[] { "1m" });
         md = md.WithProperty("roles/hb", new[] { "1m" });
-        md = md.WithProperty("sync/1mLive", "HB_1m");
-        md = md.WithProperty("sync/1mFinal", "HB_1m");
-        foreach (var tf in Windows)
+
+        if (PocoType != null)
         {
-            var liveInput = tf switch
+            var topicAttr = PocoType.GetCustomAttribute<KsqlTopicAttribute>();
+            var baseId = (topicAttr?.Name ?? PocoType.Name).ToLowerInvariant();
+            var hb = $"{baseId}_hb_1m".ToUpperInvariant();
+            var prevId = $"{baseId}_prev_1m";
+            md = md.WithProperty("sync/1mLive", hb);
+            md = md.WithProperty("sync/1mFinal", hb);
+            md = md.WithProperty("prev/1mFinal", prevId);
+            foreach (var tf in Windows)
             {
-                "1m" => "10sAgg",
-                "1wk" => "bar_1m_final",
-                _ => "bar_1m_live"
-            };
-            md = md.WithProperty($"input/{tf}Live", liveInput);
-            md = md.WithProperty($"input/{tf}Final", liveInput);
+                var liveInput = tf switch
+                {
+                    "1m" => "10sAgg",
+                    "1wk" => $"{baseId}_1m_final",
+                    _ => $"{baseId}_1m_live"
+                };
+                md = md.WithProperty($"input/{tf}Live", liveInput);
+                md = md.WithProperty($"input/{tf}Final", liveInput);
+                md = md.WithProperty($"prev/{tf}Final", prevId);
+            }
         }
         return md;
     }

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -56,7 +56,8 @@ public class DerivationPlannerTests
         Assert.Equal("BAR_HB_1M", live.SyncHint);
         var final = Assert.Single(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
         Assert.Equal("bar_1m_agg_final", final.InputHint);
-        Assert.Equal("bar_prev_1m", final.SyncHint);
+        Assert.Equal("BAR_HB_1M", final.SyncHint);
+        Assert.Equal("bar_prev_1m", final.PrevHint);
         var prev = Assert.Single(entities, e => e.Id == "bar_prev_1m" && e.Role == Role.Prev1m);
         Assert.Equal("bar_1m_final", prev.InputHint);
         Assert.Equal("BAR_HB_1M", prev.SyncHint);
@@ -74,7 +75,8 @@ public class DerivationPlannerTests
         Assert.Equal("BAR_HB_5M", live5.SyncHint);
         var final = Assert.Single(entities, e => e.Id == "bar_5m_final" && e.Role == Role.Final);
         Assert.Equal("bar_5m_agg_final", final.InputHint);
-        Assert.Equal("bar_prev_1m", final.SyncHint);
+        Assert.Equal("BAR_HB_5M", final.SyncHint);
+        Assert.Equal("bar_prev_1m", final.PrevHint);
         Assert.Contains(entities, e => e.Id == "bar_hb_5m" && e.Role == Role.Hb);
         Assert.DoesNotContain(entities, e => e.Role == Role.Prev1m);
     }

--- a/tests/Query/Builders/RollupBuilderTests.cs
+++ b/tests/Query/Builders/RollupBuilderTests.cs
@@ -1,3 +1,4 @@
+using Kafka.Ksql.Linq.Core.Attributes;
 using Kafka.Ksql.Linq.Query.Analysis;
 using Kafka.Ksql.Linq.Query.Builders;
 using Kafka.Ksql.Linq.Query.Builders.Core;
@@ -11,6 +12,7 @@ namespace Kafka.Ksql.Linq.Tests.Query.Builders;
 
 public class RollupBuilderTests
 {
+    [KsqlTopic("bar")]
     private class Rate
     {
         public string Broker { get; set; } = string.Empty;
@@ -53,6 +55,7 @@ public class RollupBuilderTests
         var visitor = new MethodCallCollectorVisitor();
         visitor.Visit(expr);
         var result = visitor.Result;
+        result.PocoType = typeof(Rate);
         if (result.Windows.Count == 0)
             throw new InvalidOperationException("Tumbling windows are required");
         if (result.TimeKey == null)
@@ -79,7 +82,7 @@ public class RollupBuilderTests
         var sql = LiveBuilder.Build(md, "1m");
         Assert.Contains("TABLE 10sAgg WINDOW TUMBLING(1m)", sql);
         Assert.Contains("EMIT CHANGES", sql);
-        Assert.Contains("SYNC HB_1m", sql);
+        Assert.Contains("SYNC BAR_HB_1M", sql);
     }
 
     [Fact]
@@ -88,7 +91,7 @@ public class RollupBuilderTests
         var md = BuildMetadata();
         var sql = LiveBuilder.Build(md, "5m");
         Assert.Contains("TABLE bar_1m_live WINDOW TUMBLING(5m)", sql);
-        Assert.DoesNotContain("HB_1m", sql);
+        Assert.DoesNotContain("BAR_HB_1M", sql);
     }
 
     [Fact]
@@ -98,11 +101,11 @@ public class RollupBuilderTests
         var sql = FinalBuilder.Build(md, "5m");
         Assert.Contains("TABLE bar_1m_live WINDOW TUMBLING(5m)", sql);
         Assert.Contains("EMIT FINAL", sql);
-        Assert.DoesNotContain("HB_1m", sql);
+        Assert.DoesNotContain("BAR_HB_1M", sql);
         Assert.DoesNotContain("COMPOSE(", sql);
         var sql1 = FinalBuilder.Build(md, "1m");
         Assert.Contains("TABLE 10sAgg WINDOW TUMBLING(1m)", sql1);
-        Assert.Contains("SYNC HB_1m", sql1);
+        Assert.Contains("SYNC BAR_HB_1M", sql1);
         Assert.DoesNotContain("COMPOSE(", sql1);
     }
 

--- a/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
+++ b/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
@@ -44,12 +44,14 @@ public class WindowedQueryBuilderCoreTests
     {
         var md1 = BaseMd()
             .WithProperty("input/1mFinal", "src1")
-            .WithProperty("sync/1mFinal", "HB_1m");
+            .WithProperty("sync/1mFinal", "HB_1m")
+            .WithProperty("prev/1mFinal", "bar_prev_1m");
         var q1 = FinalBuilder.Build(md1, "1m");
         Assert.StartsWith("TABLE src1", q1);
         Assert.Contains("WINDOW TUMBLING(1m)", q1);
         Assert.Contains("EMIT FINAL", q1);
         Assert.Contains("SYNC HB_1m", q1);
+        Assert.Contains("PREV bar_prev_1m", q1);
         Assert.DoesNotContain("COMPOSE(", q1);
 
         var md5 = BaseMd().WithProperty("input/5mFinal", "src5");


### PR DESCRIPTION
## Summary
- sync final entities on heartbeat topics and track prev_1m fallback separately
- honor PrevHint in entity adaptation and query builders
- derive prev/heartbeat names from POCO's KsqlTopic attribute

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68be9559bbc483279aef7003af18cdf3