### PR TITLE
Use live sources for weekly rollups

### DIFF
--- a/docs/diff_log/diff_derivationplanner_live_input_20250908.md
+++ b/docs/diff_log/diff_derivationplanner_live_input_20250908.md
@@ -1,0 +1,4 @@
+# Diff: DerivationPlanner live input
+
+- Weekly windows now consume daily live topics instead of 1m final.
+- Tests ensure live rollups derive from live inputs.

--- a/features/derivationplanner_live_input/instruction.md
+++ b/features/derivationplanner_live_input/instruction.md
@@ -1,0 +1,3 @@
+# DerivationPlanner live input
+
+Weekly windows should consume daily live topics. See docs/diff_log/diff_derivationplanner_live_input_20250908.md for details.

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -55,7 +55,11 @@ internal static class DerivationPlanner
             };
             entities.Add(agg);
 
-            var liveInput = tf.Unit == "m" && tf.Value == 1 ? "10sAgg" : tf.Unit == "wk" ? $"{baseId}_1m_final" : $"{baseId}_1m_live";
+            var liveInput = tf.Unit == "m" && tf.Value == 1
+                ? "10sAgg"
+                : tf.Unit == "wk"
+                    ? $"{baseId}_1d_live"
+                    : $"{baseId}_1m_live";
             var liveSync = hbId.ToUpperInvariant();
             var live = new DerivedEntity
             {

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -53,6 +53,7 @@ public class DerivationPlannerTests
 
         Assert.Contains(entities, e => e.Id == "bar_1m_agg_final" && e.Role == Role.AggFinal);
         var live = Assert.Single(entities, e => e.Id == "bar_1m_live" && e.Role == Role.Live);
+        Assert.Equal("10sAgg", live.InputHint);
         Assert.Equal("BAR_HB_1M", live.SyncHint);
         var final = Assert.Single(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
         Assert.Equal("bar_1m_agg_final", final.InputHint);
@@ -72,6 +73,7 @@ public class DerivationPlannerTests
 
         Assert.Contains(entities, e => e.Id == "bar_5m_agg_final" && e.Role == Role.AggFinal);
         var live5 = Assert.Single(entities, e => e.Id == "bar_5m_live" && e.Role == Role.Live);
+        Assert.Equal("bar_1m_live", live5.InputHint);
         Assert.Equal("BAR_HB_5M", live5.SyncHint);
         var final = Assert.Single(entities, e => e.Id == "bar_5m_final" && e.Role == Role.Final);
         Assert.Equal("bar_5m_agg_final", final.InputHint);
@@ -79,5 +81,15 @@ public class DerivationPlannerTests
         Assert.Equal("bar_prev_1m", final.PrevHint);
         Assert.Contains(entities, e => e.Id == "bar_hb_5m" && e.Role == Role.Hb);
         Assert.DoesNotContain(entities, e => e.Role == Role.Prev1m);
+    }
+
+    [Fact]
+    public void Plan_1wk_Live_Uses_1d_Live_Input()
+    {
+        var model = new EntityModel { EntityType = typeof(Source) };
+        var entities = DerivationPlanner.Plan(Create(new Timeframe(1, "wk")), model);
+
+        var live = Assert.Single(entities, e => e.Id == "bar_1wk_live" && e.Role == Role.Live);
+        Assert.Equal("bar_1d_live", live.InputHint);
     }
 }


### PR DESCRIPTION
## Summary
- Feed weekly live windows from daily live topics instead of 1m final
- Ensure live rollups always derive from live inputs via unit tests

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68be994b23f08327bd210b9c4b5b1873