### PR TITLE
Capture time key and grace for join tumbling windows

### DIFF
--- a/docs/diff_log/diff_ksqlqueryable2_tumbling_timekey_grace_20250908.md
+++ b/docs/diff_log/diff_ksqlqueryable2_tumbling_timekey_grace_20250908.md
@@ -1,0 +1,3 @@
+- KsqlQueryable2.Tumbling now extracts the time property name and stores it in the query model.
+- Optional grace periods are recorded as seconds via `GraceSeconds`.
+- Window sizes are deduplicated and ordered for consistent queries.

--- a/src/Query/Dsl/KsqlQueryable2.cs
+++ b/src/Query/Dsl/KsqlQueryable2.cs
@@ -63,7 +63,12 @@ public class KsqlQueryable2<T1, T2> : IKsqlQueryable
         DayOfWeek? week = null,
         TimeSpan? grace = null)
     {
-        _ = time;
+        if (time.Body is MemberExpression me)
+            _model.TimeKey = me.Member.Name;
+        else if (time.Body is UnaryExpression ue && ue.Operand is MemberExpression me2)
+            _model.TimeKey = me2.Member.Name;
+        if (grace.HasValue)
+            _model.GraceSeconds = (int)Math.Ceiling(grace.Value.TotalSeconds);
         if (minutes != null) foreach (var m in minutes) _model.Windows.Add($"{m}m");
         if (hours != null) foreach (var h in hours) _model.Windows.Add($"{h}h");
         if (days != null) foreach (var d in days) _model.Windows.Add($"{d}d");

--- a/tests/Query/Dsl/PropertyNameParsingTests.cs
+++ b/tests/Query/Dsl/PropertyNameParsingTests.cs
@@ -74,5 +74,38 @@ public class PropertyNameParsingTests
         visitor.Visit(call);
         Assert.Equal("Day", visitor.Result.BasedOnDayKey);
     }
+
+    [Fact]
+    public void Tumbling2_Extracts_TimeKey()
+    {
+        var q = Expression.Parameter(typeof(KsqlQueryable2<Rate, Schedule>), "q");
+        var r = Expression.Parameter(typeof(Rate), "r");
+        var s = Expression.Parameter(typeof(Schedule), "s");
+        var timeLambda = Expression.Lambda(Expression.Property(r, nameof(Rate.Timestamp)), r, s);
+        var method = typeof(KsqlQueryable2<Rate, Schedule>).GetMethods()
+            .First(m => m.Name == "Tumbling" && m.GetParameters().Length == 7);
+        var call = Expression.Call(q, method,
+            timeLambda,
+            Expression.Constant(new[] { 1 }),
+            Expression.Constant(null, typeof(int[])),
+            Expression.Constant(null, typeof(int[])),
+            Expression.Constant(null, typeof(int[])),
+            Expression.Constant(null, typeof(DayOfWeek?)),
+            Expression.Constant(null, typeof(TimeSpan?)));
+        var visitor = new MethodCallCollectorVisitor();
+        visitor.Visit(call);
+        Assert.Equal("Timestamp", visitor.Result.TimeKey);
+    }
+
+    [Fact]
+    public void Tumbling2_Sets_TimeKey_Grace_And_Orders_Windows()
+    {
+        var model = new KsqlQueryable2<Rate, Schedule>()
+            .Tumbling((r, s) => r.Timestamp, minutes: new[] { 90, 15, 15 }, hours: new[] { 1 }, grace: TimeSpan.FromSeconds(30))
+            .Build();
+        Assert.Equal("Timestamp", model.TimeKey);
+        Assert.Equal(30, model.GraceSeconds);
+        Assert.Equal(new[] { "15m", "1h", "90m" }, model.Windows);
+    }
 }
 


### PR DESCRIPTION
## Summary
- parse time expression in `KsqlQueryable2.Tumbling` to set `TimeKey`
- persist optional grace periods via `GraceSeconds`
- ensure tumbling windows are deduplicated and ordered
- add tests for two-source tumbling window time key, grace, and window ordering

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68be9ffcbc8c8327b74005cb50565274