### PR TITLE
Chain live inputs across ordered windows

### DIFF
--- a/docs/diff_log/diff_derivationplanner_live_chaining_20250908.md
+++ b/docs/diff_log/diff_derivationplanner_live_chaining_20250908.md
@@ -1,0 +1,5 @@
+# DerivationPlanner window chaining
+
+- windows ordered by size before planning
+- live topics for larger windows consume previous window's live topic
+- tests cover hour and day chaining

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -33,7 +33,18 @@ internal static class DerivationPlanner
             }
         }
 
-        foreach (var tf in qao.Windows)
+        var windows = qao.Windows
+            .OrderBy(w => w.Unit switch
+            {
+                "m" => w.Value,
+                "h" => w.Value * 60,
+                "d" => w.Value * 1440,
+                "wk" => w.Value * 10080,
+                _ => w.Value
+            })
+            .ToArray();
+        Timeframe? prevWindow = null;
+        foreach (var tf in windows)
         {
             var tfStr = $"{tf.Value}{tf.Unit}";
             var topicAttr = model.EntityType.GetCustomAttribute<KsqlTopicAttribute>();
@@ -55,11 +66,13 @@ internal static class DerivationPlanner
             };
             entities.Add(agg);
 
-            var liveInput = tf.Unit == "m" && tf.Value == 1
-                ? "10sAgg"
-                : tf.Unit == "wk"
-                    ? $"{baseId}_1d_live"
-                    : $"{baseId}_1m_live";
+            var liveInput = prevWindow == null
+                ? tf.Unit == "m" && tf.Value == 1
+                    ? "10sAgg"
+                    : tf.Unit == "wk"
+                        ? $"{baseId}_1d_live"
+                        : $"{baseId}_1m_live"
+                : $"{baseId}_{prevWindow.Value}{prevWindow.Unit}_live";
             var liveSync = hbId.ToUpperInvariant();
             var live = new DerivedEntity
             {
@@ -120,6 +133,7 @@ internal static class DerivationPlanner
                 };
                 entities.Add(prev);
             }
+            prevWindow = tf;
         }
         return entities;
     }

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -29,10 +29,10 @@ public class DerivationPlannerTests
         public double KsqlTimeFrameClose { get; set; }
     }
 
-    private static TumblingQao Create(Timeframe tf) => new()
+    private static TumblingQao Create(params Timeframe[] tfs) => new()
     {
         TimeKey = "Timestamp",
-        Windows = new[] { tf },
+        Windows = tfs,
         Keys = new[] { "Id", "BucketStart" },
         Projection = new[] { "Id", "BucketStart", "KsqlTimeFrameClose" },
         PocoShape = new[]
@@ -91,5 +91,29 @@ public class DerivationPlannerTests
 
         var live = Assert.Single(entities, e => e.Id == "bar_1wk_live" && e.Role == Role.Live);
         Assert.Equal("bar_1d_live", live.InputHint);
+    }
+
+    [Fact]
+    public void Plan_Hour_Windows_Chain()
+    {
+        var model = new EntityModel { EntityType = typeof(Source) };
+        var entities = DerivationPlanner.Plan(Create(new Timeframe(3, "h"), new Timeframe(1, "h")), model);
+
+        var live1 = Assert.Single(entities, e => e.Id == "bar_1h_live" && e.Role == Role.Live);
+        Assert.Equal("bar_1m_live", live1.InputHint);
+        var live3 = Assert.Single(entities, e => e.Id == "bar_3h_live" && e.Role == Role.Live);
+        Assert.Equal("bar_1h_live", live3.InputHint);
+    }
+
+    [Fact]
+    public void Plan_Day_Windows_Chain()
+    {
+        var model = new EntityModel { EntityType = typeof(Source) };
+        var entities = DerivationPlanner.Plan(Create(new Timeframe(1, "d"), new Timeframe(1, "h")), model);
+
+        var liveH = Assert.Single(entities, e => e.Id == "bar_1h_live" && e.Role == Role.Live);
+        Assert.Equal("bar_1m_live", liveH.InputHint);
+        var liveD = Assert.Single(entities, e => e.Id == "bar_1d_live" && e.Role == Role.Live);
+        Assert.Equal("bar_1h_live", liveD.InputHint);
     }
 }


### PR DESCRIPTION
## Summary
- order tumbling windows before planning derived entities
- chain live inputs so each window consumes the previous window's live topic
- assert hour and day window chaining in DerivationPlanner tests

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter "FullyQualifiedName~Kafka.Ksql.Linq.Tests.Query"`


------
https://chatgpt.com/codex/tasks/task_e_68bea1ada544832785d794d208c7a58d