### PR TITLE
Add WhenEmpty filler and fill derivation support

### DIFF
--- a/docs/diff_log/diff_whenempty_fill_20250908.md
+++ b/docs/diff_log/diff_whenempty_fill_20250908.md
@@ -1,0 +1,1 @@
+- Added WhenEmpty filler support with derived HB+LEFT JOIN+Fill entity.

--- a/features/whenempty_fill/instruction.md
+++ b/features/whenempty_fill/instruction.md
@@ -1,0 +1,4 @@
+# WhenEmpty filler
+- Add WhenEmpty(Func<T,T,T>) to KsqlQueryable storing lambda in KsqlQueryModel.
+- MethodCallCollectorVisitor detects WhenEmpty.
+- DerivationPlanner adds HB+LEFT JOIN+Fill derived entity only when flagged.

--- a/src/Query/Adapters/EntityModelAdapter.cs
+++ b/src/Query/Adapters/EntityModelAdapter.cs
@@ -55,6 +55,7 @@ internal static class EntityModelAdapter
                         Role.Final => TrimSuffix(baseNs, $"_{e.Timeframe.Value}{e.Timeframe.Unit}_final"),
                         Role.Prev1m => TrimSuffix(baseNs, "_prev_1m"),
                         Role.Hb => TrimSuffix(baseNs, $"_hb_{e.Timeframe.Value}{e.Timeframe.Unit}"),
+                        Role.Fill => TrimSuffix(baseNs, $"_{e.Timeframe.Value}{e.Timeframe.Unit}_fill"),
                         _ => baseNs
                     };
                 }

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -9,7 +9,7 @@ namespace Kafka.Ksql.Linq.Query.Analysis;
 
 internal static class DerivationPlanner
 {
-    public static IReadOnlyList<DerivedEntity> Plan(TumblingQao qao, EntityModel model)
+    public static IReadOnlyList<DerivedEntity> Plan(TumblingQao qao, EntityModel model, bool whenEmpty = false)
     {
         var entities = new List<DerivedEntity>();
 
@@ -116,6 +116,23 @@ internal static class DerivationPlanner
                 WeekAnchor = qao.WeekAnchor
             };
             entities.Add(hb);
+
+            if (whenEmpty)
+            {
+                var fill = new DerivedEntity
+                {
+                    Id = $"{baseId}_{tfStr}_fill",
+                    Role = Role.Fill,
+                    Timeframe = tf,
+                    KeyShape = keyShapes,
+                    ValueShape = valueShapes,
+                    InputHint = finalId,
+                    SyncHint = hbId.ToUpperInvariant(),
+                    BasedOnSpec = basedOn,
+                    WeekAnchor = qao.WeekAnchor
+                };
+                entities.Add(fill);
+            }
 
             if (tf.Unit == "m" && tf.Value == 1)
             {

--- a/src/Query/Analysis/DerivedEntity.cs
+++ b/src/Query/Analysis/DerivedEntity.cs
@@ -9,7 +9,8 @@ internal enum Role
     AggFinal,
     Final,
     Prev1m,
-    Hb
+    Hb,
+    Fill
 }
 
 internal enum MaterializationHint

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -28,7 +28,7 @@ internal static class DerivedTumblingPipeline
     {
         var baseAttr = baseModel.EntityType.GetCustomAttribute<KsqlTopicAttribute>();
         var baseName = (baseAttr?.Name ?? baseModel.TopicName ?? baseModel.EntityType.Name).ToLowerInvariant();
-        var entities = PlanDerivedEntities(qao, baseModel);
+        var entities = PlanDerivedEntities(qao, baseModel, queryModel.WhenEmptyFiller != null);
         var models = AdaptModels(entities);
         await Parallel.ForEachAsync(models, async (m, _) =>
         {
@@ -41,8 +41,8 @@ internal static class DerivedTumblingPipeline
         });
     }
 
-    public static IReadOnlyList<DerivedEntity> PlanDerivedEntities(TumblingQao qao, EntityModel model)
-        => DerivationPlanner.Plan(qao, model);
+    public static IReadOnlyList<DerivedEntity> PlanDerivedEntities(TumblingQao qao, EntityModel model, bool whenEmpty)
+        => DerivationPlanner.Plan(qao, model, whenEmpty);
 
     public static IReadOnlyList<EntityModel> AdaptModels(IReadOnlyList<DerivedEntity> entities)
         => EntityModelAdapter.Adapt(entities);
@@ -64,6 +64,7 @@ internal static class DerivedTumblingPipeline
             Role.Final => $"{baseName}_{tf}_final",
             Role.Prev1m => $"{baseName}_prev_1m",
             Role.Hb => $"{baseName}_hb_{tf}",
+            Role.Fill => $"{baseName}_{tf}_fill",
             _ => $"{baseName}_{tf}"
         };
         var ddl = KsqlCreateWindowedStatementBuilder.Build(name, qm, tf);

--- a/src/Query/Dsl/KsqlQueryModel.cs
+++ b/src/Query/Dsl/KsqlQueryModel.cs
@@ -32,6 +32,7 @@ public class KsqlQueryModel
     public bool IsFinal { get; set; }
     public int? GraceSeconds { get; set; }
     public int? BaseUnitSeconds { get; set; }
+    public LambdaExpression? WhenEmptyFiller { get; set; }
     public System.Collections.Generic.Dictionary<string, object?> Extras { get; } = new();
 
     public KsqlQueryModel Clone()
@@ -57,7 +58,8 @@ public class KsqlQueryModel
             ForbidDefaultWithin = ForbidDefaultWithin,
             IsFinal = IsFinal,
             GraceSeconds = GraceSeconds,
-            BaseUnitSeconds = BaseUnitSeconds
+            BaseUnitSeconds = BaseUnitSeconds,
+            WhenEmptyFiller = WhenEmptyFiller
         };
         clone.Windows.AddRange(Windows);
         clone.BasedOnJoinKeys.AddRange(BasedOnJoinKeys);

--- a/src/Query/Dsl/KsqlQueryable.cs
+++ b/src/Query/Dsl/KsqlQueryable.cs
@@ -190,6 +190,12 @@ public class KsqlQueryable<T1> : IKsqlQueryable, IScheduledScope<T1>
         return this;
     }
 
+    public KsqlQueryable<T1> WhenEmpty(Expression<Func<T1, T1, T1>> filler)
+    {
+        _model.WhenEmptyFiller = filler;
+        return this;
+    }
+
     public KsqlQueryable2<T1, T2> Join<T2>(Expression<Func<T1, T2, bool>> condition)
     {
         if (_stage != QueryBuildStage.From)

--- a/src/Query/Pipeline/ExpressionAnalysisResult.cs
+++ b/src/Query/Pipeline/ExpressionAnalysisResult.cs
@@ -29,6 +29,7 @@ internal class ExpressionAnalysisResult
     public bool BasedOnCloseInclusive { get; set; } = false;
     public string? BasedOnDayKey { get; set; }
     public Type? PocoType { get; set; }
+    public bool WhenEmpty { get; set; }
 
     private static bool IsAggregateMethod(string methodName)
     {

--- a/src/Query/Pipeline/MethodCallCollectorVisitor.cs
+++ b/src/Query/Pipeline/MethodCallCollectorVisitor.cs
@@ -23,6 +23,9 @@ internal class MethodCallCollectorVisitor : ExpressionVisitor
             case "TimeFrame":
                 ParseTimeFrame(node);
                 break;
+            case "WhenEmpty":
+                Result.WhenEmpty = true;
+                break;
         }
         return base.VisitMethodCall(node);
     }

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -116,4 +116,12 @@ public class DerivationPlannerTests
         var liveD = Assert.Single(entities, e => e.Id == "bar_1d_live" && e.Role == Role.Live);
         Assert.Equal("bar_1h_live", liveD.InputHint);
     }
+
+    [Fact]
+    public void Plan_WhenEmpty_Adds_Fill_Entity()
+    {
+        var model = new EntityModel { EntityType = typeof(Source) };
+        var entities = DerivationPlanner.Plan(Create(new Timeframe(1, "m")), model, true);
+        Assert.Contains(entities, e => e.Id == "bar_1m_fill" && e.Role == Role.Fill);
+    }
 }

--- a/tests/Query/Dsl/PropertyNameParsingTests.cs
+++ b/tests/Query/Dsl/PropertyNameParsingTests.cs
@@ -101,5 +101,19 @@ public class PropertyNameParsingTests
         Assert.Equal(30, model.GraceSeconds);
         Assert.Equal(new[] { "15m", "1h", "90m" }, model.Windows);
     }
+
+    [Fact]
+    public void WhenEmpty_Sets_Flag()
+    {
+        var q = Expression.Parameter(typeof(KsqlQueryable<Rate>), "q");
+        var r1 = Expression.Parameter(typeof(Rate), "r1");
+        var r2 = Expression.Parameter(typeof(Rate), "r2");
+        var filler = Expression.Lambda<Func<Rate, Rate, Rate>>(r1, r1, r2);
+        var method = typeof(KsqlQueryable<Rate>).GetMethod("WhenEmpty");
+        var call = Expression.Call(q, method!, filler);
+        var visitor = new MethodCallCollectorVisitor();
+        visitor.Visit(call);
+        Assert.True(visitor.Result.WhenEmpty);
+    }
 }
 


### PR DESCRIPTION
## Summary
- add `WhenEmpty` filler API and propagate expression to query model
- collect `WhenEmpty` calls and mark analysis result
- derive HB+LEFT JOIN+Fill entity when `WhenEmpty` flag present

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter FullyQualifiedName\!~Kafka.Ksql.Linq.Tests.Integration`

------
https://chatgpt.com/codex/tasks/task_e_68bec74660088327b03b3da277397cdf