### PR TITLE
fix: remove live chaining and expand base 1m hub

### DIFF
--- a/docs/diff_log/diff_derivationplanner_prevwindow_removal_20250908.md
+++ b/docs/diff_log/diff_derivationplanner_prevwindow_removal_20250908.md
@@ -1,0 +1,5 @@
+# Diff: DerivationPlanner prev window removal
+
+- Removed chaining of live inputs; all windows now consume base 1m live topics (weekly uses 1d live).
+- ExpressionAnalysisResult metadata reflects the same 1m-based live inputs.
+- Planner always expands a 1m heartbeat and prev1m entity even if 1m windows aren't specified.

--- a/features/derivationplanner_live_input/instruction.md
+++ b/features/derivationplanner_live_input/instruction.md
@@ -1,3 +1,6 @@
 # DerivationPlanner live input
 
-Weekly windows should consume daily live topics. See docs/diff_log/diff_derivationplanner_live_input_20250908.md for details.
+Weekly windows should consume daily live topics.
+Live inputs are fixed to base 1m streams without chaining (weekly uses 1d live).
+Planner expands a 1m hub even when 1m windows aren't requested.
+See docs/diff_log/diff_derivationplanner_prevwindow_removal_20250908.md for details.

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -33,6 +33,8 @@ internal static class DerivationPlanner
             }
         }
 
+        var topicAttr = model.EntityType.GetCustomAttribute<KsqlTopicAttribute>();
+        var baseId = (topicAttr?.Name ?? model.TopicName ?? model.EntityType.Name).ToLowerInvariant();
         var windows = qao.Windows
             .OrderBy(w => w.Unit switch
             {
@@ -43,12 +45,9 @@ internal static class DerivationPlanner
                 _ => w.Value
             })
             .ToArray();
-        Timeframe? prevWindow = null;
         foreach (var tf in windows)
         {
             var tfStr = $"{tf.Value}{tf.Unit}";
-            var topicAttr = model.EntityType.GetCustomAttribute<KsqlTopicAttribute>();
-            var baseId = (topicAttr?.Name ?? model.TopicName ?? model.EntityType.Name).ToLowerInvariant();
             var aggId = $"{baseId}_{tfStr}_agg_final";
             var liveId = $"{baseId}_{tfStr}_live";
             var finalId = $"{baseId}_{tfStr}_final";
@@ -66,13 +65,9 @@ internal static class DerivationPlanner
             };
             entities.Add(agg);
 
-            var liveInput = prevWindow == null
-                ? tf.Unit == "m" && tf.Value == 1
-                    ? "10sAgg"
-                    : tf.Unit == "wk"
-                        ? $"{baseId}_1d_live"
-                        : $"{baseId}_1m_live"
-                : $"{baseId}_{prevWindow.Value}{prevWindow.Unit}_live";
+            var liveInput = tf.Unit == "wk"
+                ? $"{baseId}_1d_live"
+                : $"{baseId}_1m_live";
             var liveSync = hbId.ToUpperInvariant();
             var live = new DerivedEntity
             {
@@ -150,7 +145,35 @@ internal static class DerivationPlanner
                 };
                 entities.Add(prev);
             }
-            prevWindow = tf;
+        }
+        if (!windows.Any(w => w.Unit == "m" && w.Value == 1))
+        {
+            var hb1m = new DerivedEntity
+            {
+                Id = $"{baseId}_hb_1m",
+                Role = Role.Hb,
+                Timeframe = new Timeframe(1, "m"),
+                KeyShape = keyShapes,
+                ValueShape = Array.Empty<ColumnShape>(),
+                MaterializationHint = MaterializationHint.Stream,
+                BasedOnSpec = basedOn,
+                WeekAnchor = qao.WeekAnchor
+            };
+            entities.Add(hb1m);
+
+            var prev = new DerivedEntity
+            {
+                Id = $"{baseId}_prev_1m",
+                Role = Role.Prev1m,
+                Timeframe = new Timeframe(1, "m"),
+                KeyShape = keyShapes,
+                ValueShape = valueShapes,
+                InputHint = $"{baseId}_1m_final",
+                SyncHint = $"{baseId}_hb_1m".ToUpperInvariant(),
+                BasedOnSpec = basedOn,
+                WeekAnchor = qao.WeekAnchor
+            };
+            entities.Add(prev);
         }
         return entities;
     }

--- a/src/Query/Pipeline/ExpressionAnalysisResult.cs
+++ b/src/Query/Pipeline/ExpressionAnalysisResult.cs
@@ -72,8 +72,7 @@ internal class ExpressionAnalysisResult
             {
                 var liveInput = tf switch
                 {
-                    "1m" => "10sAgg",
-                    "1wk" => $"{baseId}_1m_final",
+                    "1wk" => $"{baseId}_1d_live",
                     _ => $"{baseId}_1m_live"
                 };
                 md = md.WithProperty($"input/{tf}Live", liveInput);

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -53,7 +53,7 @@ public class DerivationPlannerTests
 
         Assert.Contains(entities, e => e.Id == "bar_1m_agg_final" && e.Role == Role.AggFinal);
         var live = Assert.Single(entities, e => e.Id == "bar_1m_live" && e.Role == Role.Live);
-        Assert.Equal("10sAgg", live.InputHint);
+        Assert.Equal("bar_1m_live", live.InputHint);
         Assert.Equal("BAR_HB_1M", live.SyncHint);
         var final = Assert.Single(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
         Assert.Equal("bar_1m_agg_final", final.InputHint);
@@ -80,7 +80,8 @@ public class DerivationPlannerTests
         Assert.Equal("BAR_HB_5M", final.SyncHint);
         Assert.Equal("bar_prev_1m", final.PrevHint);
         Assert.Contains(entities, e => e.Id == "bar_hb_5m" && e.Role == Role.Hb);
-        Assert.DoesNotContain(entities, e => e.Role == Role.Prev1m);
+        Assert.Contains(entities, e => e.Id == "bar_hb_1m" && e.Role == Role.Hb);
+        Assert.Contains(entities, e => e.Id == "bar_prev_1m" && e.Role == Role.Prev1m);
     }
 
     [Fact]
@@ -102,7 +103,7 @@ public class DerivationPlannerTests
         var live1 = Assert.Single(entities, e => e.Id == "bar_1h_live" && e.Role == Role.Live);
         Assert.Equal("bar_1m_live", live1.InputHint);
         var live3 = Assert.Single(entities, e => e.Id == "bar_3h_live" && e.Role == Role.Live);
-        Assert.Equal("bar_1h_live", live3.InputHint);
+        Assert.Equal("bar_1m_live", live3.InputHint);
     }
 
     [Fact]
@@ -114,7 +115,7 @@ public class DerivationPlannerTests
         var liveH = Assert.Single(entities, e => e.Id == "bar_1h_live" && e.Role == Role.Live);
         Assert.Equal("bar_1m_live", liveH.InputHint);
         var liveD = Assert.Single(entities, e => e.Id == "bar_1d_live" && e.Role == Role.Live);
-        Assert.Equal("bar_1h_live", liveD.InputHint);
+        Assert.Equal("bar_1m_live", liveD.InputHint);
     }
 
     [Fact]

--- a/tests/Query/Builders/RollupBuilderTests.cs
+++ b/tests/Query/Builders/RollupBuilderTests.cs
@@ -95,7 +95,7 @@ public class RollupBuilderTests
     {
         var md = BuildMetadata();
         var sql = LiveBuilder.Build(md, "1m");
-        Assert.Contains("TABLE 10sAgg WINDOW TUMBLING(1m)", sql);
+        Assert.Contains("TABLE bar_1m_live WINDOW TUMBLING(1m)", sql);
         Assert.Contains("EMIT CHANGES", sql);
         Assert.Contains("SYNC BAR_HB_1M", sql);
     }
@@ -119,7 +119,7 @@ public class RollupBuilderTests
         Assert.DoesNotContain("BAR_HB_1M", sql);
         Assert.DoesNotContain("COMPOSE(", sql);
         var sql1 = FinalBuilder.Build(md, "1m");
-        Assert.Contains("TABLE 10sAgg WINDOW TUMBLING(1m)", sql1);
+        Assert.Contains("TABLE bar_1m_live WINDOW TUMBLING(1m)", sql1);
         Assert.Contains("SYNC BAR_HB_1M", sql1);
         Assert.DoesNotContain("COMPOSE(", sql1);
     }


### PR DESCRIPTION
## Summary
- derive live topics directly from base 1m streams and use daily live for weekly windows
- ensure derivation planner always expands a 1m heartbeat/prev entity
- update rollup metadata generation and tests accordingly

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bed007aeb08327893fe3b5e82274ff