### PR TITLE
Add base unit window alignment validation

### DIFF
--- a/docs/diff_log/diff_baseunit_window_validation_20251014.md
+++ b/docs/diff_log/diff_baseunit_window_validation_20251014.md
@@ -1,0 +1,2 @@
+- Add BaseUnitSeconds-window alignment validation and error messaging.
+- Ensure SchemaRegistration passes BaseUnitSeconds to TumblingQao.

--- a/src/KsqlContext.SchemaRegistration.cs
+++ b/src/KsqlContext.SchemaRegistration.cs
@@ -457,7 +457,7 @@ public abstract partial class KsqlContext
                     m.QueryModel.BasedOnOpenInclusive,
                     m.QueryModel.BasedOnCloseInclusive),
                 WeekAnchor = m.QueryModel!.WeekAnchor,
-                BaseUnitSeconds = m.QueryModel!.BaseUnitSeconds
+                BaseUnitSeconds = m.QueryModel!.BaseUnitSeconds // pass through base unit for window checks
             };
         }
 

--- a/src/Query/Pipeline/DDLQueryGenerator.cs
+++ b/src/Query/Pipeline/DDLQueryGenerator.cs
@@ -422,6 +422,7 @@ internal class DDLQueryGenerator : GeneratorBase, IDDLQueryGenerator
             if (string.IsNullOrEmpty(result.BucketColumnName))
                 throw new InvalidOperationException("WindowStart() projection required for windowed queries");
         }
+        WindowValidator.Validate(result);
         return result;
     }
 

--- a/src/Query/Pipeline/DMLQueryGenerator.cs
+++ b/src/Query/Pipeline/DMLQueryGenerator.cs
@@ -432,6 +432,7 @@ internal class DMLQueryGenerator : GeneratorBase, IDMLQueryGenerator
             if (string.IsNullOrEmpty(result.BucketColumnName))
                 throw new InvalidOperationException("WindowStart() projection required for windowed queries");
         }
+        WindowValidator.Validate(result);
         return result;
     }
 

--- a/src/Query/Pipeline/WindowValidator.cs
+++ b/src/Query/Pipeline/WindowValidator.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Kafka.Ksql.Linq.Query.Pipeline;
+
+internal static class WindowValidator
+{
+    public static void Validate(ExpressionAnalysisResult result)
+    {
+        if (result == null) throw new ArgumentNullException(nameof(result));
+        if (!result.BaseUnitSeconds.HasValue || result.Windows.Count == 0)
+            return;
+        var baseUnit = result.BaseUnitSeconds.Value;
+        foreach (var w in result.Windows)
+        {
+            if (ToSeconds(w) % baseUnit != 0)
+                throw new InvalidOperationException($"Window {w} must be a multiple of base {baseUnit}s.");
+        }
+    }
+
+    private static int ToSeconds(string w)
+    {
+        if (w.EndsWith("mo", StringComparison.OrdinalIgnoreCase))
+            return int.Parse(w[..^2]) * 30 * 24 * 3600;
+        if (w.EndsWith("wk", StringComparison.OrdinalIgnoreCase))
+            return int.Parse(w[..^2]) * 7 * 24 * 3600;
+        var unit = w[^1];
+        var value = int.Parse(w[..^1]);
+        return unit switch
+        {
+            's' => value,
+            'm' => value * 60,
+            'h' => value * 3600,
+            'd' => value * 86400,
+            _ => value
+        };
+    }
+}

--- a/tests/Query/Pipeline/WindowValidatorTests.cs
+++ b/tests/Query/Pipeline/WindowValidatorTests.cs
@@ -1,0 +1,25 @@
+using System;
+using Kafka.Ksql.Linq.Query.Pipeline;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Pipeline;
+
+public class WindowValidatorTests
+{
+    [Fact]
+    public void Validate_Throws_When_Window_Not_Multiple()
+    {
+        var res = new ExpressionAnalysisResult { BaseUnitSeconds = 5 };
+        res.Windows.Add("7s");
+        var ex = Assert.Throws<InvalidOperationException>(() => WindowValidator.Validate(res));
+        Assert.Equal("Window 7s must be a multiple of base 5s.", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_Passes_For_Aligned_Windows()
+    {
+        var res = new ExpressionAnalysisResult { BaseUnitSeconds = 5 };
+        res.Windows.Add("10s");
+        WindowValidator.Validate(res);
+    }
+}


### PR DESCRIPTION
## Summary
- validate that each tumbling window aligns with the declared base unit
- surface clear error message when window is not a multiple of the base unit
- pass BaseUnitSeconds through schema registration for downstream processing

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter 'FullyQualifiedName!~KsqlContextToQueryIntegrationTests'`

------
https://chatgpt.com/codex/tasks/task_e_68bed168c2b083279d63debd797bbac6