### PR TITLE
Expose base unit and grace parameters for tumbling windows

### DIFF
--- a/docs/diff_log/diff_tumbling_baseunit_grace_20250908.md
+++ b/docs/diff_log/diff_tumbling_baseunit_grace_20250908.md
@@ -1,0 +1,4 @@
+- Removed BaseUnitSeconds from Windows DSL; base unit now passed as Tumbling argument.
+- Tumbling accepts baseUnitSeconds and optional grace period; values stored in KsqlQueryModel.
+- MethodCallCollectorVisitor parses positional baseUnitSeconds and grace arguments.
+- Added GraceSeconds to ExpressionAnalysisResult, KsqlQueryModel and TumblingQao, propagated through BuildQao.

--- a/src/KsqlContext.SchemaRegistration.cs
+++ b/src/KsqlContext.SchemaRegistration.cs
@@ -457,7 +457,8 @@ public abstract partial class KsqlContext
                     m.QueryModel.BasedOnOpenInclusive,
                     m.QueryModel.BasedOnCloseInclusive),
                 WeekAnchor = m.QueryModel!.WeekAnchor,
-                BaseUnitSeconds = m.QueryModel!.BaseUnitSeconds // pass through base unit for window checks
+                BaseUnitSeconds = m.QueryModel!.BaseUnitSeconds,
+                GraceSeconds = m.QueryModel!.GraceSeconds
             };
         }
 

--- a/src/Query/Analysis/TumblingQao.cs
+++ b/src/Query/Analysis/TumblingQao.cs
@@ -23,4 +23,5 @@ internal class TumblingQao
     public BasedOnSpec BasedOn { get; init; } = new(new List<string>(), string.Empty, string.Empty, string.Empty);
     public DayOfWeek WeekAnchor { get; init; } = DayOfWeek.Monday;
     public int? BaseUnitSeconds { get; init; }
+    public int? GraceSeconds { get; init; }
 }

--- a/src/Query/Dsl/IScheduledScope.cs
+++ b/src/Query/Dsl/IScheduledScope.cs
@@ -7,5 +7,7 @@ public interface IScheduledScope<T>
 {
     KsqlQueryable<T> Tumbling(
         Expression<Func<T, DateTime>> time,
-        Windows windows);
+        Windows windows,
+        int baseUnitSeconds = 10,
+        TimeSpan? grace = null);
 }

--- a/src/Query/Dsl/KsqlQueryModel.cs
+++ b/src/Query/Dsl/KsqlQueryModel.cs
@@ -29,6 +29,7 @@ public class KsqlQueryModel
     public int? WithinSeconds { get; set; }
     public bool ForbidDefaultWithin { get; set; }
     public int? BaseUnitSeconds { get; set; }
+    public int? GraceSeconds { get; set; }
     public LambdaExpression? WhenEmptyFiller { get; set; }
     public System.Collections.Generic.Dictionary<string, object?> Extras { get; } = new();
 
@@ -54,6 +55,7 @@ public class KsqlQueryModel
             WithinSeconds = WithinSeconds,
             ForbidDefaultWithin = ForbidDefaultWithin,
             BaseUnitSeconds = BaseUnitSeconds,
+            GraceSeconds = GraceSeconds,
             WhenEmptyFiller = WhenEmptyFiller
         };
         clone.Windows.AddRange(Windows);

--- a/src/Query/Dsl/KsqlQueryable.cs
+++ b/src/Query/Dsl/KsqlQueryable.cs
@@ -61,7 +61,9 @@ public class KsqlQueryable<T1> : IKsqlQueryable, IScheduledScope<T1>
 
     public KsqlQueryable<T1> Tumbling(
         Expression<Func<T1, DateTime>> time,
-        Windows windows)
+        Windows windows,
+        int baseUnitSeconds = 10,
+        TimeSpan? grace = null)
     {
         if (time.Body is MemberExpression me)
             _model.TimeKey = me.Member.Name;
@@ -71,8 +73,9 @@ public class KsqlQueryable<T1> : IKsqlQueryable, IScheduledScope<T1>
         if (windows.Hours != null) foreach (var h in windows.Hours) _model.Windows.Add($"{h}h");
         if (windows.Days != null) foreach (var d in windows.Days) _model.Windows.Add($"{d}d");
         if (windows.Months != null) foreach (var mo in windows.Months) _model.Windows.Add($"{mo}mo");
-        if (windows.BaseUnitSeconds.HasValue)
-            _model.BaseUnitSeconds = windows.BaseUnitSeconds;
+        _model.BaseUnitSeconds = baseUnitSeconds;
+        if (grace.HasValue)
+            _model.GraceSeconds = (int)Math.Ceiling(grace.Value.TotalSeconds);
         static int ToMinutes(string tf)
         {
             if (tf.EndsWith("mo")) return int.Parse(tf[..^2]) * 43200;

--- a/src/Query/Dsl/KsqlQueryable2.cs
+++ b/src/Query/Dsl/KsqlQueryable2.cs
@@ -55,7 +55,9 @@ public class KsqlQueryable2<T1, T2> : IKsqlQueryable
 
     public KsqlQueryable2<T1, T2> Tumbling(
         Expression<Func<T1, T2, DateTime>> time,
-        Windows windows)
+        Windows windows,
+        int baseUnitSeconds = 10,
+        TimeSpan? grace = null)
     {
         if (time.Body is MemberExpression me)
             _model.TimeKey = me.Member.Name;
@@ -65,8 +67,9 @@ public class KsqlQueryable2<T1, T2> : IKsqlQueryable
         if (windows.Hours != null) foreach (var h in windows.Hours) _model.Windows.Add($"{h}h");
         if (windows.Days != null) foreach (var d in windows.Days) _model.Windows.Add($"{d}d");
         if (windows.Months != null) foreach (var mo in windows.Months) _model.Windows.Add($"{mo}mo");
-        if (windows.BaseUnitSeconds.HasValue)
-            _model.BaseUnitSeconds = windows.BaseUnitSeconds;
+        _model.BaseUnitSeconds = baseUnitSeconds;
+        if (grace.HasValue)
+            _model.GraceSeconds = (int)Math.Ceiling(grace.Value.TotalSeconds);
         static int ToMinutes(string tf)
         {
             if (tf.EndsWith("mo")) return int.Parse(tf[..^2]) * 43200;

--- a/src/Query/Dsl/Windows.cs
+++ b/src/Query/Dsl/Windows.cs
@@ -6,5 +6,4 @@ public class Windows
     public int[]? Hours { get; set; }
     public int[]? Days { get; set; }
     public int[]? Months { get; set; }
-    public int? BaseUnitSeconds { get; set; }
 }

--- a/src/Query/Pipeline/ExpressionAnalysisResult.cs
+++ b/src/Query/Pipeline/ExpressionAnalysisResult.cs
@@ -21,6 +21,7 @@ internal class ExpressionAnalysisResult
     public List<string> GroupByKeys { get; } = new();
     public DayOfWeek WeekAnchor { get; set; } = DayOfWeek.Monday;
     public int? BaseUnitSeconds { get; set; }
+    public int? GraceSeconds { get; set; }
 
     public List<string> BasedOnJoinKeys { get; } = new();
     public string? BasedOnOpen { get; set; }

--- a/src/Query/Pipeline/MethodCallCollectorVisitor.cs
+++ b/src/Query/Pipeline/MethodCallCollectorVisitor.cs
@@ -49,13 +49,10 @@ internal class MethodCallCollectorVisitor : ExpressionVisitor
                         foreach (var ce in nae.Expressions.OfType<ConstantExpression>())
                             Result.Windows.Add(Normalize((int)ce.Value!, name));
                     }
-                    else if (expr is ConstantExpression ce)
+                    else if (expr is ConstantExpression ce && ce.Value is int[] arr)
                     {
-                        if (name == nameof(Windows.BaseUnitSeconds) && ce.Value is int b)
-                            Result.BaseUnitSeconds = b;
-                        else if (ce.Value is int[] arr)
-                            foreach (var v in arr)
-                                Result.Windows.Add(Normalize(v, name));
+                        foreach (var v in arr)
+                            Result.Windows.Add(Normalize(v, name));
                     }
                 }
             }
@@ -65,9 +62,14 @@ internal class MethodCallCollectorVisitor : ExpressionVisitor
                 if (w.Hours != null) foreach (var v in w.Hours) Result.Windows.Add(Normalize(v, nameof(w.Hours)));
                 if (w.Days != null) foreach (var v in w.Days) Result.Windows.Add(Normalize(v, nameof(w.Days)));
                 if (w.Months != null) foreach (var v in w.Months) Result.Windows.Add(Normalize(v, nameof(w.Months)));
-                if (w.BaseUnitSeconds.HasValue) Result.BaseUnitSeconds = w.BaseUnitSeconds;
             }
         }
+
+        if (call.Arguments.Count > 2 && call.Arguments[2] is ConstantExpression ce2 && ce2.Value is int b)
+            Result.BaseUnitSeconds = b;
+
+        if (call.Arguments.Count > 3 && call.Arguments[3] is ConstantExpression ce3 && ce3.Value is TimeSpan ts)
+            Result.GraceSeconds = (int)Math.Ceiling(ts.TotalSeconds);
 
         var ordered = Result.Windows.Distinct().OrderBy(ToMinutes).ToList();
         Result.Windows.Clear();

--- a/tests/Query/Builders/RollupBuilderTests.cs
+++ b/tests/Query/Builders/RollupBuilderTests.cs
@@ -44,7 +44,7 @@ public class RollupBuilderTests
                     s.Open <= r.Timestamp &&
                     r.Timestamp < s.Close,
                 s => s.MarketDate)
-            .Tumbling(r => r.Timestamp, new Windows { Minutes = new[] { 1, 5 } })
+            .Tumbling(r => r.Timestamp, new Windows { Minutes = new[] { 1, 5 } }, 10, null)
             .GroupBy(r => new { r.Broker, r.Symbol })
             .Select(g => new { g.Key.Broker, g.Key.Symbol, BucketStart = g.WindowStart() }))).Body;
         var analysis = Analyze(expr);

--- a/tests/Query/Dsl/PropertyNameParsingTests.cs
+++ b/tests/Query/Dsl/PropertyNameParsingTests.cs
@@ -29,11 +29,13 @@ public class PropertyNameParsingTests
         var q = Expression.Parameter(typeof(KsqlQueryable<Rate>), "q");
         var r = Expression.Parameter(typeof(Rate), "r");
         var timeLambda = Expression.Lambda(Expression.Property(r, nameof(Rate.Timestamp)), r);
-        var method = typeof(KsqlQueryable<Rate>).GetMethods().First(m => m.Name == "Tumbling" && m.GetParameters().Length == 2);
+        var method = typeof(KsqlQueryable<Rate>).GetMethods().First(m => m.Name == "Tumbling" && m.GetParameters().Length == 4);
         var windows = Expression.MemberInit(Expression.New(typeof(Windows)));
         var call = Expression.Call(q, method,
             timeLambda,
-            windows);
+            windows,
+            Expression.Constant(10),
+            Expression.Constant(null, typeof(TimeSpan?)));
         var visitor = new MethodCallCollectorVisitor();
         visitor.Visit(call);
         Assert.Equal("Timestamp", visitor.Result.TimeKey);
@@ -79,11 +81,13 @@ public class PropertyNameParsingTests
         var s = Expression.Parameter(typeof(Schedule), "s");
         var timeLambda = Expression.Lambda(Expression.Property(r, nameof(Rate.Timestamp)), r, s);
         var method = typeof(KsqlQueryable2<Rate, Schedule>).GetMethods()
-            .First(m => m.Name == "Tumbling" && m.GetParameters().Length == 2);
+            .First(m => m.Name == "Tumbling" && m.GetParameters().Length == 4);
         var windows = Expression.MemberInit(Expression.New(typeof(Windows)));
         var call = Expression.Call(q, method,
             timeLambda,
-            windows);
+            windows,
+            Expression.Constant(10),
+            Expression.Constant(null, typeof(TimeSpan?)));
         var visitor = new MethodCallCollectorVisitor();
         visitor.Visit(call);
         Assert.Equal("Timestamp", visitor.Result.TimeKey);


### PR DESCRIPTION
## Summary
- remove BaseUnitSeconds from Windows DSL
- allow Tumbling to accept base unit and optional grace
- propagate grace seconds through query analysis and schema registration

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -c Release`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68bed46307988327ae6d33f69eed2ebd