### PR TITLE
Validate base unit and minute windows

### DIFF
--- a/docs/diff_log/diff_windowvalidator_minute_checks_20251102.md
+++ b/docs/diff_log/diff_windowvalidator_minute_checks_20251102.md
@@ -1,0 +1,3 @@
+# Window validator minute checks
+- Enforce base unit divides 60 seconds.
+- Windows must be multiples of base unit and of 60 seconds when >= 1 minute.

--- a/src/Query/Pipeline/WindowValidator.cs
+++ b/src/Query/Pipeline/WindowValidator.cs
@@ -9,11 +9,21 @@ internal static class WindowValidator
         if (result == null) throw new ArgumentNullException(nameof(result));
         if (!result.BaseUnitSeconds.HasValue || result.Windows.Count == 0)
             return;
+
         var baseUnit = result.BaseUnitSeconds.Value;
+
+        if (60 % baseUnit != 0)
+            throw new InvalidOperationException("Base unit must divide 60 seconds.");
+
         foreach (var w in result.Windows)
         {
-            if (ToSeconds(w) % baseUnit != 0)
+            var seconds = ToSeconds(w);
+
+            if (seconds % baseUnit != 0)
                 throw new InvalidOperationException($"Window {w} must be a multiple of base {baseUnit}s.");
+
+            if (seconds >= 60 && seconds % 60 != 0)
+                throw new InvalidOperationException("Windows ≥ 1 minute must be whole-minute multiples.");
         }
     }
 

--- a/tests/Query/Pipeline/WindowValidatorTests.cs
+++ b/tests/Query/Pipeline/WindowValidatorTests.cs
@@ -7,7 +7,16 @@ namespace Kafka.Ksql.Linq.Tests.Query.Pipeline;
 public class WindowValidatorTests
 {
     [Fact]
-    public void Validate_Throws_When_Window_Not_Multiple()
+    public void Validate_Throws_When_BaseUnit_Not_Divide_60()
+    {
+        var res = new ExpressionAnalysisResult { BaseUnitSeconds = 7 };
+        res.Windows.Add("7s");
+        var ex = Assert.Throws<InvalidOperationException>(() => WindowValidator.Validate(res));
+        Assert.Equal("Base unit must divide 60 seconds.", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_Throws_When_Window_Not_Multiple_Of_Base()
     {
         var res = new ExpressionAnalysisResult { BaseUnitSeconds = 5 };
         res.Windows.Add("7s");
@@ -16,10 +25,27 @@ public class WindowValidatorTests
     }
 
     [Fact]
+    public void Validate_Throws_When_Window_Not_Whole_Minutes()
+    {
+        var res = new ExpressionAnalysisResult { BaseUnitSeconds = 5 };
+        res.Windows.Add("70s");
+        var ex = Assert.Throws<InvalidOperationException>(() => WindowValidator.Validate(res));
+        Assert.Equal("Windows ≥ 1 minute must be whole-minute multiples.", ex.Message);
+    }
+
+    [Fact]
     public void Validate_Passes_For_Aligned_Windows()
     {
         var res = new ExpressionAnalysisResult { BaseUnitSeconds = 5 };
         res.Windows.Add("10s");
+        WindowValidator.Validate(res);
+    }
+
+    [Fact]
+    public void Validate_Passes_For_Minute_Multiple_Window()
+    {
+        var res = new ExpressionAnalysisResult { BaseUnitSeconds = 5 };
+        res.Windows.Add("120s");
         WindowValidator.Validate(res);
     }
 }


### PR DESCRIPTION
## Summary
- ensure base unit divides 60 seconds
- enforce whole-minute windows for durations >= 1 minute
- cover window validator edge cases with tests

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68bed7961d1483279f0122c6b2bee646