### PR TITLE
Validate single WindowStart in windowed queries

### DIFF
--- a/docs/diff_log/diff_windowstart_validator_20250908.md
+++ b/docs/diff_log/diff_windowstart_validator_20250908.md
@@ -1,0 +1,1 @@
+- enforce single WindowStart() projection for windowed queries in DDL/DML generators.

--- a/features/windowstart_validator/instruction.md
+++ b/features/windowstart_validator/instruction.md
@@ -1,0 +1,3 @@
+# windowstart_validator
+Ensure windowed queries include exactly one `WindowStart()` in projection.
+See docs/diff_log/diff_windowstart_validator_20250908.md.

--- a/src/Query/Pipeline/DDLQueryGenerator.cs
+++ b/src/Query/Pipeline/DDLQueryGenerator.cs
@@ -421,6 +421,8 @@ internal class DDLQueryGenerator : GeneratorBase, IDDLQueryGenerator
                 throw new InvalidOperationException("Time key is required");
             if (string.IsNullOrEmpty(result.BucketColumnName))
                 throw new InvalidOperationException("WindowStart() projection required for windowed queries");
+            if (result.WindowStartCallCount != 1)
+                throw new InvalidOperationException("Windowed query requires exactly one WindowStart() in projection.");
         }
         WindowValidator.Validate(result);
         return result;

--- a/src/Query/Pipeline/DMLQueryGenerator.cs
+++ b/src/Query/Pipeline/DMLQueryGenerator.cs
@@ -431,6 +431,8 @@ internal class DMLQueryGenerator : GeneratorBase, IDMLQueryGenerator
                 throw new InvalidOperationException("Time key is required");
             if (string.IsNullOrEmpty(result.BucketColumnName))
                 throw new InvalidOperationException("WindowStart() projection required for windowed queries");
+            if (result.WindowStartCallCount != 1)
+                throw new InvalidOperationException("Windowed query requires exactly one WindowStart() in projection.");
         }
         WindowValidator.Validate(result);
         return result;

--- a/tests/Query/Pipeline/DDLQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/DDLQueryGeneratorTests.cs
@@ -5,6 +5,8 @@ using Kafka.Ksql.Linq.Core.Attributes;
 using Kafka.Ksql.Linq.Core.Modeling;
 using Kafka.Ksql.Linq.Query.Ddl;
 using Kafka.Ksql.Linq.Query.Pipeline;
+using Kafka.Ksql.Linq.Query.Dsl;
+using Kafka.Ksql.Linq;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -197,6 +199,12 @@ public class DDLQueryGeneratorTests
         public string Name { get; set; } = string.Empty;
     }
 
+    private class WindowEntity
+    {
+        public int Id { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+
     [KsqlTopic("attr_entity", PartitionCount = 3, ReplicationFactor = 2)]
     private class AttrEntity
     {
@@ -288,5 +296,21 @@ public class DDLQueryGeneratorTests
         var sql = GenerateDdl(model);
         Assert.Contains("PARTITIONS=6", sql);
         Assert.Contains("REPLICAS=1", sql);
+    }
+
+    [Fact]
+    public void GenerateCreateTableAs_MultipleWindowStart_Throws()
+    {
+        IQueryable<WindowEntity> src = new List<WindowEntity>().AsQueryable();
+
+        var expr = src
+            .Tumbling(e => e.Timestamp, new Windows { Minutes = new[] { 1 } })
+            .GroupBy(e => e.Id)
+            .Select(g => new { Start1 = g.WindowStart(), Start2 = g.WindowStart() });
+
+        var generator = new DDLQueryGenerator();
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            ExecuteInScope(() => generator.GenerateCreateTableAs("t1", "src", expr.Expression)));
+        Assert.Contains("Windowed query requires exactly one WindowStart() in projection.", ex.Message);
     }
 }

--- a/tests/Query/Pipeline/DMLQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/DMLQueryGeneratorTests.cs
@@ -1,6 +1,8 @@
 using Kafka.Ksql.Linq.Core.Attributes;
 using Kafka.Ksql.Linq.Core.Modeling;
 using Kafka.Ksql.Linq.Query.Pipeline;
+using Kafka.Ksql.Linq.Query.Dsl;
+using Kafka.Ksql.Linq;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -171,6 +173,12 @@ public class DMLQueryGeneratorTests
         public int CustomerId { get; set; }
         public double Amount { get; set; }
         public int Count { get; set; }
+    }
+
+    private class WindowEntity
+    {
+        public int Id { get; set; }
+        public DateTime Timestamp { get; set; }
     }
 
     [Fact]
@@ -811,5 +819,21 @@ public class DMLQueryGeneratorTests
             ExecuteInScope(() => generator.GenerateLinqQuery("orders", query.Expression, true, true)));
 
         Assert.Contains("GROUP BY is not supported in pull or table queries", ex.Message);
+    }
+
+    [Fact]
+    public void GenerateLinqQuery_MultipleWindowStart_Throws()
+    {
+        IQueryable<WindowEntity> src = new List<WindowEntity>().AsQueryable();
+
+        var expr = src
+            .Tumbling(e => e.Timestamp, new Windows { Minutes = new[] { 1 } })
+            .GroupBy(e => e.Id)
+            .Select(g => new { Start1 = g.WindowStart(), Start2 = g.WindowStart() });
+
+        var generator = new DMLQueryGenerator();
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            ExecuteInScope(() => generator.GenerateLinqQuery("win", expr.Expression, false)));
+        Assert.Contains("Windowed query requires exactly one WindowStart() in projection.", ex.Message);
     }
 }

--- a/tests/Query/Pipeline/TestQueryableExtensions.cs
+++ b/tests/Query/Pipeline/TestQueryableExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Kafka.Ksql.Linq.Query.Dsl;
 
 namespace Kafka.Ksql.Linq.Tests.Query.Pipeline;
 
@@ -9,6 +10,11 @@ internal static class TestQueryableExtensions
 {
     private static readonly MethodInfo HavingMethodInfo = typeof(TestQueryableExtensions)
         .GetMethod(nameof(Having), BindingFlags.Static | BindingFlags.Public)!
+        .GetGenericMethodDefinition();
+
+    private static readonly MethodInfo TumblingMethodInfo = typeof(TestQueryableExtensions)
+        .GetMethods(BindingFlags.Static | BindingFlags.Public)
+        .Single(m => m.Name == nameof(Tumbling) && m.GetParameters().Length == 3 && !m.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute), false))
         .GetGenericMethodDefinition();
 
     public static IQueryable<IGrouping<TKey, TSource>> Having<TKey, TSource>(
@@ -22,4 +28,23 @@ internal static class TestQueryableExtensions
             predicate);
         return source.Provider.CreateQuery<IGrouping<TKey, TSource>>(call);
     }
+
+    public static IQueryable<TSource> Tumbling<TSource>(
+        this IQueryable<TSource> source,
+        Expression<Func<TSource, DateTime>> time,
+        Windows windows)
+    {
+        var call = Expression.Call(
+            null,
+            TumblingMethodInfo.MakeGenericMethod(typeof(TSource)),
+            Expression.Quote(time),
+            Expression.Constant(windows),
+            source.Expression);
+        return source.Provider.CreateQuery<TSource>(call);
+    }
+
+    public static IQueryable<TSource> Tumbling<TSource>(
+        Expression<Func<TSource, DateTime>> time,
+        Windows windows,
+        IQueryable<TSource> source) => source;
 }


### PR DESCRIPTION
## Summary
- ensure DDL and DML query generators enforce exactly one WindowStart() for windowed projections
- test multiple WindowStart() calls raise an error
- document window start validation feature

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter "FullyQualifiedName~Kafka.Ksql.Linq.Tests.Query.Pipeline"`


------
https://chatgpt.com/codex/tasks/task_e_68bedc17100c8327ad7b2e93c4bde96b