### PR TITLE
Enforce base unit for tumbling window validation

### DIFF
--- a/docs/diff_log/diff_windowvalidator_baseunit_required_20250908.md
+++ b/docs/diff_log/diff_windowvalidator_baseunit_required_20250908.md
@@ -1,0 +1,1 @@
+- WindowValidator now throws when BaseUnitSeconds is missing for defined windows.

--- a/src/Query/Pipeline/WindowValidator.cs
+++ b/src/Query/Pipeline/WindowValidator.cs
@@ -7,8 +7,10 @@ internal static class WindowValidator
     public static void Validate(ExpressionAnalysisResult result)
     {
         if (result == null) throw new ArgumentNullException(nameof(result));
-        if (!result.BaseUnitSeconds.HasValue || result.Windows.Count == 0)
+        if (result.Windows.Count == 0)
             return;
+        if (!result.BaseUnitSeconds.HasValue)
+            throw new InvalidOperationException("Base unit is required for tumbling windows.");
 
         var baseUnit = result.BaseUnitSeconds.Value;
 

--- a/tests/Query/Pipeline/WindowValidatorTests.cs
+++ b/tests/Query/Pipeline/WindowValidatorTests.cs
@@ -7,6 +7,15 @@ namespace Kafka.Ksql.Linq.Tests.Query.Pipeline;
 public class WindowValidatorTests
 {
     [Fact]
+    public void Validate_Throws_When_BaseUnit_Missing()
+    {
+        var res = new ExpressionAnalysisResult();
+        res.Windows.Add("5s");
+        var ex = Assert.Throws<InvalidOperationException>(() => WindowValidator.Validate(res));
+        Assert.Equal("Base unit is required for tumbling windows.", ex.Message);
+    }
+
+    [Fact]
     public void Validate_Throws_When_BaseUnit_Not_Divide_60()
     {
         var res = new ExpressionAnalysisResult { BaseUnitSeconds = 7 };


### PR DESCRIPTION
## Summary
- ensure window validation throws when BaseUnitSeconds is missing
- test WindowValidator for missing base unit
- log WindowValidator change

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter WindowValidatorTests`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bf0e39a25c832784fe3bacc1e9014b