### PR TITLE
Support EMIT FINAL for derived tumbling queries

### DIFF
--- a/docs/diff_log/diff_derived_tumbling_pipeline_emit_override_20250909.md
+++ b/docs/diff_log/diff_derived_tumbling_pipeline_emit_override_20250909.md
@@ -1,0 +1,3 @@
+- KsqlCreateWindowedStatementBuilder now accepts optional emit override to replace `EMIT CHANGES`.
+- DerivedTumblingPipeline selects role-based emit using RoleTraits and forwards it to windowed builder.
+- Final role DDLs now emit `EMIT FINAL`; tests verify this behavior.

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -2,6 +2,7 @@ using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Attributes;
 using Kafka.Ksql.Linq.Query.Adapters;
 using Kafka.Ksql.Linq.Query.Builders;
+using Kafka.Ksql.Linq.Query.Builders.Core;
 using Kafka.Ksql.Linq.Query.Dsl;
 using Kafka.Ksql.Linq.Query.Abstractions;
 using Kafka.Ksql.Linq.Mapping;
@@ -56,6 +57,15 @@ internal static class DerivedTumblingPipeline
     {
         var qm = queryModel.Clone();
         var tf = (string)model.AdditionalSettings["timeframe"];
+        Timeframe tfObj;
+        if (tf.EndsWith("wk", StringComparison.OrdinalIgnoreCase))
+            tfObj = new Timeframe(int.Parse(tf[..^2]), "wk");
+        else if (tf.EndsWith("mo", StringComparison.OrdinalIgnoreCase))
+            tfObj = new Timeframe(int.Parse(tf[..^2]), "mo");
+        else
+            tfObj = new Timeframe(int.Parse(tf[..^1]), tf[^1].ToString());
+        var spec = RoleTraits.For(role, tfObj);
+        var emit = spec.Emit != null ? $"EMIT {spec.Emit}" : null;
         var name = role switch
         {
             Role.AggFinal => $"{baseName}_{tf}_agg_final",
@@ -66,7 +76,7 @@ internal static class DerivedTumblingPipeline
             Role.Fill => $"{baseName}_{tf}_fill",
             _ => $"{baseName}_{tf}"
         };
-        var ddl = KsqlCreateWindowedStatementBuilder.Build(name, qm, tf);
+        var ddl = KsqlCreateWindowedStatementBuilder.Build(name, qm, tf, emit);
         var dt = resolveType(name);
         model.EntityType = dt;
         model.TopicName = name;

--- a/src/Query/Builders/KsqlCreateWindowedStatementBuilder.cs
+++ b/src/Query/Builders/KsqlCreateWindowedStatementBuilder.cs
@@ -12,12 +12,14 @@ namespace Kafka.Ksql.Linq.Query.Builders;
 /// </summary>
 internal static class KsqlCreateWindowedStatementBuilder
 {
-    public static string Build(string name, KsqlQueryModel model, string timeframe)
+    public static string Build(string name, KsqlQueryModel model, string timeframe, string? emitOverride = null)
     {
         if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("name required", nameof(name));
         if (model is null) throw new ArgumentNullException(nameof(model));
         if (string.IsNullOrWhiteSpace(timeframe)) throw new ArgumentException("timeframe required", nameof(timeframe));
         var baseSql = KsqlCreateStatementBuilder.Build(name, model);
+        if (!string.IsNullOrWhiteSpace(emitOverride))
+            baseSql = baseSql.Replace("EMIT CHANGES", emitOverride);
         var window = FormatWindow(timeframe);
         var sql = InjectWindowAfterFrom(baseSql, window);
         return sql;

--- a/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
@@ -62,5 +62,8 @@ public class DerivedTumblingPipelineConcurrencyTests
         var expected = 9; // 1m: AggFinal/Live/Final + Hb + Prev, 5m: AggFinal/Live/Final + Hb
         Assert.Equal(expected, registry.Count);
         Assert.Equal(expected, ddls.Count);
+        foreach (var ddl in ddls)
+            if (ddl.Contains("_final"))
+                Assert.Contains("EMIT FINAL", ddl);
     }
 }

--- a/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
@@ -66,6 +66,6 @@ public class DerivedTumblingPipelineTests
         var final = ddls.Single(s => s.Contains("_1m_final"));
         Assert.Contains(ddls, s => s.Contains("_prev_1m"));
         Assert.Contains("EMIT CHANGES", live);
-        Assert.Contains("_1m_final", final);
+        Assert.Contains("EMIT FINAL", final);
     }
 }


### PR DESCRIPTION
## Summary
- allow windowed builder to replace `EMIT CHANGES` with a provided clause
- derive role-based emit clauses so final windows use `EMIT FINAL`
- document emit override support

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c014c2abc48327974e27483a6a685a