### PR TITLE
Chain derived tumbling windows through prior finals

### DIFF
--- a/docs/diff_log/diff_derivationplanner_final_input_chain_20250909.md
+++ b/docs/diff_log/diff_derivationplanner_final_input_chain_20250909.md
@@ -1,0 +1,4 @@
+- AggFinal and Final entities now take the previous `_final` table as `InputHint`, chaining window sources.
+- DerivedTumblingPipeline forwards `AdditionalSettings["input"]` to windowed builder to override the `FROM` clause.
+- KsqlCreateWindowedStatementBuilder gained `inputOverride` parameter to replace source name in generated DDL.
+- Added test ensuring `bar_5m_final` DDL uses `FROM bar_1m_final` with `EMIT FINAL`.

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -45,6 +45,7 @@ internal static class DerivationPlanner
                 _ => w.Value
             })
             .ToArray();
+        string? prevFinalId = null;
         foreach (var tf in windows)
         {
             var tfStr = $"{tf.Value}{tf.Unit}";
@@ -60,6 +61,7 @@ internal static class DerivationPlanner
                 Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
+                InputHint = prevFinalId,
                 BasedOnSpec = basedOn,
                 WeekAnchor = qao.WeekAnchor
             };
@@ -83,7 +85,7 @@ internal static class DerivationPlanner
             };
             entities.Add(live);
 
-            var finalInput = aggId;
+            var finalInput = prevFinalId ?? aggId;
             var final = new DerivedEntity
             {
                 Id = finalId,
@@ -98,6 +100,8 @@ internal static class DerivationPlanner
                 WeekAnchor = qao.WeekAnchor
             };
             entities.Add(final);
+
+            prevFinalId = finalId;
 
             var hb = new DerivedEntity
             {

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -76,7 +76,8 @@ internal static class DerivedTumblingPipeline
             Role.Fill => $"{baseName}_{tf}_fill",
             _ => $"{baseName}_{tf}"
         };
-        var ddl = KsqlCreateWindowedStatementBuilder.Build(name, qm, tf, emit);
+        var inputOverride = model.AdditionalSettings.TryGetValue("input", out var inputObj) ? inputObj?.ToString() : null;
+        var ddl = KsqlCreateWindowedStatementBuilder.Build(name, qm, tf, emit, inputOverride);
         var dt = resolveType(name);
         model.EntityType = dt;
         model.TopicName = name;

--- a/src/Query/Builders/KsqlCreateWindowedStatementBuilder.cs
+++ b/src/Query/Builders/KsqlCreateWindowedStatementBuilder.cs
@@ -12,7 +12,7 @@ namespace Kafka.Ksql.Linq.Query.Builders;
 /// </summary>
 internal static class KsqlCreateWindowedStatementBuilder
 {
-    public static string Build(string name, KsqlQueryModel model, string timeframe, string? emitOverride = null)
+    public static string Build(string name, KsqlQueryModel model, string timeframe, string? emitOverride = null, string? inputOverride = null)
     {
         if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("name required", nameof(name));
         if (model is null) throw new ArgumentNullException(nameof(model));
@@ -20,6 +20,8 @@ internal static class KsqlCreateWindowedStatementBuilder
         var baseSql = KsqlCreateStatementBuilder.Build(name, model);
         if (!string.IsNullOrWhiteSpace(emitOverride))
             baseSql = baseSql.Replace("EMIT CHANGES", emitOverride);
+        if (!string.IsNullOrWhiteSpace(inputOverride))
+            baseSql = OverrideFrom(baseSql, inputOverride);
         var window = FormatWindow(timeframe);
         var sql = InjectWindowAfterFrom(baseSql, window);
         return sql;
@@ -60,6 +62,12 @@ internal static class KsqlCreateWindowedStatementBuilder
             'd' => $"WINDOW TUMBLING (SIZE {val} DAYS)",
             _ => $"WINDOW TUMBLING (SIZE {val} MINUTES)"
         };
+    }
+
+    private static string OverrideFrom(string sql, string source)
+    {
+        var pattern = new Regex(@"\bFROM\s+([A-Za-z_][\w]*)\s+([A-Za-z_][\w]*)", RegexOptions.IgnoreCase);
+        return pattern.Replace(sql, m => $"FROM {source} {m.Groups[2].Value}", 1);
     }
 
     private static string InjectWindowAfterFrom(string sql, string windowClause)

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -71,7 +71,8 @@ public class DerivationPlannerTests
         var model = new EntityModel { EntityType = typeof(Source) };
         var entities = DerivationPlanner.Plan(Create(new Timeframe(5, "m")), model);
 
-        Assert.Contains(entities, e => e.Id == "bar_5m_agg_final" && e.Role == Role.AggFinal);
+        var agg5 = Assert.Single(entities, e => e.Id == "bar_5m_agg_final" && e.Role == Role.AggFinal);
+        Assert.Null(agg5.InputHint);
         var live5 = Assert.Single(entities, e => e.Id == "bar_5m_live" && e.Role == Role.Live);
         Assert.Equal("bar_1m_live", live5.InputHint);
         Assert.Equal("BAR_HB_5M", live5.SyncHint);

--- a/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Query.Analysis;
 
-[KsqlTopic("test-topic")]
+[KsqlTopic("bar")]
 class TestSource
 {
     public int Id { get; set; }
@@ -62,10 +62,55 @@ public class DerivedTumblingPipelineTests
 
         await DerivedTumblingPipeline.RunAsync(qao, baseModel, model, Exec, Resolver, mapping, registry, new LoggerFactory().CreateLogger("test"));
 
-        var live = ddls.Single(s => s.Contains("_1m_live"));
-        var final = ddls.Single(s => s.Contains("_1m_final"));
+        var live = ddls.Single(s => s.StartsWith("CREATE TABLE bar_1m_live") || s.StartsWith("CREATE STREAM bar_1m_live"));
+        var final = ddls.Single(s => s.StartsWith("CREATE TABLE bar_1m_final") || s.StartsWith("CREATE STREAM bar_1m_final"));
         Assert.Contains(ddls, s => s.Contains("_prev_1m"));
         Assert.Contains("EMIT CHANGES", live);
         Assert.Contains("EMIT FINAL", final);
+    }
+
+    [Fact]
+    public async Task Final_5m_uses_prev_final_as_input()
+    {
+        var qao = new TumblingQao
+        {
+            TimeKey = "Timestamp",
+            Windows = new[] { new Timeframe(1, "m"), new Timeframe(5, "m") },
+            Keys = new[] { "Id", "BucketStart" },
+            Projection = new[] { "Id", "BucketStart", "KsqlTimeFrameClose" },
+            PocoShape = new[]
+            {
+                new ColumnShape("Id", typeof(int), false),
+                new ColumnShape("BucketStart", typeof(long), false),
+                new ColumnShape("KsqlTimeFrameClose", typeof(double), false)
+            },
+            BasedOn = new BasedOnSpec(new[] { "Id", "BucketStart" }, string.Empty, "KsqlTimeFrameClose", string.Empty),
+            WeekAnchor = DayOfWeek.Monday
+        };
+        var baseModel = new EntityModel { EntityType = typeof(TestSource) };
+        var model = new KsqlQueryModel
+        {
+            SourceTypes = new[] { typeof(TestSource) },
+            Windows = { "1m", "5m" }
+        };
+
+        var ddls = new ConcurrentBag<string>();
+        Task Exec(string sql)
+        {
+            ddls.Add(sql);
+            return Task.CompletedTask;
+        }
+
+        var mapping = new MappingRegistry();
+        var registry = new ConcurrentDictionary<Type, EntityModel>();
+        var asm = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("dyn"), AssemblyBuilderAccess.Run);
+        var mod = asm.DefineDynamicModule("m");
+        Type Resolver(string _) => mod.DefineType("T" + Guid.NewGuid().ToString("N")).CreateType()!;
+
+        await DerivedTumblingPipeline.RunAsync(qao, baseModel, model, Exec, Resolver, mapping, registry, new LoggerFactory().CreateLogger("test"));
+
+        var ddl5 = ddls.Single(s => s.Contains("_5m_final"));
+        Assert.Contains("FROM bar_1m_final", ddl5);
+        Assert.Contains("EMIT FINAL", ddl5);
     }
 }


### PR DESCRIPTION
## Summary
- feed each AggFinal and Final window from the previous `_final` table to chain derivations
- allow DerivedTumblingPipeline to override the source table via `AdditionalSettings["input"]`
- ensure 5m final window DDL pulls from `bar_1m_final`

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c01f4a5954832794cdb8c29b26b610