### PR TITLE
Remove final grace qualifier from AggFinal emit

### DIFF
--- a/docs/diff_log/diff_emit_final_grace_removal_20250909.md
+++ b/docs/diff_log/diff_emit_final_grace_removal_20250909.md
@@ -1,0 +1,4 @@
+- AggFinal role emits `FINAL` instead of `FINAL GRACE`.
+- Window tumbling builder accepts optional grace seconds appended as `GRACE PERIOD`.
+- WindowedQueryBuilder forwards `GraceSeconds` from `QueryMetadata`.
+- Updated tests to expect `EMIT FINAL`.

--- a/src/Query/Builders/Core/RoleTraits.cs
+++ b/src/Query/Builders/Core/RoleTraits.cs
@@ -14,7 +14,7 @@ internal static class RoleTraits
         return role switch
         {
             Role.Live => new(true, "CHANGES", true),
-            Role.AggFinal => new(true, "FINAL GRACE", false),
+            Role.AggFinal => new(true, "FINAL", false),
             Role.Final => new(true, "FINAL", true),
             _ => new(false, null, false)
         };

--- a/src/Query/Builders/Core/WindowedQueryBuilder.cs
+++ b/src/Query/Builders/Core/WindowedQueryBuilder.cs
@@ -23,7 +23,7 @@ internal static class WindowedQueryBuilder
         if (role == Role.Live || role == Role.Final)
             sb.Append($"TABLE {input}");
         if (spec.Window)
-            sb.Append(' ').Append(QueryBuilderUtils.ApplyWindowTumbling(tfStr));
+            sb.Append(' ').Append(QueryBuilderUtils.ApplyWindowTumbling(tfStr, md.GraceSeconds));
         if (spec.Emit != null)
             sb.Append(' ').Append($"EMIT {spec.Emit}");
         if (spec.SyncHb1m)

--- a/src/Query/Builders/Utils/QueryBuilderUtils.cs
+++ b/src/Query/Builders/Utils/QueryBuilderUtils.cs
@@ -22,7 +22,11 @@ internal static class QueryBuilderUtils
         return $"JOIN ON {join} AND s.{openProp} {openOp} r.{timeKey} AND r.{timeKey} {closeOp} s.{closeProp}"; 
     }
 
-    public static string ApplyWindowTumbling(string timeframe) => $"WINDOW TUMBLING({timeframe})";
+    public static string ApplyWindowTumbling(string timeframe, int? graceSeconds = null)
+    {
+        var grace = graceSeconds.HasValue ? $" GRACE PERIOD {graceSeconds.Value}s" : string.Empty;
+        return $"WINDOW TUMBLING({timeframe}{grace})";
+    }
 
     public static string ApplySync_HB1m(string sync) => $"SYNC {sync}";
 

--- a/src/Query/Pipeline/QueryMetadata.cs
+++ b/src/Query/Pipeline/QueryMetadata.cs
@@ -9,6 +9,7 @@ internal record QueryMetadata(
     string? BaseObject = null,
     Dictionary<string, object>? Properties = null)
 {
+    public int? GraceSeconds { get; init; }
     /// <summary>
     /// プロパティ追加
     /// </summary>

--- a/tests/Query/Builders/RollupBuilderTests.cs
+++ b/tests/Query/Builders/RollupBuilderTests.cs
@@ -82,12 +82,12 @@ public class RollupBuilderTests
     }
 
     [Fact]
-    public void AggFinal_Builds_FinalWithGrace()
+    public void AggFinal_Builds_Final()
     {
         var md = BuildMetadata();
         var sql = AggFinalBuilder.Build(md, "1m");
         Assert.Contains("WINDOW TUMBLING(1m)", sql);
-        Assert.Contains("EMIT FINAL GRACE", sql);
+        Assert.Contains("EMIT FINAL", sql);
     }
 
     [Fact]

--- a/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
+++ b/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
@@ -32,10 +32,10 @@ public class WindowedQueryBuilderCoreTests
     }
 
     [Fact]
-    public void Core_Builds_AggFinal_FinalPlusGrace()
+    public void Core_Builds_AggFinal_EmitFinal()
     {
         var q = AggFinalBuilder.Build(BaseMd(), "1m");
-        Assert.Contains("FINAL GRACE", q);
+        Assert.Contains("EMIT FINAL", q);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Drop "GRACE" suffix from AggFinal's emission spec
- Support optional GRACE PERIOD seconds in tumbling windows
- Forward grace seconds from metadata to window builder and update tests

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c02343dc508327957d6f041fb4ee71