### PR TITLE
Process derived models sequentially

### DIFF
--- a/docs/diff_log/diff_derived_tumbling_pipeline_sequential_20250909.md
+++ b/docs/diff_log/diff_derived_tumbling_pipeline_sequential_20250909.md
@@ -1,0 +1,3 @@
+- Replaced `Parallel.ForEachAsync` with a sequential `foreach` in `DerivedTumblingPipeline.RunAsync` to send DDL commands in order.
+- Maintained existing registration sequence to keep mapping and registry updates consistent.
+

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -31,7 +31,7 @@ internal static class DerivedTumblingPipeline
         var baseName = (baseAttr?.Name ?? baseModel.TopicName ?? baseModel.EntityType.Name).ToLowerInvariant();
         var entities = PlanDerivedEntities(qao, baseModel, queryModel.WhenEmptyFiller != null);
         var models = AdaptModels(entities);
-        await Parallel.ForEachAsync(models, async (m, _) =>
+        foreach (var m in models)
         {
             var role = Enum.Parse<Role>((string)m.AdditionalSettings["role"]);
             var (ddl, dt, ns) = BuildDdlAndRegister(baseName, queryModel, m, role, resolveType);
@@ -39,7 +39,7 @@ internal static class DerivedTumblingPipeline
             await execute(ddl);
             mapping.RegisterEntityModel(m, genericValue: true, overrideNamespace: ns);
             registry[dt] = m;
-        });
+        }
     }
 
     public static IReadOnlyList<DerivedEntity> PlanDerivedEntities(TumblingQao qao, EntityModel model, bool whenEmpty)


### PR DESCRIPTION
## Summary
- send derived DDL statements sequentially in `DerivedTumblingPipeline` to guarantee ordering
- document sequential execution change

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c032c85fb4832786150b028deba9b1