### PR TITLE
Avoid self-referencing input for 1m live windows

### DIFF
--- a/docs/diff_log/diff_derivationplanner_live_input_20250909.md
+++ b/docs/diff_log/diff_derivationplanner_live_input_20250909.md
@@ -1,0 +1,3 @@
+# Diff: DerivationPlanner live input
+
+- 1m live windows consume the base topic to avoid self-referencing inputs.

--- a/features/derivationplanner_live_input/instruction.md
+++ b/features/derivationplanner_live_input/instruction.md
@@ -1,6 +1,6 @@
 # DerivationPlanner live input
 
 Weekly windows should consume daily live topics.
-Live inputs are fixed to base 1m streams without chaining (weekly uses 1d live).
+Live inputs are fixed to base 1m streams without chaining (weekly uses 1d live). A 1m window consumes the base topic.
 Planner expands a 1m hub even when 1m windows aren't requested.
 See docs/diff_log/diff_derivationplanner_prevwindow_removal_20250908.md for details.

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -67,9 +67,11 @@ internal static class DerivationPlanner
             };
             entities.Add(agg);
 
-            var liveInput = tf.Unit == "wk"
-                ? $"{baseId}_1d_live"
-                : $"{baseId}_1m_live";
+            var liveInput = tf.Unit == "m" && tf.Value == 1
+                ? baseId
+                : tf.Unit == "wk"
+                    ? $"{baseId}_1d_live"
+                    : $"{baseId}_1m_live";
             var liveSync = hbId.ToUpperInvariant();
             var live = new DerivedEntity
             {
@@ -78,7 +80,7 @@ internal static class DerivationPlanner
                 Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
-                InputHint = liveInput,
+                InputHint = liveInput == liveId ? null : liveInput,
                 SyncHint = liveSync,
                 BasedOnSpec = basedOn,
                 WeekAnchor = qao.WeekAnchor

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -53,7 +53,7 @@ public class DerivationPlannerTests
 
         Assert.Contains(entities, e => e.Id == "bar_1m_agg_final" && e.Role == Role.AggFinal);
         var live = Assert.Single(entities, e => e.Id == "bar_1m_live" && e.Role == Role.Live);
-        Assert.Equal("bar_1m_live", live.InputHint);
+        Assert.Equal("bar", live.InputHint);
         Assert.Equal("BAR_HB_1M", live.SyncHint);
         var final = Assert.Single(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
         Assert.Equal("bar_1m_agg_final", final.InputHint);


### PR DESCRIPTION
## Summary
- prevent `DerivationPlanner` from assigning `bar_1m_live` as its own live input when timeframe is 1 minute
- document live-input behavior for 1m windows and weekly windows
- add diff log entry and adjust tests

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter 'FullyQualifiedName!~Integration'`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj --filter 'FullyQualifiedName!~Integration'`


------
https://chatgpt.com/codex/tasks/task_e_68c04cf4bbcc8327b88c196407670d2d