### PR TITLE
Ensure DerivationPlanner builds 1-minute hub by default

### DIFF
--- a/docs/diff_log/diff_derivationplanner_1m_hub_20250909.md
+++ b/docs/diff_log/diff_derivationplanner_1m_hub_20250909.md
@@ -1,0 +1,3 @@
+- DerivationPlanner builds a 1m hub when no 1m window is specified.
+- Adds _1m_agg_final, _1m_live and _1m_final alongside hb_1m and prev_1m.
+- Tests verify _1m_live and _1m_final are created even with other windows.

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -154,11 +154,53 @@ internal static class DerivationPlanner
         }
         if (!windows.Any(w => w.Unit == "m" && w.Value == 1))
         {
+            var tf = new Timeframe(1, "m");
+            var agg1m = new DerivedEntity
+            {
+                Id = $"{baseId}_1m_agg_final",
+                Role = Role.AggFinal,
+                Timeframe = tf,
+                KeyShape = keyShapes,
+                ValueShape = valueShapes,
+                BasedOnSpec = basedOn,
+                WeekAnchor = qao.WeekAnchor
+            };
+            entities.Add(agg1m);
+
+            var live1m = new DerivedEntity
+            {
+                Id = $"{baseId}_1m_live",
+                Role = Role.Live,
+                Timeframe = tf,
+                KeyShape = keyShapes,
+                ValueShape = valueShapes,
+                InputHint = baseId,
+                SyncHint = $"{baseId}_hb_1m".ToUpperInvariant(),
+                BasedOnSpec = basedOn,
+                WeekAnchor = qao.WeekAnchor
+            };
+            entities.Add(live1m);
+
+            var final1m = new DerivedEntity
+            {
+                Id = $"{baseId}_1m_final",
+                Role = Role.Final,
+                Timeframe = tf,
+                KeyShape = keyShapes,
+                ValueShape = valueShapes,
+                InputHint = agg1m.Id,
+                SyncHint = $"{baseId}_hb_1m".ToUpperInvariant(),
+                PrevHint = $"{baseId}_prev_1m",
+                BasedOnSpec = basedOn,
+                WeekAnchor = qao.WeekAnchor
+            };
+            entities.Add(final1m);
+
             var hb1m = new DerivedEntity
             {
                 Id = $"{baseId}_hb_1m",
                 Role = Role.Hb,
-                Timeframe = new Timeframe(1, "m"),
+                Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = Array.Empty<ColumnShape>(),
                 MaterializationHint = MaterializationHint.Stream,
@@ -171,10 +213,10 @@ internal static class DerivationPlanner
             {
                 Id = $"{baseId}_prev_1m",
                 Role = Role.Prev1m,
-                Timeframe = new Timeframe(1, "m"),
+                Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
-                InputHint = $"{baseId}_1m_final",
+                InputHint = final1m.Id,
                 SyncHint = $"{baseId}_hb_1m".ToUpperInvariant(),
                 BasedOnSpec = basedOn,
                 WeekAnchor = qao.WeekAnchor

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -66,7 +66,7 @@ public class DerivationPlannerTests
     }
 
     [Fact]
-    public void Plan_5m_Includes_Hb()
+    public void Plan_5m_Includes_1m_Hub()
     {
         var model = new EntityModel { EntityType = typeof(Source) };
         var entities = DerivationPlanner.Plan(Create(new Timeframe(5, "m")), model);
@@ -80,6 +80,10 @@ public class DerivationPlannerTests
         Assert.Equal("bar_5m_agg_final", final.InputHint);
         Assert.Equal("BAR_HB_5M", final.SyncHint);
         Assert.Equal("bar_prev_1m", final.PrevHint);
+
+        Assert.Contains(entities, e => e.Id == "bar_1m_agg_final" && e.Role == Role.AggFinal);
+        Assert.Contains(entities, e => e.Id == "bar_1m_live" && e.Role == Role.Live);
+        Assert.Contains(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
         Assert.Contains(entities, e => e.Id == "bar_hb_5m" && e.Role == Role.Hb);
         Assert.Contains(entities, e => e.Id == "bar_hb_1m" && e.Role == Role.Hb);
         Assert.Contains(entities, e => e.Id == "bar_prev_1m" && e.Role == Role.Prev1m);


### PR DESCRIPTION
## Summary
- build 1m agg/live/final/hb/prev entities when no 1m window is provided
- verify 1m hub appears even alongside other windows
- document derivation planner 1m hub addition

## Testing
- `dotnet test Kafka.Ksql.Linq.sln --filter 'FullyQualifiedName!~Kafka.Ksql.Linq.Tests.Integration'`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c04e12cd9083278a60362fe444d2b7