### PR TITLE
fix: let 1m live windows read base source

### DIFF
--- a/docs/diff_log/diff_derivationplanner_live_input_null_20250909.md
+++ b/docs/diff_log/diff_derivationplanner_live_input_null_20250909.md
@@ -1,0 +1,5 @@
+# Diff: DerivationPlanner live input null
+
+- 1m live windows omit `InputHint` so `bar_1m_live` reads the base source.
+- Fallback-generated 1m live window also sets `InputHint` to null.
+

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -67,8 +67,8 @@ internal static class DerivationPlanner
             };
             entities.Add(agg);
 
-            var liveInput = tf.Unit == "m" && tf.Value == 1
-                ? baseId
+            string? liveInput = tf.Unit == "m" && tf.Value == 1
+                ? null
                 : tf.Unit == "wk"
                     ? $"{baseId}_1d_live"
                     : $"{baseId}_1m_live";
@@ -80,7 +80,7 @@ internal static class DerivationPlanner
                 Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
-                InputHint = liveInput == liveId ? null : liveInput,
+                InputHint = liveInput,
                 SyncHint = liveSync,
                 BasedOnSpec = basedOn,
                 WeekAnchor = qao.WeekAnchor
@@ -174,7 +174,7 @@ internal static class DerivationPlanner
                 Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
-                InputHint = baseId,
+                InputHint = null,
                 SyncHint = $"{baseId}_hb_1m".ToUpperInvariant(),
                 BasedOnSpec = basedOn,
                 WeekAnchor = qao.WeekAnchor

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -53,7 +53,7 @@ public class DerivationPlannerTests
 
         Assert.Contains(entities, e => e.Id == "bar_1m_agg_final" && e.Role == Role.AggFinal);
         var live = Assert.Single(entities, e => e.Id == "bar_1m_live" && e.Role == Role.Live);
-        Assert.Equal("bar", live.InputHint);
+        Assert.Null(live.InputHint);
         Assert.Equal("BAR_HB_1M", live.SyncHint);
         var final = Assert.Single(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
         Assert.Equal("bar_1m_agg_final", final.InputHint);


### PR DESCRIPTION
## Summary
- avoid self-referencing for 1m live windows by omitting InputHint
- ensure fallback 1m live window also omits InputHint
- align DerivationPlanner tests and log diff

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c0510e58bc83279cbad11e715a681f