### PR TITLE
fix: reaggregate final tumbling projection

### DIFF
--- a/docs/diff_log/diff_derived_tumbling_pipeline_reagg_projection_20251103.md
+++ b/docs/diff_log/diff_derived_tumbling_pipeline_reagg_projection_20251103.md
@@ -1,0 +1,4 @@
+- derive Final/Prev1m select projection from aggregated columns
+- avoid referencing non-existent BID when building _1m_final
+- pull aggregation functions from original projection definitions
+- reaggregate any non-key projection column without assuming OHLC field names

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -6,17 +6,24 @@ using Kafka.Ksql.Linq.Query.Builders.Core;
 using Kafka.Ksql.Linq.Query.Dsl;
 using Kafka.Ksql.Linq.Query.Abstractions;
 using Kafka.Ksql.Linq.Mapping;
+using Kafka.Ksql.Linq;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Reflection.Emit;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 
 namespace Kafka.Ksql.Linq.Query.Analysis;
 
 internal static class DerivedTumblingPipeline
 {
+    private static readonly ModuleBuilder _module = AssemblyBuilder
+        .DefineDynamicAssembly(new AssemblyName("KafkaKsqlLinq.DerivedTumbling"), AssemblyBuilderAccess.Run)
+        .DefineDynamicModule("Main");
     public static async Task RunAsync(
         TumblingQao qao,
         EntityModel baseModel,
@@ -34,9 +41,9 @@ internal static class DerivedTumblingPipeline
         foreach (var m in models)
         {
             var role = Enum.Parse<Role>((string)m.AdditionalSettings["role"]);
-            var (ddl, dt, ns) = BuildDdlAndRegister(baseName, queryModel, m, role, resolveType);
-            logger.LogInformation("KSQL DDL (derived {Entity}): {Sql}", m.TopicName, ddl);
-            await execute(ddl);
+        var (ddl, dt, ns) = BuildDdlAndRegister(baseName, queryModel, m, role, resolveType);
+        logger.LogInformation("KSQL DDL (derived {Entity}): {Sql}", m.TopicName, ddl);
+        await execute(ddl);
             mapping.RegisterEntityModel(m, genericValue: true, overrideNamespace: ns);
             registry[dt] = m;
         }
@@ -56,6 +63,12 @@ internal static class DerivedTumblingPipeline
         Func<string, Type> resolveType)
     {
         var qm = queryModel.Clone();
+        if ((role == Role.Final || role == Role.Prev1m) && qm.SelectProjection != null)
+        {
+            var (sel, grp) = BuildFinalProjection(model, qm.SelectProjection);
+            qm.SelectProjection = sel;
+            qm.GroupByExpression = grp;
+        }
         var tf = (string)model.AdditionalSettings["timeframe"];
         Timeframe tfObj;
         if (tf.EndsWith("wk", StringComparison.OrdinalIgnoreCase))
@@ -84,5 +97,132 @@ internal static class DerivedTumblingPipeline
         model.SetStreamTableType(qm.DetermineType());
         var ns = model.AdditionalSettings.TryGetValue("namespace", out var nsObj) ? nsObj?.ToString() : null;
         return (ddl, dt, ns);
+    }
+
+    private static (LambdaExpression select, LambdaExpression group) BuildFinalProjection(
+        EntityModel model,
+        LambdaExpression baseProjection)
+    {
+        var joinKeys = (string[])model.AdditionalSettings["basedOn/joinKeys"];
+        var keyNames = (string[])model.AdditionalSettings["keys"];
+        var keyTypes = (Type[])model.AdditionalSettings["keys/types"];
+        var projNames = (string[])model.AdditionalSettings["projection"];
+        var projTypes = (Type[])model.AdditionalSettings["projection/types"];
+
+        var methods = new Dictionary<string, MethodInfo>();
+        switch (baseProjection.Body)
+        {
+            case MemberInitExpression m:
+                foreach (var b in m.Bindings.OfType<MemberAssignment>())
+                    if (b.Expression is MethodCallExpression mc)
+                        methods[b.Member.Name] = mc.Method.GetGenericMethodDefinition();
+                break;
+            case UnaryExpression { Operand: MemberInitExpression m }:
+                foreach (var b in m.Bindings.OfType<MemberAssignment>())
+                    if (b.Expression is MethodCallExpression mc)
+                        methods[b.Member.Name] = mc.Method.GetGenericMethodDefinition();
+                break;
+            case NewExpression ne when ne.Members != null:
+                for (int i = 0; i < ne.Members.Count; i++)
+                    if (ne.Arguments[i] is MethodCallExpression mc)
+                        methods[ne.Members[i].Name] = mc.Method.GetGenericMethodDefinition();
+                break;
+            case UnaryExpression { Operand: NewExpression ne } when ne.Members != null:
+                for (int i = 0; i < ne.Members.Count; i++)
+                    if (ne.Arguments[i] is MethodCallExpression mc)
+                        methods[ne.Members[i].Name] = mc.Method.GetGenericMethodDefinition();
+                break;
+        }
+
+        Type FindType(string name)
+        {
+            var idx = Array.FindIndex(keyNames, k => string.Equals(k, name, StringComparison.OrdinalIgnoreCase));
+            if (idx >= 0) return keyTypes[idx];
+            idx = Array.FindIndex(projNames, k => string.Equals(k, name, StringComparison.OrdinalIgnoreCase));
+            if (idx >= 0) return projTypes[idx];
+            return typeof(object);
+        }
+
+        var bucket = keyNames.FirstOrDefault(k => string.Equals(k, "BucketStart", StringComparison.OrdinalIgnoreCase)) ?? "BucketStart";
+
+        var keyList = joinKeys.ToList();
+        if (!keyList.Any(k => string.Equals(k, bucket, StringComparison.OrdinalIgnoreCase)))
+            keyList.Add(bucket);
+
+        var keyProps = keyList.Select(k => (Name: k, Type: FindType(k))).ToArray();
+        var valueNames = projNames
+            .Where(p => !keyList.Any(k => string.Equals(k, p, StringComparison.OrdinalIgnoreCase)))
+            .Where(p => methods.ContainsKey(p))
+            .ToArray();
+        var valueProps = valueNames.Select(v => (Name: v, Type: FindType(v))).ToArray();
+        var resultProps = keyProps.Concat(valueProps).ToArray();
+
+        Type CreateType((string Name, Type Type)[] props)
+        {
+            var tb = _module.DefineType("T" + Guid.NewGuid().ToString("N"), TypeAttributes.Public);
+            foreach (var p in props)
+            {
+                var field = tb.DefineField("_" + p.Name, p.Type, FieldAttributes.Private);
+                var prop = tb.DefineProperty(p.Name, PropertyAttributes.None, p.Type, null);
+                var get = tb.DefineMethod("get_" + p.Name, MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig, p.Type, Type.EmptyTypes);
+                var il = get.GetILGenerator();
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldfld, field);
+                il.Emit(OpCodes.Ret);
+                var set = tb.DefineMethod("set_" + p.Name, MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig, null, new[] { p.Type });
+                var il2 = set.GetILGenerator();
+                il2.Emit(OpCodes.Ldarg_0);
+                il2.Emit(OpCodes.Ldarg_1);
+                il2.Emit(OpCodes.Stfld, field);
+                il2.Emit(OpCodes.Ret);
+                prop.SetGetMethod(get);
+                prop.SetSetMethod(set);
+            }
+            return tb.CreateType()!;
+        }
+
+        var elementType = CreateType(resultProps);
+        var keyType = CreateType(keyProps);
+        var gType = typeof(IGrouping<,>).MakeGenericType(keyType, elementType);
+        var g = Expression.Parameter(gType, "g");
+        var keyExpr = Expression.Property(g, "Key");
+        var bindings = new List<MemberBinding>();
+
+        foreach (var kp in keyProps)
+        {
+            var prop = elementType.GetProperty(kp.Name)!;
+            var val = Expression.Property(keyExpr, kp.Name);
+            bindings.Add(Expression.Bind(prop, val));
+        }
+
+        var x = Expression.Parameter(elementType, "x");
+
+        Expression Agg(MethodInfo method, string col, Type retType)
+        {
+            var selectorBody = Expression.Property(x, col);
+            var selector = Expression.Lambda(selectorBody, x);
+            MethodInfo mi;
+            if (method.DeclaringType == typeof(OffsetAggregateExtensions))
+                mi = method.MakeGenericMethod(elementType, keyType, retType);
+            else if (method.GetGenericArguments().Length == 2)
+                mi = method.MakeGenericMethod(elementType, retType);
+            else
+                mi = method.MakeGenericMethod(elementType);
+            return Expression.Call(mi, g, selector);
+        }
+
+        foreach (var vp in valueProps)
+        {
+            var method = methods[vp.Name];
+            bindings.Add(Expression.Bind(elementType.GetProperty(vp.Name)!, Agg(method, vp.Name, vp.Type)));
+        }
+
+        var selectBody = Expression.MemberInit(Expression.New(elementType), bindings);
+        var select = Expression.Lambda(selectBody, g);
+
+        var r = Expression.Parameter(elementType, "r");
+        var keyBindings = keyProps.Select(kp => Expression.Bind(keyType.GetProperty(kp.Name)!, Expression.Property(r, kp.Name)));
+        var group = Expression.Lambda(Expression.MemberInit(Expression.New(keyType), keyBindings), r);
+        return (select, group);
     }
 }

--- a/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
@@ -6,9 +6,11 @@ using Kafka.Ksql.Linq.Mapping;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -46,7 +48,6 @@ public class DerivedTumblingPipelineTests
             SourceTypes = new[] { typeof(TestSource) },
             Windows = { "1m" }
         };
-
         var ddls = new ConcurrentBag<string>();
         Task Exec(string sql)
         {
@@ -112,5 +113,69 @@ public class DerivedTumblingPipelineTests
         var ddl5 = ddls.Single(s => s.Contains("_5m_final"));
         Assert.Contains("FROM bar_1m_final", ddl5);
         Assert.Contains("EMIT FINAL", ddl5);
+    }
+
+    [Fact]
+    public async Task Final_projection_reaggregates_columns()
+    {
+        var qao = new TumblingQao
+        {
+            TimeKey = "Timestamp",
+            Windows = new[] { new Timeframe(1, "m") },
+            Keys = new[] { "Broker", "Symbol", "BucketStart" },
+            Projection = new[] { "Broker", "Symbol", "BucketStart", "Open", "High", "Low", "KsqlTimeFrameClose", "Volume" },
+            PocoShape = new[]
+            {
+                new ColumnShape("Broker", typeof(string), false),
+                new ColumnShape("Symbol", typeof(string), false),
+                new ColumnShape("BucketStart", typeof(long), false),
+                new ColumnShape("Open", typeof(double), false),
+                new ColumnShape("High", typeof(double), false),
+                new ColumnShape("Low", typeof(double), false),
+                new ColumnShape("KsqlTimeFrameClose", typeof(double), false),
+                new ColumnShape("Volume", typeof(double), false)
+            },
+            BasedOn = new BasedOnSpec(new[] { "Broker", "Symbol" }, "Open", "KsqlTimeFrameClose", string.Empty),
+            WeekAnchor = DayOfWeek.Monday
+        };
+        var baseModel = new EntityModel { EntityType = typeof(TestSource) };
+        var model = new KsqlQueryModel
+        {
+            SourceTypes = new[] { typeof(TestSource) },
+            Windows = { "1m" }
+        };
+        Expression<Func<IGrouping<object, TestSource>, object>> sel = g => new
+        {
+            Open = g.EarliestByOffset(x => 0.0),
+            High = g.Max(x => 0.0),
+            Low = g.Min(x => 0.0),
+            KsqlTimeFrameClose = g.LatestByOffset(x => 0.0),
+            Volume = g.Sum(x => 0.0)
+        };
+        model.SelectProjection = sel;
+        Assert.NotNull(model.SelectProjection);
+
+        var ddls = new ConcurrentBag<string>();
+        Task Exec(string sql)
+        {
+            ddls.Add(sql);
+            return Task.CompletedTask;
+        }
+
+        var mapping = new MappingRegistry();
+        var registry = new ConcurrentDictionary<Type, EntityModel>();
+        var asm = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("dyn"), AssemblyBuilderAccess.Run);
+        var mod = asm.DefineDynamicModule("m");
+        Type Resolver(string _) => mod.DefineType("T" + Guid.NewGuid().ToString("N")).CreateType()!;
+
+        await DerivedTumblingPipeline.RunAsync(qao, baseModel, model, Exec, Resolver, mapping, registry, new LoggerFactory().CreateLogger("test"));
+
+        var ddl = ddls.Single(s => s.StartsWith("CREATE TABLE bar_1m_final") || s.StartsWith("CREATE STREAM bar_1m_final"));
+        Assert.Contains("EARLIEST_BY_OFFSET(Open) AS Open", ddl);
+        Assert.Contains("MAX(High) AS High", ddl);
+        Assert.Contains("MIN(Low) AS Low", ddl);
+        Assert.Contains("LATEST_BY_OFFSET(KsqlTimeFrameClose) AS KsqlTimeFrameClose", ddl);
+        Assert.Contains("SUM(Volume) AS Volume", ddl);
+        Assert.DoesNotContain("BID", ddl, StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
## Summary
- rebuild final/prev1m tumbling projections using aggregation methods from the original Select
- ensure _1m_final no longer references BID column and supports arbitrary value columns
- document derived tumbling reaggregation

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c0540eed9c832785049ecfee6edfe4