### PR TITLE
Remove windowing from final derived tumbling tables

### DIFF
--- a/docs/diff_log/diff_derived_tumbling_pipeline_final_nonwindow_20250909.md
+++ b/docs/diff_log/diff_derived_tumbling_pipeline_final_nonwindow_20250909.md
@@ -1,0 +1,3 @@
+- Final and Prev1m roles now clone query model and drop tumbling windows to create non-windowed persistent tables.
+- Grouping uses join keys plus bucket start from model settings while keeping EARLIEST_BY_OFFSET/O aggregation.
+- DDL generation for these roles uses KsqlCreateStatementBuilder without WINDOW clause and applies EMIT/FROM overrides.

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -16,6 +16,7 @@ using System.Reflection.Emit;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 
 namespace Kafka.Ksql.Linq.Query.Analysis;
 
@@ -63,11 +64,15 @@ internal static class DerivedTumblingPipeline
         Func<string, Type> resolveType)
     {
         var qm = queryModel.Clone();
-        if ((role == Role.Final || role == Role.Prev1m) && qm.SelectProjection != null)
+        if (role == Role.Final || role == Role.Prev1m)
         {
-            var (sel, grp) = BuildFinalProjection(model, qm.SelectProjection);
-            qm.SelectProjection = sel;
-            qm.GroupByExpression = grp;
+            if (qm.SelectProjection != null)
+            {
+                var (sel, grp) = BuildFinalProjection(model, qm.SelectProjection);
+                qm.SelectProjection = sel;
+                qm.GroupByExpression = grp;
+            }
+            qm.Windows.Clear();
         }
         var tf = (string)model.AdditionalSettings["timeframe"];
         Timeframe tfObj;
@@ -90,13 +95,31 @@ internal static class DerivedTumblingPipeline
             _ => $"{baseName}_{tf}"
         };
         var inputOverride = model.AdditionalSettings.TryGetValue("input", out var inputObj) ? inputObj?.ToString() : null;
-        var ddl = KsqlCreateWindowedStatementBuilder.Build(name, qm, tf, emit, inputOverride);
+        string ddl;
+        if (role == Role.Final || role == Role.Prev1m)
+        {
+            ddl = KsqlCreateStatementBuilder.Build(name, qm);
+            if (!string.IsNullOrWhiteSpace(emit))
+                ddl = ddl.Replace("EMIT CHANGES", emit);
+            if (!string.IsNullOrWhiteSpace(inputOverride))
+                ddl = OverrideFrom(ddl, inputOverride);
+        }
+        else
+        {
+            ddl = KsqlCreateWindowedStatementBuilder.Build(name, qm, tf, emit, inputOverride);
+        }
         var dt = resolveType(name);
         model.EntityType = dt;
         model.TopicName = name;
         model.SetStreamTableType(qm.DetermineType());
         var ns = model.AdditionalSettings.TryGetValue("namespace", out var nsObj) ? nsObj?.ToString() : null;
         return (ddl, dt, ns);
+    }
+
+    private static string OverrideFrom(string sql, string source)
+    {
+        var pattern = new Regex(@"\bFROM\s+([A-Za-z_][\w]*)\s+([A-Za-z_][\w]*)", RegexOptions.IgnoreCase);
+        return pattern.Replace(sql, m => $"FROM {source} {m.Groups[2].Value}", 1);
     }
 
     private static (LambdaExpression select, LambdaExpression group) BuildFinalProjection(


### PR DESCRIPTION
## Summary
- Drop tumbling windows for FINAL and PREV1M derived roles
- Regroup using model-defined join keys plus bucket start
- Build non-windowed DDL via `KsqlCreateStatementBuilder`

## Testing
- `dotnet build src/Kafka.Ksql.Linq.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --no-build -v q --filter 'FullyQualifiedName!~Kafka.Ksql.Linq.Tests.Integration'`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj -v q`


------
https://chatgpt.com/codex/tasks/task_e_68c0636f90b48327aa291449b51e3081