### PR TITLE
Remove agg_final stage from derived tumbling

### DIFF
--- a/docs/diff_log/diff_derivationplanner_1m_hub_20250909.md
+++ b/docs/diff_log/diff_derivationplanner_1m_hub_20250909.md
@@ -1,3 +1,3 @@
 - DerivationPlanner builds a 1m hub when no 1m window is specified.
-- Adds _1m_agg_final, _1m_live and _1m_final alongside hb_1m and prev_1m.
+- Adds _1m_live and _1m_final alongside hb_1m and prev_1m.
 - Tests verify _1m_live and _1m_final are created even with other windows.

--- a/docs/diff_log/diff_derivationplanner_remove_agg_final_20251116.md
+++ b/docs/diff_log/diff_derivationplanner_remove_agg_final_20251116.md
@@ -1,0 +1,4 @@
+- Removed _agg_final entities from derivation planning and derived pipeline naming.
+- Final entities now source from previous _final or base topic.
+- Fallback 1m hub's final stage uses base topic as input.
+- Tests and docs updated to drop _agg_final references.

--- a/src/Query/Adapters/EntityModelAdapter.cs
+++ b/src/Query/Adapters/EntityModelAdapter.cs
@@ -50,7 +50,6 @@ internal static class EntityModelAdapter
                 {
                     baseNs = e.Role switch
                     {
-                        Role.AggFinal => TrimSuffix(baseNs, $"_{e.Timeframe.Value}{e.Timeframe.Unit}_agg_final"),
                         Role.Live => TrimSuffix(baseNs, $"_{e.Timeframe.Value}{e.Timeframe.Unit}_live"),
                         Role.Final => TrimSuffix(baseNs, $"_{e.Timeframe.Value}{e.Timeframe.Unit}_final"),
                         Role.Prev1m => TrimSuffix(baseNs, "_prev_1m"),

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -49,23 +49,9 @@ internal static class DerivationPlanner
         foreach (var tf in windows)
         {
             var tfStr = $"{tf.Value}{tf.Unit}";
-            var aggId = $"{baseId}_{tfStr}_agg_final";
             var liveId = $"{baseId}_{tfStr}_live";
             var finalId = $"{baseId}_{tfStr}_final";
             var hbId = $"{baseId}_hb_{tfStr}";
-
-            var agg = new DerivedEntity
-            {
-                Id = aggId,
-                Role = Role.AggFinal,
-                Timeframe = tf,
-                KeyShape = keyShapes,
-                ValueShape = valueShapes,
-                InputHint = prevFinalId,
-                BasedOnSpec = basedOn,
-                WeekAnchor = qao.WeekAnchor
-            };
-            entities.Add(agg);
 
             string? liveInput = tf.Unit == "m" && tf.Value == 1
                 ? null
@@ -87,7 +73,7 @@ internal static class DerivationPlanner
             };
             entities.Add(live);
 
-            var finalInput = prevFinalId ?? aggId;
+            var finalInput = prevFinalId ?? baseId;
             var final = new DerivedEntity
             {
                 Id = finalId,
@@ -155,18 +141,6 @@ internal static class DerivationPlanner
         if (!windows.Any(w => w.Unit == "m" && w.Value == 1))
         {
             var tf = new Timeframe(1, "m");
-            var agg1m = new DerivedEntity
-            {
-                Id = $"{baseId}_1m_agg_final",
-                Role = Role.AggFinal,
-                Timeframe = tf,
-                KeyShape = keyShapes,
-                ValueShape = valueShapes,
-                BasedOnSpec = basedOn,
-                WeekAnchor = qao.WeekAnchor
-            };
-            entities.Add(agg1m);
-
             var live1m = new DerivedEntity
             {
                 Id = $"{baseId}_1m_live",
@@ -188,7 +162,7 @@ internal static class DerivationPlanner
                 Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
-                InputHint = agg1m.Id,
+                InputHint = baseId,
                 SyncHint = $"{baseId}_hb_1m".ToUpperInvariant(),
                 PrevHint = $"{baseId}_prev_1m",
                 BasedOnSpec = basedOn,

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -86,7 +86,6 @@ internal static class DerivedTumblingPipeline
         var emit = spec.Emit != null ? $"EMIT {spec.Emit}" : null;
         var name = role switch
         {
-            Role.AggFinal => $"{baseName}_{tf}_agg_final",
             Role.Live => $"{baseName}_{tf}_live",
             Role.Final => $"{baseName}_{tf}_final",
             Role.Prev1m => $"{baseName}_prev_1m",

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -46,17 +46,16 @@ public class DerivationPlannerTests
     };
 
     [Fact]
-    public void Plan_1m_Includes_Agg_Live_Final_Hb_Prev()
+    public void Plan_1m_Includes_Live_Final_Hb_Prev()
     {
         var model = new EntityModel { EntityType = typeof(Source) };
         var entities = DerivationPlanner.Plan(Create(new Timeframe(1, "m")), model);
 
-        Assert.Contains(entities, e => e.Id == "bar_1m_agg_final" && e.Role == Role.AggFinal);
         var live = Assert.Single(entities, e => e.Id == "bar_1m_live" && e.Role == Role.Live);
         Assert.Null(live.InputHint);
         Assert.Equal("BAR_HB_1M", live.SyncHint);
         var final = Assert.Single(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
-        Assert.Equal("bar_1m_agg_final", final.InputHint);
+        Assert.Equal("bar", final.InputHint);
         Assert.Equal("BAR_HB_1M", final.SyncHint);
         Assert.Equal("bar_prev_1m", final.PrevHint);
         var prev = Assert.Single(entities, e => e.Id == "bar_prev_1m" && e.Role == Role.Prev1m);
@@ -71,19 +70,16 @@ public class DerivationPlannerTests
         var model = new EntityModel { EntityType = typeof(Source) };
         var entities = DerivationPlanner.Plan(Create(new Timeframe(5, "m")), model);
 
-        var agg5 = Assert.Single(entities, e => e.Id == "bar_5m_agg_final" && e.Role == Role.AggFinal);
-        Assert.Null(agg5.InputHint);
         var live5 = Assert.Single(entities, e => e.Id == "bar_5m_live" && e.Role == Role.Live);
         Assert.Equal("bar_1m_live", live5.InputHint);
         Assert.Equal("BAR_HB_5M", live5.SyncHint);
         var final = Assert.Single(entities, e => e.Id == "bar_5m_final" && e.Role == Role.Final);
-        Assert.Equal("bar_5m_agg_final", final.InputHint);
+        Assert.Equal("bar", final.InputHint);
         Assert.Equal("BAR_HB_5M", final.SyncHint);
         Assert.Equal("bar_prev_1m", final.PrevHint);
-
-        Assert.Contains(entities, e => e.Id == "bar_1m_agg_final" && e.Role == Role.AggFinal);
         Assert.Contains(entities, e => e.Id == "bar_1m_live" && e.Role == Role.Live);
-        Assert.Contains(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
+        var final1m = Assert.Single(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
+        Assert.Equal("bar", final1m.InputHint);
         Assert.Contains(entities, e => e.Id == "bar_hb_5m" && e.Role == Role.Hb);
         Assert.Contains(entities, e => e.Id == "bar_hb_1m" && e.Role == Role.Hb);
         Assert.Contains(entities, e => e.Id == "bar_prev_1m" && e.Role == Role.Prev1m);

--- a/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
@@ -59,7 +59,7 @@ public class DerivedTumblingPipelineConcurrencyTests
 
         await DerivedTumblingPipeline.RunAsync(qao, baseModel, model, Exec, Resolver, mapping, registry, new LoggerFactory().CreateLogger("test"));
 
-        var expected = 9; // 1m: AggFinal/Live/Final + Hb + Prev, 5m: AggFinal/Live/Final + Hb
+        var expected = 7; // 1m: Live/Final + Hb + Prev, 5m: Live/Final + Hb
         Assert.Equal(expected, registry.Count);
         Assert.Equal(expected, ddls.Count);
         foreach (var ddl in ddls)


### PR DESCRIPTION
## Summary
- stop generating `_agg_final` entities; finals chain from previous `_final` or base topic
- drop `_agg_final` naming role from derived pipeline
- update tests and docs for new final-input behavior

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c068a7d6148327a8d1887fda10aa8e