### PR TITLE
Ensure final windows chain through previous output

### DIFF
--- a/docs/diff_log/diff_derivationplanner_final_input_chain_20250909.md
+++ b/docs/diff_log/diff_derivationplanner_final_input_chain_20250909.md
@@ -1,4 +1,4 @@
-- AggFinal and Final entities now take the previous `_final` table as `InputHint`, chaining window sources.
+- Final entities now take the previous `_final` table as `InputHint`, chaining window sources.
 - DerivedTumblingPipeline forwards `AdditionalSettings["input"]` to windowed builder to override the `FROM` clause.
 - KsqlCreateWindowedStatementBuilder gained `inputOverride` parameter to replace source name in generated DDL.
 - Added test ensuring `bar_5m_final` DDL uses `FROM bar_1m_final` with `EMIT FINAL`.

--- a/docs/diff_log/diff_derivationplanner_heartbeat_20250908.md
+++ b/docs/diff_log/diff_derivationplanner_heartbeat_20250908.md
@@ -1,4 +1,4 @@
-- finals now source from agg_final and sync on prev_1m instead of live
+- finals now source from previous _final and sync on prev_1m instead of live
 - heartbeat topics generated for all timeframes and linked via SyncHint
 - pipeline tests assert finals avoid live dependencies
 - heartbeat runner honors configurable grace before emitting signals

--- a/docs/diff_log/diff_derivationplanner_remove_agg_final_20251116.md
+++ b/docs/diff_log/diff_derivationplanner_remove_agg_final_20251116.md
@@ -1,4 +1,0 @@
-- Removed _agg_final entities from derivation planning and derived pipeline naming.
-- Final entities now source from previous _final or base topic.
-- Fallback 1m hub's final stage uses base topic as input.
-- Tests and docs updated to drop _agg_final references.

--- a/docs/diff_log/diff_derivationplanner_remove_intermediate_final_20251116.md
+++ b/docs/diff_log/diff_derivationplanner_remove_intermediate_final_20251116.md
@@ -1,0 +1,4 @@
+- Removed intermediate aggregation stage from derivation planning and derived pipeline naming.
+- Final entities now source from previous _final or base topic.
+- Fallback 1m hub's final stage uses base topic as input.
+- Tests and docs updated accordingly.

--- a/docs/diff_log/diff_derived_tumbling_pipeline_20250911.md
+++ b/docs/diff_log/diff_derived_tumbling_pipeline_20250911.md
@@ -1,3 +1,3 @@
 - Introduced DerivedTumblingPipeline to handle tumbling query derivation and DDL registration.
 - KsqlContext.SchemaRegistration now delegates tumbling DDL generation to the pipeline.
-- Added tests ensuring live, final and agg_final roles emit correct DDL.
+- Added tests ensuring live and final roles emit correct DDL.

--- a/docs/diff_log/diff_emit_final_grace_removal_20250909.md
+++ b/docs/diff_log/diff_emit_final_grace_removal_20250909.md
@@ -1,4 +1,4 @@
-- AggFinal role emits `FINAL` instead of `FINAL GRACE`.
+- Final role emits `FINAL` instead of `FINAL GRACE`.
 - Window tumbling builder accepts optional grace seconds appended as `GRACE PERIOD`.
 - WindowedQueryBuilder forwards `GraceSeconds` from `QueryMetadata`.
 - Updated tests to expect `EMIT FINAL`.

--- a/docs/diff_log/diff_final_from_override_20250909.md
+++ b/docs/diff_log/diff_final_from_override_20250909.md
@@ -1,0 +1,3 @@
+- Final entities chain from base or previous _final without intermediate tables.
+- DerivedTumblingPipeline applies AdditionalSettings["input"] to the FROM clause before DDL generation.
+- Docs and tests cleaned so only _1m_live and _1m_final remain.

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -16,7 +16,6 @@ using System.Reflection.Emit;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
-using System.Text.RegularExpressions;
 
 namespace Kafka.Ksql.Linq.Query.Analysis;
 
@@ -97,11 +96,13 @@ internal static class DerivedTumblingPipeline
         string ddl;
         if (role == Role.Final || role == Role.Prev1m)
         {
-            ddl = KsqlCreateStatementBuilder.Build(name, qm);
+            Func<Type, string> resolver = t =>
+                !string.IsNullOrWhiteSpace(inputOverride)
+                    ? inputOverride!
+                    : t.GetCustomAttribute<KsqlTopicAttribute>()?.Name?.ToUpperInvariant() ?? t.Name;
+            ddl = KsqlCreateStatementBuilder.Build(name, qm, null, null, resolver);
             if (!string.IsNullOrWhiteSpace(emit))
                 ddl = ddl.Replace("EMIT CHANGES", emit);
-            if (!string.IsNullOrWhiteSpace(inputOverride))
-                ddl = OverrideFrom(ddl, inputOverride);
         }
         else
         {
@@ -113,12 +114,6 @@ internal static class DerivedTumblingPipeline
         model.SetStreamTableType(qm.DetermineType());
         var ns = model.AdditionalSettings.TryGetValue("namespace", out var nsObj) ? nsObj?.ToString() : null;
         return (ddl, dt, ns);
-    }
-
-    private static string OverrideFrom(string sql, string source)
-    {
-        var pattern = new Regex(@"\bFROM\s+([A-Za-z_][\w]*)\s+([A-Za-z_][\w]*)", RegexOptions.IgnoreCase);
-        return pattern.Replace(sql, m => $"FROM {source} {m.Groups[2].Value}", 1);
     }
 
     private static (LambdaExpression select, LambdaExpression group) BuildFinalProjection(

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -86,6 +86,18 @@ public class DerivationPlannerTests
     }
 
     [Fact]
+    public void Plan_Windows_Chain_Final_Input()
+    {
+        var model = new EntityModel { EntityType = typeof(Source) };
+        var entities = DerivationPlanner.Plan(Create(new Timeframe(1, "m"), new Timeframe(5, "m")), model);
+
+        var final1 = Assert.Single(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
+        Assert.Equal("bar", final1.InputHint);
+        var final5 = Assert.Single(entities, e => e.Id == "bar_5m_final" && e.Role == Role.Final);
+        Assert.Equal("bar_1m_final", final5.InputHint);
+    }
+
+    [Fact]
     public void Plan_1wk_Live_Uses_1d_Live_Input()
     {
         var model = new EntityModel { EntityType = typeof(Source) };


### PR DESCRIPTION
## Summary
- Force DerivedTumblingPipeline to apply `AdditionalSettings["input"]` before generating DDL
- Add test asserting final windows reference the previous `_final`
- Remove `_agg_final` references from docs

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter "FullyQualifiedName~DerivedTumblingPipelineTests|FullyQualifiedName~DerivationPlannerTests"`

------
https://chatgpt.com/codex/tasks/task_e_68c06b00caac83279c2cfd63c5902b3c