### PR TITLE
Chain final inputs and override derived pipeline sources

### DIFF
--- a/docs/diff_log/diff_derivationplanner_final_input_chain_20250909_v2.md
+++ b/docs/diff_log/diff_derivationplanner_final_input_chain_20250909_v2.md
@@ -1,0 +1,4 @@
+# diff: derivationplanner final input chain update (2025-09-09)
+
+- first `_1m_final` entity reads directly from `baseId`
+- later final entities chain to the previous final

--- a/docs/diff_log/diff_derived_tumbling_pipeline_source_projection_20250909.md
+++ b/docs/diff_log/diff_derived_tumbling_pipeline_source_projection_20250909.md
@@ -1,0 +1,5 @@
+# diff: derived tumbling pipeline source projection override (2025-09-09)
+
+- `Role.Final` and `Role.Prev1m` clear `qm.Windows`
+- `FROM` source is replaced with `AdditionalSettings["input"]`
+- projection uses `Open`, `High`, `Low`, `KsqlTimeFrameClose` from the input table

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -47,7 +47,7 @@ internal static class DerivationPlanner
             .ToList();
         if (!windows.Any(w => w.Unit == "m" && w.Value == 1))
             windows.Insert(0, new Timeframe(1, "m"));
-        string? prevFinalId = null;
+        var prevFinalId = baseId;
         foreach (var tf in windows)
         {
             var tfStr = $"{tf.Value}{tf.Unit}";
@@ -75,7 +75,7 @@ internal static class DerivationPlanner
             };
             entities.Add(live);
 
-            var finalInput = prevFinalId ?? baseId;
+            var finalInput = prevFinalId;
             var final = new DerivedEntity
             {
                 Id = finalId,

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -63,15 +63,15 @@ internal static class DerivedTumblingPipeline
         Func<string, Type> resolveType)
     {
         var qm = queryModel.Clone();
+        var inputOverride = baseName;
+        if (model.AdditionalSettings.TryGetValue("input", out var inputObj))
+            inputOverride = inputObj?.ToString() ?? baseName;
         if (role == Role.Final || role == Role.Prev1m)
         {
-            if (qm.SelectProjection != null)
-            {
-                var (sel, grp) = BuildFinalProjection(model, qm.SelectProjection);
-                qm.SelectProjection = sel;
-                qm.GroupByExpression = grp;
-            }
             qm.Windows.Clear();
+            qm.GroupByExpression = null;
+            var inputType = resolveType(inputOverride);
+            qm.SelectProjection = BuildInputProjection(inputType);
         }
         var tf = (string)model.AdditionalSettings["timeframe"];
         Timeframe tfObj;
@@ -92,9 +92,6 @@ internal static class DerivedTumblingPipeline
             Role.Fill => $"{baseName}_{tf}_fill",
             _ => $"{baseName}_{tf}"
         };
-        var inputOverride = baseName;
-        if (model.AdditionalSettings.TryGetValue("input", out var inputObj))
-            inputOverride = inputObj?.ToString() ?? baseName;
         string ddl;
         if (role == Role.Final || role == Role.Prev1m)
         {
@@ -113,6 +110,20 @@ internal static class DerivedTumblingPipeline
         model.SetStreamTableType(qm.DetermineType());
         var ns = model.AdditionalSettings.TryGetValue("namespace", out var nsObj) ? nsObj?.ToString() : null;
         return (ddl, dt, ns);
+    }
+
+    private static LambdaExpression BuildInputProjection(Type inputType)
+    {
+        var p = Expression.Parameter(inputType, "x");
+        var props = new[] { "Open", "High", "Low", "KsqlTimeFrameClose" }
+            .Select(n => inputType.GetProperty(n, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase))
+            .Where(pr => pr != null)
+            .Cast<PropertyInfo>()
+            .ToArray();
+        if (props.Length == 0) return Expression.Lambda(p, p);
+        var bindings = props.Select(pr => Expression.Bind(pr, Expression.Property(p, pr)));
+        var body = Expression.MemberInit(Expression.New(inputType), bindings);
+        return Expression.Lambda(body, p);
     }
 
     private static (LambdaExpression select, LambdaExpression group) BuildFinalProjection(


### PR DESCRIPTION
## Summary
- chain `_final` entities so first minute final reads from base and later finals chain from previous
- for `Final`/`Prev1m` roles clear tumbling settings, override source, and project Open/High/Low/Close columns

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` *(fails: Kafka.Ksql.Linq.Tests.Query.Analysis.DerivedTumblingPipelineTests.Final_projection_reaggregates_columns)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b1897f6083279782fa3c630356ce