### PR TITLE
Support per-timeframe window grace

### DIFF
--- a/docs/diff_log/diff_window_grace_increment_20250910.md
+++ b/docs/diff_log/diff_window_grace_increment_20250910.md
@@ -1,0 +1,3 @@
+# Window grace increment
+- TumblingQao and ExpressionAnalysisResult track per-timeframe grace values.
+- DerivationPlanner, WindowValidator and builders enforce parent+1s grace.

--- a/features/window_grace_increment/instruction.md
+++ b/features/window_grace_increment/instruction.md
@@ -1,0 +1,2 @@
+# Window grace increment
+- Each window's grace is parent grace +1s.

--- a/src/Query/Adapters/EntityModelAdapter.cs
+++ b/src/Query/Adapters/EntityModelAdapter.cs
@@ -39,6 +39,7 @@ internal static class EntityModelAdapter
             model.AdditionalSettings["basedOn/closeInclusive"] = e.BasedOnSpec.IsCloseInclusive;
             model.AdditionalSettings["role"] = e.Role.ToString();
             model.AdditionalSettings["timeframe"] = $"{e.Timeframe.Value}{e.Timeframe.Unit}";
+            model.AdditionalSettings["graceSeconds"] = e.GraceSeconds;
             if (e.SyncHint != null) model.AdditionalSettings[$"sync"] = e.SyncHint;
             if (e.InputHint != null) model.AdditionalSettings[$"input"] = e.InputHint;
             if (e.PrevHint != null) model.AdditionalSettings[$"prev"] = e.PrevHint;

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -48,6 +48,14 @@ internal static class DerivationPlanner
             .ToList();
         if (!windows.Any(w => w.Unit == "s" && w.Value == 1))
             windows.Insert(0, new Timeframe(1, "s"));
+        var graceMap = new Dictionary<string, int>();
+        var grace = qao.GraceSeconds ?? 0;
+        foreach (var tf in windows)
+        {
+            grace++;
+            graceMap[$"{tf.Value}{tf.Unit}"] = grace;
+        }
+        qao.GracePerTimeframe = graceMap;
         var hub = $"{baseId}_1s_final_s";
         foreach (var tf in windows)
         {
@@ -65,7 +73,8 @@ internal static class DerivationPlanner
                     SyncHint = hbId.ToUpperInvariant(),
                     PrevHint = $"{baseId}_prev_1m",
                     BasedOnSpec = basedOn,
-                    WeekAnchor = qao.WeekAnchor
+                    WeekAnchor = qao.WeekAnchor,
+                    GraceSeconds = graceMap[tfStr]
                 };
                 entities.Add(final1s);
 
@@ -80,7 +89,8 @@ internal static class DerivationPlanner
                     SyncHint = hbId.ToUpperInvariant(),
                     PrevHint = $"{baseId}_prev_1m",
                     BasedOnSpec = basedOn,
-                    WeekAnchor = qao.WeekAnchor
+                    WeekAnchor = qao.WeekAnchor,
+                    GraceSeconds = graceMap[tfStr]
                 };
                 entities.Add(final1sStream);
 
@@ -93,7 +103,8 @@ internal static class DerivationPlanner
                     ValueShape = Array.Empty<ColumnShape>(),
                     MaterializationHint = MaterializationHint.Stream,
                     BasedOnSpec = basedOn,
-                    WeekAnchor = qao.WeekAnchor
+                    WeekAnchor = qao.WeekAnchor,
+                    GraceSeconds = graceMap[tfStr]
                 };
                 entities.Add(hb1s);
                 continue;
@@ -111,7 +122,8 @@ internal static class DerivationPlanner
                 InputHint = hub,
                 SyncHint = hbId.ToUpperInvariant(),
                 BasedOnSpec = basedOn,
-                WeekAnchor = qao.WeekAnchor
+                WeekAnchor = qao.WeekAnchor,
+                GraceSeconds = graceMap[tfStr]
             };
             entities.Add(live);
 
@@ -126,7 +138,8 @@ internal static class DerivationPlanner
                 SyncHint = hbId.ToUpperInvariant(),
                 PrevHint = $"{baseId}_prev_1m",
                 BasedOnSpec = basedOn,
-                WeekAnchor = qao.WeekAnchor
+                WeekAnchor = qao.WeekAnchor,
+                GraceSeconds = graceMap[tfStr]
             };
             entities.Add(final);
 
@@ -139,7 +152,8 @@ internal static class DerivationPlanner
                 ValueShape = Array.Empty<ColumnShape>(),
                 MaterializationHint = MaterializationHint.Stream,
                 BasedOnSpec = basedOn,
-                WeekAnchor = qao.WeekAnchor
+                WeekAnchor = qao.WeekAnchor,
+                GraceSeconds = graceMap[tfStr]
             };
             entities.Add(hb);
 
@@ -155,7 +169,8 @@ internal static class DerivationPlanner
                     InputHint = hub,
                     SyncHint = hbId.ToUpperInvariant(),
                     BasedOnSpec = basedOn,
-                    WeekAnchor = qao.WeekAnchor
+                    WeekAnchor = qao.WeekAnchor,
+                    GraceSeconds = graceMap[tfStr]
                 };
                 entities.Add(fill);
             }
@@ -172,7 +187,8 @@ internal static class DerivationPlanner
                     InputHint = hub,
                     SyncHint = hbId.ToUpperInvariant(),
                     BasedOnSpec = basedOn,
-                    WeekAnchor = qao.WeekAnchor
+                    WeekAnchor = qao.WeekAnchor,
+                    GraceSeconds = graceMap[tfStr]
                 };
                 entities.Add(prev);
             }
@@ -180,6 +196,7 @@ internal static class DerivationPlanner
         if (!entities.Any(e => e.Role == Role.Prev1m))
         {
             var hbId = $"{baseId}_hb_1m";
+            var grace1m = graceMap.TryGetValue("1m", out var g1) ? g1 : graceMap.Values.Last() + 1;
             var prev = new DerivedEntity
             {
                 Id = $"{baseId}_prev_1m",
@@ -190,7 +207,8 @@ internal static class DerivationPlanner
                 InputHint = hub,
                 SyncHint = hbId.ToUpperInvariant(),
                 BasedOnSpec = basedOn,
-                WeekAnchor = qao.WeekAnchor
+                WeekAnchor = qao.WeekAnchor,
+                GraceSeconds = grace1m
             };
             entities.Add(prev);
             if (!entities.Any(e => e.Id == hbId))
@@ -204,7 +222,8 @@ internal static class DerivationPlanner
                     ValueShape = Array.Empty<ColumnShape>(),
                     MaterializationHint = MaterializationHint.Stream,
                     BasedOnSpec = basedOn,
-                    WeekAnchor = qao.WeekAnchor
+                    WeekAnchor = qao.WeekAnchor,
+                    GraceSeconds = grace1m
                 };
                 entities.Add(hb);
             }

--- a/src/Query/Analysis/DerivedEntity.cs
+++ b/src/Query/Analysis/DerivedEntity.cs
@@ -37,4 +37,5 @@ internal class DerivedEntity
     public string? PrevHint { get; init; }
     public BasedOnSpec BasedOnSpec { get; init; } = new(new List<string>(), string.Empty, string.Empty, string.Empty);
     public DayOfWeek WeekAnchor { get; init; } = DayOfWeek.Monday;
+    public int GraceSeconds { get; init; }
 }

--- a/src/Query/Analysis/TumblingQao.cs
+++ b/src/Query/Analysis/TumblingQao.cs
@@ -24,4 +24,5 @@ internal class TumblingQao
     public DayOfWeek WeekAnchor { get; init; } = DayOfWeek.Monday;
     public int? BaseUnitSeconds { get; init; }
     public int? GraceSeconds { get; init; }
+    public Dictionary<string, int> GracePerTimeframe { get; set; } = new();
 }

--- a/src/Query/Builders/Core/WindowedQueryBuilder.cs
+++ b/src/Query/Builders/Core/WindowedQueryBuilder.cs
@@ -23,7 +23,10 @@ internal static class WindowedQueryBuilder
         if (role == Role.Live || role == Role.Final)
             sb.Append($"TABLE {input}");
         if (spec.Window)
-            sb.Append(' ').Append(QueryBuilderUtils.ApplyWindowTumbling(tfStr, md.GraceSeconds));
+        {
+            var grace = md.GetProperty<int?>($"grace/{tfStr}");
+            sb.Append(' ').Append(QueryBuilderUtils.ApplyWindowTumbling(tfStr, grace));
+        }
         if (spec.Emit != null)
             sb.Append(' ').Append($"EMIT {spec.Emit}");
         if (spec.SyncHb1m)

--- a/src/Query/Pipeline/ExpressionAnalysisResult.cs
+++ b/src/Query/Pipeline/ExpressionAnalysisResult.cs
@@ -22,6 +22,7 @@ internal class ExpressionAnalysisResult
     public DayOfWeek WeekAnchor { get; set; } = DayOfWeek.Monday;
     public int? BaseUnitSeconds { get; set; }
     public int? GraceSeconds { get; set; }
+    public Dictionary<string, int> GracePerTimeframe { get; } = new();
 
     public List<string> BasedOnJoinKeys { get; } = new();
     public string? BasedOnOpen { get; set; }
@@ -41,7 +42,7 @@ internal class ExpressionAnalysisResult
 
     public QueryMetadata ToMetadata()
     {
-        var md = new QueryMetadata(DateTime.UtcNow, "Query");
+        var md = new QueryMetadata(DateTime.UtcNow, "Query") { GraceSeconds = GraceSeconds };
         md = md.WithProperty("windows", Windows.ToArray());
         md = md.WithProperty("timeKey", TimeKey!);
         md = md.WithProperty("basedOn/joinKeys", BasedOnJoinKeys.ToArray());
@@ -59,6 +60,9 @@ internal class ExpressionAnalysisResult
         md = md.WithProperty("roles/final", Windows.ToArray());
         md = md.WithProperty("roles/prev", new[] { "1m" });
         md = md.WithProperty("roles/hb", new[] { "1m" });
+
+        foreach (var kv in GracePerTimeframe)
+            md = md.WithProperty($"grace/{kv.Key}", kv.Value);
 
         if (PocoType != null)
         {

--- a/src/Query/Pipeline/WindowValidator.cs
+++ b/src/Query/Pipeline/WindowValidator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 namespace Kafka.Ksql.Linq.Query.Pipeline;
 
@@ -17,7 +18,8 @@ internal static class WindowValidator
         if (60 % baseUnit != 0)
             throw new InvalidOperationException("Base unit must divide 60 seconds.");
 
-        foreach (var w in result.Windows)
+        var ordered = result.Windows.OrderBy(ToSeconds).ToList();
+        foreach (var w in ordered)
         {
             var seconds = ToSeconds(w);
 
@@ -26,6 +28,15 @@ internal static class WindowValidator
 
             if (seconds >= 60 && seconds % 60 != 0)
                 throw new InvalidOperationException("Windows ≥ 1 minute must be whole-minute multiples.");
+        }
+
+        var grace = result.GraceSeconds ?? 0;
+        foreach (var w in ordered)
+        {
+            grace++;
+            if (result.GracePerTimeframe.TryGetValue(w, out var g) && g != grace)
+                throw new InvalidOperationException($"Window {w} grace must be parent grace + 1s.");
+            result.GracePerTimeframe[w] = grace;
         }
     }
 

--- a/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
+++ b/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
@@ -62,6 +62,16 @@ public class WindowedQueryBuilderCoreTests
     }
 
     [Fact]
+    public void FinalBuilder_Uses_PerTimeframe_Grace()
+    {
+        var md = BaseMd()
+            .WithProperty("input/1mFinal", "src")
+            .WithProperty("grace/1m", 4);
+        var q = FinalBuilder.Build(md, "1m");
+        Assert.Contains("WINDOW TUMBLING(1m GRACE PERIOD 4s)", q);
+    }
+
+    [Fact]
     public void Core_Applies_TimeFrame_Join_And_Boundary_To_All()
     {
         var md = BaseMd().WithProperty("input/1mLive", "s");

--- a/tests/Query/Pipeline/WindowValidatorTests.cs
+++ b/tests/Query/Pipeline/WindowValidatorTests.cs
@@ -57,4 +57,23 @@ public class WindowValidatorTests
         res.Windows.Add("120s");
         WindowValidator.Validate(res);
     }
+
+    [Fact]
+    public void Validate_Computes_Grace_Map()
+    {
+        var res = new ExpressionAnalysisResult { BaseUnitSeconds = 5, GraceSeconds = 1 };
+        res.Windows.Add("10s");
+        WindowValidator.Validate(res);
+        Assert.Equal(2, res.GracePerTimeframe["10s"]);
+    }
+
+    [Fact]
+    public void Validate_Throws_When_Grace_Mismatch()
+    {
+        var res = new ExpressionAnalysisResult { BaseUnitSeconds = 5, GraceSeconds = 1 };
+        res.Windows.Add("10s");
+        res.GracePerTimeframe["10s"] = 5;
+        var ex = Assert.Throws<InvalidOperationException>(() => WindowValidator.Validate(res));
+        Assert.Equal("Window 10s grace must be parent grace + 1s.", ex.Message);
+    }
 }


### PR DESCRIPTION
## Summary
- track initial and per-window grace in tumbling analysis results
- validate and propagate parent+1s grace through derivation and query building
- add tests for grace mapping and window generation

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c16459e3808327963a2679b2a13200