### PR TITLE
Handle month windows from 1s hub

### DIFF
--- a/docs/diff_log/diff_derivationplanner_months_20251117.md
+++ b/docs/diff_log/diff_derivationplanner_months_20251117.md
@@ -1,0 +1,4 @@
+# Diff: DerivationPlanner months
+
+- Planner orders month windows by converting months to 43200 minutes.
+- ExpressionAnalysisResult maps month windows to the 1s hub input.

--- a/features/derivationplanner_months/instruction.md
+++ b/features/derivationplanner_months/instruction.md
@@ -1,0 +1,4 @@
+# DerivationPlanner months
+
+Monthly windows roll up from the 1s hub and are ordered by converting months to 43200-minute units.
+See docs/diff_log/diff_derivationplanner_months_20251117.md for details.

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -43,6 +43,7 @@ internal static class DerivationPlanner
                 "h" => w.Value * 60,
                 "d" => w.Value * 1440,
                 "wk" => w.Value * 10080,
+                "mo" => w.Value * 43200,
                 _ => w.Value
             })
             .ToList();

--- a/src/Query/Pipeline/ExpressionAnalysisResult.cs
+++ b/src/Query/Pipeline/ExpressionAnalysisResult.cs
@@ -78,6 +78,7 @@ internal class ExpressionAnalysisResult
                 var liveInput = tf switch
                 {
                     "1wk" => $"{baseId}_1d_live",
+                    _ when tf.EndsWith("mo") => $"{baseId}_1s_final_s",
                     _ => $"{baseId}_1m_live"
                 };
                 md = md.WithProperty($"input/{tf}Live", liveInput);

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -127,6 +127,15 @@ public class DerivationPlannerTests
     }
 
     [Fact]
+    public void Plan_Month_Windows_Use_Hub()
+    {
+        var model = new EntityModel { EntityType = typeof(Source) };
+        var entities = DerivationPlanner.Plan(Create(new Timeframe(1, "mo")), model);
+        var live = Assert.Single(entities, e => e.Id == "bar_1mo_live" && e.Role == Role.Live);
+        Assert.Equal("bar_1s_final_s", live.InputHint);
+    }
+
+    [Fact]
     public void Plan_WhenEmpty_Adds_Fill_Entity()
     {
         var model = new EntityModel { EntityType = typeof(Source) };

--- a/tests/Query/Dsl/PropertyNameParsingTests.cs
+++ b/tests/Query/Dsl/PropertyNameParsingTests.cs
@@ -104,6 +104,15 @@ public class PropertyNameParsingTests
     }
 
     [Fact]
+    public void Tumbling_Orders_Month_Windows()
+    {
+        var model = new KsqlQueryable<Rate>()
+            .Tumbling(r => r.Timestamp, new Windows { Days = new[] { 1 }, Months = new[] { 6, 1 } })
+            .Build();
+        Assert.Equal(new[] { "1d", "1mo", "6mo" }, model.Windows);
+    }
+
+    [Fact]
     public void WhenEmpty_Sets_Flag()
     {
         var q = Expression.Parameter(typeof(KsqlQueryable<Rate>), "q");

--- a/tests/Query/Pipeline/ExpressionAnalysisResultMonthTests.cs
+++ b/tests/Query/Pipeline/ExpressionAnalysisResultMonthTests.cs
@@ -1,0 +1,29 @@
+using Kafka.Ksql.Linq.Core.Attributes;
+using Kafka.Ksql.Linq.Query.Pipeline;
+using System;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Pipeline;
+
+public class ExpressionAnalysisResultMonthTests
+{
+    [KsqlTopic("bar")]
+    private class Source { }
+
+    [Fact]
+    public void Metadata_Uses_Hub_For_Month_Window()
+    {
+        var res = new ExpressionAnalysisResult
+        {
+            PocoType = typeof(Source),
+            TimeKey = "Ts",
+            BasedOnOpen = "Open",
+            BasedOnClose = "Close",
+            BasedOnDayKey = "Day"
+        };
+        res.BasedOnJoinKeys.Add("Id");
+        res.Windows.Add("1mo");
+        var md = res.ToMetadata();
+        Assert.Equal("bar_1s_final_s", md.GetProperty<string>("input/1moLive"));
+    }
+}


### PR DESCRIPTION
## Summary
- order month windows using 43200-minute conversion
- map month rollups to the 1s hub input
- test months window ordering and hub inputs

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c1666394d08327abc8e4c693ed6c72