### PR TITLE
Use hub stream for metadata sync

### DIFF
--- a/docs/diff_log/diff_expressionanalysisresult_hub_20250910.md
+++ b/docs/diff_log/diff_expressionanalysisresult_hub_20250910.md
@@ -1,0 +1,3 @@
+- Adjust ExpressionAnalysisResult.ToMetadata to emit sync/prev/input from baseId_1s_final_s.
+- roles/prev and roles/hb no longer include fixed 1m; added only when PocoType present.
+- Updated RollupBuilderTests for new hub naming.

--- a/src/Query/Pipeline/ExpressionAnalysisResult.cs
+++ b/src/Query/Pipeline/ExpressionAnalysisResult.cs
@@ -58,8 +58,6 @@ internal class ExpressionAnalysisResult
         md = md.WithProperty("roles/live", Windows.ToArray());
         md = md.WithProperty("roles/aggFinal", Windows.ToArray());
         md = md.WithProperty("roles/final", Windows.ToArray());
-        md = md.WithProperty("roles/prev", new[] { "1m" });
-        md = md.WithProperty("roles/hb", new[] { "1m" });
 
         foreach (var kv in GracePerTimeframe)
             md = md.WithProperty($"grace/{kv.Key}", kv.Value);
@@ -68,23 +66,18 @@ internal class ExpressionAnalysisResult
         {
             var topicAttr = PocoType.GetCustomAttribute<KsqlTopicAttribute>();
             var baseId = (topicAttr?.Name ?? PocoType.Name).ToLowerInvariant();
-            var hb = $"{baseId}_hb_1m".ToUpperInvariant();
-            var prevId = $"{baseId}_prev_1m";
-            md = md.WithProperty("sync/1mLive", hb);
-            md = md.WithProperty("sync/1mFinal", hb);
-            md = md.WithProperty("prev/1mFinal", prevId);
+            var hub = $"{baseId}_1s_final_s";
+            md = md.WithProperty("sync/1mLive", hub);
+            md = md.WithProperty("sync/1mFinal", hub);
+            md = md.WithProperty("prev/1mFinal", hub);
             foreach (var tf in Windows)
             {
-                var liveInput = tf switch
-                {
-                    "1wk" => $"{baseId}_1d_live",
-                    _ when tf.EndsWith("mo") => $"{baseId}_1s_final_s",
-                    _ => $"{baseId}_1m_live"
-                };
-                md = md.WithProperty($"input/{tf}Live", liveInput);
-                md = md.WithProperty($"input/{tf}Final", liveInput);
-                md = md.WithProperty($"prev/{tf}Final", prevId);
+                md = md.WithProperty($"input/{tf}Live", hub);
+                md = md.WithProperty($"input/{tf}Final", hub);
+                md = md.WithProperty($"prev/{tf}Final", hub);
             }
+            md = md.WithProperty("roles/prev", new[] { "1m" });
+            md = md.WithProperty("roles/hb", new[] { "1m" });
         }
         return md;
     }

--- a/tests/Query/Builders/RollupBuilderTests.cs
+++ b/tests/Query/Builders/RollupBuilderTests.cs
@@ -95,9 +95,9 @@ public class RollupBuilderTests
     {
         var md = BuildMetadata();
         var sql = LiveBuilder.Build(md, "1m");
-        Assert.Contains("TABLE bar_1m_live WINDOW TUMBLING(1m)", sql);
+        Assert.Contains("TABLE bar_1s_final_s WINDOW TUMBLING(1m)", sql);
         Assert.Contains("EMIT CHANGES", sql);
-        Assert.Contains("SYNC BAR_HB_1M", sql);
+        Assert.Contains("SYNC bar_1s_final_s", sql);
     }
 
     [Fact]
@@ -105,8 +105,8 @@ public class RollupBuilderTests
     {
         var md = BuildMetadata();
         var sql = LiveBuilder.Build(md, "5m");
-        Assert.Contains("TABLE bar_1m_live WINDOW TUMBLING(5m)", sql);
-        Assert.DoesNotContain("BAR_HB_1M", sql);
+        Assert.Contains("TABLE bar_1s_final_s WINDOW TUMBLING(5m)", sql);
+        Assert.DoesNotContain("SYNC", sql);
     }
 
     [Fact]
@@ -114,13 +114,13 @@ public class RollupBuilderTests
     {
         var md = BuildMetadata();
         var sql = FinalBuilder.Build(md, "5m");
-        Assert.Contains("TABLE bar_1m_live WINDOW TUMBLING(5m)", sql);
+        Assert.Contains("TABLE bar_1s_final_s WINDOW TUMBLING(5m)", sql);
         Assert.Contains("EMIT FINAL", sql);
-        Assert.DoesNotContain("BAR_HB_1M", sql);
+        Assert.DoesNotContain("SYNC", sql);
         Assert.DoesNotContain("COMPOSE(", sql);
         var sql1 = FinalBuilder.Build(md, "1m");
-        Assert.Contains("TABLE bar_1m_live WINDOW TUMBLING(1m)", sql1);
-        Assert.Contains("SYNC BAR_HB_1M", sql1);
+        Assert.Contains("TABLE bar_1s_final_s WINDOW TUMBLING(1m)", sql1);
+        Assert.Contains("SYNC bar_1s_final_s", sql1);
         Assert.DoesNotContain("COMPOSE(", sql1);
     }
 


### PR DESCRIPTION
## Summary
- derive metadata sync/prev/input from hub stream `*_1s_final_s`
- add heartbeat/prev roles only when Poco metadata is available
- adjust rollup builder tests for hub-named input and sync

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c168a968248327973d1b8b88904740