### PR TITLE
feat: conditionally hint prev1m for 1s hub

### DIFF
--- a/docs/diff_log/diff_derivationplanner_final1s_prevhint_20250910.md
+++ b/docs/diff_log/diff_derivationplanner_final1s_prevhint_20250910.md
@@ -1,0 +1,4 @@
+# Diff: DerivationPlanner final1s prevhint
+
+- Final1s and Final1sStream no longer set `PrevHint` unless a 1m window is requested.
+- Updated tests to cover conditional `PrevHint` on the 1s hub.

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -35,6 +35,8 @@ internal static class DerivationPlanner
 
         var topicAttr = model.EntityType.GetCustomAttribute<KsqlTopicAttribute>();
         var baseId = (topicAttr?.Name ?? model.TopicName ?? model.EntityType.Name).ToLowerInvariant();
+        var has1m = qao.Windows.Any(w => w.Unit == "m" && w.Value == 1);
+        var prev1mHint = has1m ? $"{baseId}_prev_1m" : null;
         var windows = qao.Windows
             .OrderBy(w => w.Unit switch
             {
@@ -72,7 +74,7 @@ internal static class DerivationPlanner
                     KeyShape = keyShapes,
                     ValueShape = valueShapes,
                     SyncHint = hbId.ToUpperInvariant(),
-                    PrevHint = $"{baseId}_prev_1m",
+                    PrevHint = prev1mHint,
                     BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor,
                     GraceSeconds = graceMap[tfStr]
@@ -88,7 +90,7 @@ internal static class DerivationPlanner
                     ValueShape = valueShapes,
                     InputHint = $"{baseId}_1s_final",
                     SyncHint = hbId.ToUpperInvariant(),
-                    PrevHint = $"{baseId}_prev_1m",
+                    PrevHint = prev1mHint,
                     BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor,
                     GraceSeconds = graceMap[tfStr]

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -50,8 +50,10 @@ public class DerivationPlannerTests
     {
         var model = new EntityModel { EntityType = typeof(Source) };
         var entities = DerivationPlanner.Plan(Create(new Timeframe(1, "m")), model);
-        Assert.Contains(entities, e => e.Id == "bar_1s_final" && e.Role == Role.Final1s);
-        Assert.Contains(entities, e => e.Id == "bar_1s_final_s" && e.Role == Role.Final1sStream);
+        var final1s = Assert.Single(entities, e => e.Id == "bar_1s_final" && e.Role == Role.Final1s);
+        Assert.Equal("bar_prev_1m", final1s.PrevHint);
+        var final1sStream = Assert.Single(entities, e => e.Id == "bar_1s_final_s" && e.Role == Role.Final1sStream);
+        Assert.Equal("bar_prev_1m", final1sStream.PrevHint);
         var live = Assert.Single(entities, e => e.Id == "bar_1m_live" && e.Role == Role.Live);
         Assert.Equal("bar_1s_final_s", live.InputHint);
         Assert.Equal("BAR_HB_1M", live.SyncHint);
@@ -71,8 +73,10 @@ public class DerivationPlannerTests
     {
         var model = new EntityModel { EntityType = typeof(Source) };
         var entities = DerivationPlanner.Plan(Create(new Timeframe(5, "m")), model);
-        Assert.Contains(entities, e => e.Id == "bar_1s_final" && e.Role == Role.Final1s);
-        Assert.Contains(entities, e => e.Id == "bar_1s_final_s" && e.Role == Role.Final1sStream);
+        var final1s = Assert.Single(entities, e => e.Id == "bar_1s_final" && e.Role == Role.Final1s);
+        Assert.Null(final1s.PrevHint);
+        var final1sStream = Assert.Single(entities, e => e.Id == "bar_1s_final_s" && e.Role == Role.Final1sStream);
+        Assert.Null(final1sStream.PrevHint);
         var live5 = Assert.Single(entities, e => e.Id == "bar_5m_live" && e.Role == Role.Live);
         Assert.Equal("bar_1s_final_s", live5.InputHint);
         Assert.Equal("BAR_HB_5M", live5.SyncHint);


### PR DESCRIPTION
## Summary
- only set PrevHint on 1s final entities when a 1m window is requested
- adjust DerivationPlanner tests for conditional PrevHint
- document derivation planner prevhint change

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter DerivationPlannerTests`


------
https://chatgpt.com/codex/tasks/task_e_68c16b7dbd248327882f931aa1ddf92e