### PR TITLE
Propagate window grace map to derived entities

### DIFF
--- a/docs/diff_log/diff_window_grace_propagation_20251127.md
+++ b/docs/diff_log/diff_window_grace_propagation_20251127.md
@@ -1,0 +1,3 @@
+- TumblingQao holds a read-only Grace map per timeframe.
+- DerivationPlanner uses parent grace +1 for each derived entity and updates the map in place.
+- WindowValidator verifies provided Grace values and only populates missing entries.

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -50,13 +50,19 @@ internal static class DerivationPlanner
         if (!windows.Any(w => w.Unit == "s" && w.Value == 1))
             windows.Insert(0, new Timeframe(1, "s"));
         var graceMap = new Dictionary<string, int>();
-        var grace = qao.GraceSeconds ?? 0;
+        var prevGrace = qao.GraceSeconds ?? 0;
         foreach (var tf in windows)
         {
-            grace++;
-            graceMap[$"{tf.Value}{tf.Unit}"] = grace;
+            var key = $"{tf.Value}{tf.Unit}";
+            if (qao.GracePerTimeframe.TryGetValue(key, out var parent))
+                prevGrace = parent;
+            var next = prevGrace + 1;
+            graceMap[key] = next;
+            prevGrace = next;
         }
-        qao.GracePerTimeframe = graceMap;
+        qao.GracePerTimeframe.Clear();
+        foreach (var kv in graceMap)
+            qao.GracePerTimeframe[kv.Key] = kv.Value;
         var hub = $"{baseId}_1s_final_s";
         foreach (var tf in windows)
         {

--- a/src/Query/Analysis/TumblingQao.cs
+++ b/src/Query/Analysis/TumblingQao.cs
@@ -24,5 +24,5 @@ internal class TumblingQao
     public DayOfWeek WeekAnchor { get; init; } = DayOfWeek.Monday;
     public int? BaseUnitSeconds { get; init; }
     public int? GraceSeconds { get; init; }
-    public Dictionary<string, int> GracePerTimeframe { get; set; } = new();
+    public Dictionary<string, int> GracePerTimeframe { get; } = new();
 }

--- a/src/Query/Pipeline/WindowValidator.cs
+++ b/src/Query/Pipeline/WindowValidator.cs
@@ -34,9 +34,15 @@ internal static class WindowValidator
         foreach (var w in ordered)
         {
             grace++;
-            if (result.GracePerTimeframe.TryGetValue(w, out var g) && g != grace)
-                throw new InvalidOperationException($"Window {w} grace must be parent grace + 1s.");
-            result.GracePerTimeframe[w] = grace;
+            if (result.GracePerTimeframe.TryGetValue(w, out var g))
+            {
+                if (g != grace)
+                    throw new InvalidOperationException($"Window {w} grace must be parent grace + 1s.");
+            }
+            else
+            {
+                result.GracePerTimeframe[w] = grace;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- keep per-timeframe grace map on tumbling QAO
- propagate parent grace +1s to derived entities
- verify provided grace values before populating missing entries

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter FullyQualifiedName\!~Integration`

------
https://chatgpt.com/codex/tasks/task_e_68c1716422f08327b49244a34df0c059