### PR TITLE
Handle month ordering for derivation planner

### DIFF
--- a/docs/diff_log/diff_derivationplanner_months_to_minutes_20250910.md
+++ b/docs/diff_log/diff_derivationplanner_months_to_minutes_20250910.md
@@ -1,0 +1,7 @@
+# DerivationPlanner months to minutes order
+
+## Summary
+- Treat `mo` windows as minutes (30 days) when ordering timeframes.
+
+## Impact
+- Month-based windows are ordered correctly relative to other units.

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -43,7 +43,7 @@ internal static class DerivationPlanner
                 "h" => w.Value * 60,
                 "d" => w.Value * 1440,
                 "wk" => w.Value * 10080,
-                "mo" => w.Value * 43200,
+                "mo" => w.Value * 43200m,
                 _ => w.Value
             })
             .ToList();

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -134,6 +134,17 @@ public class DerivationPlannerTests
     }
 
     [Fact]
+    public void Plan_Months_Array_Uses_Hub()
+    {
+        var model = new EntityModel { EntityType = typeof(Source) };
+        var entities = DerivationPlanner.Plan(Create(new Timeframe(1, "mo"), new Timeframe(12, "mo")), model);
+        var live1 = Assert.Single(entities, e => e.Id == "bar_1mo_live" && e.Role == Role.Live);
+        Assert.Equal("bar_1s_final_s", live1.InputHint);
+        var live12 = Assert.Single(entities, e => e.Id == "bar_12mo_live" && e.Role == Role.Live);
+        Assert.Equal("bar_1s_final_s", live12.InputHint);
+    }
+
+    [Fact]
     public void Plan_WhenEmpty_Adds_Fill_Entity()
     {
         var model = new EntityModel { EntityType = typeof(Source) };


### PR DESCRIPTION
## Summary
- convert month timeframe to minutes when ordering windows
- test month windows input via hub
- document month ordering change

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c17316f4dc8327b1541bfa0325e7f2