### PR TITLE
Add projection analyzer for WindowStart validation

### DIFF
--- a/docs/diff_log/diff_projection_analyzer_windowstart_20250910.md
+++ b/docs/diff_log/diff_projection_analyzer_windowstart_20250910.md
@@ -1,0 +1,3 @@
+# ProjectionAnalyzer WindowStart validation
+- Added `ProjectionAnalyzer` to enforce exactly one `WindowStart()` in projections.
+- Added tests covering missing and multiple `WindowStart()` calls.

--- a/src/Query/Analysis/ProjectionAnalyzer.cs
+++ b/src/Query/Analysis/ProjectionAnalyzer.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Linq.Expressions;
+using Kafka.Ksql.Linq.Query.Builders;
+
+namespace Kafka.Ksql.Linq.Query.Analysis;
+
+internal static class ProjectionAnalyzer
+{
+    public static void Validate(LambdaExpression projection)
+    {
+        if (projection == null) throw new ArgumentNullException(nameof(projection));
+        var visitor = new WindowStartDetectionVisitor();
+        visitor.Visit(projection.Body);
+        if (visitor.Count == 0)
+            throw new InvalidOperationException("WindowStart() projection required for windowed queries");
+        if (visitor.Count != 1)
+            throw new InvalidOperationException("Windowed query requires exactly one WindowStart() in projection.");
+    }
+}

--- a/tests/Query/Analysis/ProjectionAnalyzerTests.cs
+++ b/tests/Query/Analysis/ProjectionAnalyzerTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Query.Analysis;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Analysis;
+
+public class ProjectionAnalyzerTests
+{
+    [Fact]
+    public void Validate_NoWindowStart_Throws()
+    {
+        Expression<Func<IGrouping<int, int>, object>> expr = g => new { Count = g.Count() };
+        var ex = Assert.Throws<InvalidOperationException>(() => ProjectionAnalyzer.Validate(expr));
+        Assert.Contains("WindowStart() projection required for windowed queries", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_MultipleWindowStart_Throws()
+    {
+        Expression<Func<IGrouping<int, int>, object>> expr = g => new { Start1 = g.WindowStart(), Start2 = g.WindowStart() };
+        var ex = Assert.Throws<InvalidOperationException>(() => ProjectionAnalyzer.Validate(expr));
+        Assert.Contains("Windowed query requires exactly one WindowStart() in projection.", ex.Message);
+    }
+}


### PR DESCRIPTION
## Summary
- enforce exactly one `WindowStart()` in projections
- test missing and duplicate `WindowStart()` scenarios
- record change in diff log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter FullyQualifiedName\!~Kafka.Ksql.Linq.Tests.Integration`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c1766d7ba083278df06f8f693ad0a5