### PR TITLE
Clarify filteredraw upstream responsibility and use filtered names in tests

### DIFF
--- a/docs/chart.md
+++ b/docs/chart.md
@@ -26,7 +26,8 @@ TimeFrame → Tumbling → GroupBy → Select → (WhenEmpty?)
     && s.Open <= r.Timestamp && r.Timestamp < s.Close,
     dayKey: s => s.MarketDate)
 ```
-- **実行レイヤでの原則**：マーケットスケジュールによる取引時間判定は Raw 取り込み直後（または最上流）で付与し、`IsTrading` による **filteredraw** を生成してから集計する（DSL外の責務）
+- **実行レイヤでの原則**: マーケットスケジュールによる取引時間判定は Raw 取り込み直後（または最上流）で付与し、`IsTrading` による **filteredraw** を生成してから集計する。  
+  filteredraw の生成は上流責務であり、DSL は `<raw_stream_name>_filtered` を参照するのみ。
 - `dayKey` は **日足以上（days, months）**で営業日境界を与える **マーカー**。
 - 分足・時間足では原則不要（指定可）。スケジュール判定自体は上流ガードで行う。
 
@@ -141,7 +142,7 @@ TimeFrame → Tumbling → GroupBy → Select → (WhenEmpty?)
   - 例: `bar_1s_final`, `bar_1m_live`, `bar_5m_live`, `bar_1d_live`
 - **timeframe表記**: `s`=秒, `m`=分, `h`=時間, `d`=日, `mo`=月
 - **live/finalの接尾辞**: 集計モードを明示する
-- **filteredraw/nontrading_raw**: 取引時間フィルタ済/除外用の特別ストリーム <raw_stream_name>_filtered
+  - **filteredraw/nontrading_raw**: 取引時間フィルタ済/除外用の特別ストリーム `<raw_stream_name>_filtered`（上流で生成。DSL は参照のみ）
 - **1s_final**: 全上位足の唯一の親。必ず存在
 
 1s_final / 1s_final_s の役割

--- a/docs/diff_log/diff_filteredraw_upstream_20250910.md
+++ b/docs/diff_log/diff_filteredraw_upstream_20250910.md
@@ -1,0 +1,4 @@
+# diff_filteredraw_upstream_20250910
+- 明示的に `filteredraw` を上流責務として文書化。
+- DSL `TimeFrame` に `filteredraw` 上流責務コメントを追加。
+- テストを `trade_raw_filtered` などフィルタ済み名前提に更新。

--- a/src/Query/Dsl/KsqlQueryable.cs
+++ b/src/Query/Dsl/KsqlQueryable.cs
@@ -101,6 +101,8 @@ public class KsqlQueryable<T1> : IKsqlQueryable, IScheduledScope<T1>
         throw new NotSupportedException("Legacy Tumbling overload is not supported in this phase.");
     }
 
+    // filteredraw は上流責務。DSL は既にフィルタ済みストリーム
+    // （例: trade_raw_filtered）を参照するだけ。
     public IScheduledScope<T1> TimeFrame<TSchedule>(
         Expression<Func<T1, TSchedule, bool>> predicate,
         Expression<Func<TSchedule, object>>? dayKey = null)

--- a/tests/Query/Builders/RollupBuilderTests.cs
+++ b/tests/Query/Builders/RollupBuilderTests.cs
@@ -13,7 +13,7 @@ namespace Kafka.Ksql.Linq.Tests.Query.Builders;
 
 public class RollupBuilderTests
 {
-    [KsqlTopic("bar")]
+    [KsqlTopic("trade_raw_filtered")]
     private class Rate
     {
         public string Broker { get; set; } = string.Empty;
@@ -86,8 +86,8 @@ public class RollupBuilderTests
     {
         var md = BuildMetadata();
         var sql = LiveBuilder.Build(md, "1m");
-        Assert.Contains("TABLE bar_1s_final_s WINDOW TUMBLING(1m)", sql);
-        Assert.Contains("SYNC bar_1s_final_s", sql);
+        Assert.Contains("TABLE trade_raw_filtered_1s_final_s WINDOW TUMBLING(1m)", sql);
+        Assert.Contains("SYNC trade_raw_filtered_1s_final_s", sql);
     }
 
     [Fact]
@@ -95,7 +95,7 @@ public class RollupBuilderTests
     {
         var md = BuildMetadata();
         var sql = LiveBuilder.Build(md, "5m");
-        Assert.Contains("TABLE bar_1s_final_s WINDOW TUMBLING(5m)", sql);
+        Assert.Contains("TABLE trade_raw_filtered_1s_final_s WINDOW TUMBLING(5m)", sql);
         Assert.DoesNotContain("SYNC", sql);
     }
 
@@ -104,13 +104,13 @@ public class RollupBuilderTests
     {
         var md = BuildMetadata();
         var sql = FinalBuilder.Build(md, "5m");
-        Assert.Contains("TABLE bar_1s_final_s WINDOW TUMBLING(5m)", sql);
+        Assert.Contains("TABLE trade_raw_filtered_1s_final_s WINDOW TUMBLING(5m)", sql);
         Assert.Contains("EMIT FINAL", sql);
         Assert.DoesNotContain("SYNC", sql);
         Assert.DoesNotContain("COMPOSE(", sql);
         var sql1 = FinalBuilder.Build(md, "1m");
-        Assert.Contains("TABLE bar_1s_final_s WINDOW TUMBLING(1m)", sql1);
-        Assert.Contains("SYNC bar_1s_final_s", sql1);
+        Assert.Contains("TABLE trade_raw_filtered_1s_final_s WINDOW TUMBLING(1m)", sql1);
+        Assert.Contains("SYNC trade_raw_filtered_1s_final_s", sql1);
         Assert.DoesNotContain("COMPOSE(", sql1);
     }
 


### PR DESCRIPTION
## Summary
- Document that `filteredraw` creation is upstream-only and referenced by DSL
- Note upstream `filteredraw` responsibility in `TimeFrame` code comment
- Use `trade_raw_filtered` naming in rollup builder tests

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c177aaec788327ae79ce6e806a5ddc