### PR TITLE
Remove obsolete role metadata from ExpressionAnalysisResult

### DIFF
--- a/docs/diff_log/diff_expressionanalysisresult_roles_cleanup_20250910.md
+++ b/docs/diff_log/diff_expressionanalysisresult_roles_cleanup_20250910.md
@@ -1,0 +1,2 @@
+- Removed windows, roles/live, roles/aggFinal, roles/final, roles/prev, and roles/hb properties from ExpressionAnalysisResult metadata.
+- Metadata now only carries inputs, prev, sync, and per-timeframe grace for builders.

--- a/src/Query/Pipeline/ExpressionAnalysisResult.cs
+++ b/src/Query/Pipeline/ExpressionAnalysisResult.cs
@@ -43,7 +43,6 @@ internal class ExpressionAnalysisResult
     public QueryMetadata ToMetadata()
     {
         var md = new QueryMetadata(DateTime.UtcNow, "Query") { GraceSeconds = GraceSeconds };
-        md = md.WithProperty("windows", Windows.ToArray());
         md = md.WithProperty("timeKey", TimeKey!);
         md = md.WithProperty("basedOn/joinKeys", BasedOnJoinKeys.ToArray());
         md = md.WithProperty("basedOn/openProp", BasedOnOpen!);
@@ -54,10 +53,6 @@ internal class ExpressionAnalysisResult
 
         if (BucketColumnName != null)
             md = md.WithProperty("bucketColumn", BucketColumnName);
-
-        md = md.WithProperty("roles/live", Windows.ToArray());
-        md = md.WithProperty("roles/aggFinal", Windows.ToArray());
-        md = md.WithProperty("roles/final", Windows.ToArray());
 
         foreach (var kv in GracePerTimeframe)
             md = md.WithProperty($"grace/{kv.Key}", kv.Value);
@@ -76,8 +71,6 @@ internal class ExpressionAnalysisResult
                 md = md.WithProperty($"input/{tf}Final", hub);
                 md = md.WithProperty($"prev/{tf}Final", hub);
             }
-            md = md.WithProperty("roles/prev", new[] { "1m" });
-            md = md.WithProperty("roles/hb", new[] { "1m" });
         }
         return md;
     }


### PR DESCRIPTION
## Summary
- drop legacy `windows` and `roles/*` metadata from `ExpressionAnalysisResult`
- log metadata cleanup in diff_log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c17a4c89e48327b14d07281384b6d3