### PR TITLE
Remove BuildFinalProjection from derived tumbling pipeline

### DIFF
--- a/docs/diff_log/diff_derived_tumbling_pipeline_buildfinalprojection_removal_20250910.md
+++ b/docs/diff_log/diff_derived_tumbling_pipeline_buildfinalprojection_removal_20250910.md
@@ -1,0 +1,4 @@
+# Derived tumbling pipeline final projection removal
+
+- Removed `BuildFinalProjection` and related dynamic type generation.
+- Eliminated unused `ModuleBuilder` field and reflection emit dependency.

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -12,7 +12,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Reflection.Emit;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
@@ -21,9 +20,6 @@ namespace Kafka.Ksql.Linq.Query.Analysis;
 
 internal static class DerivedTumblingPipeline
 {
-    private static readonly ModuleBuilder _module = AssemblyBuilder
-        .DefineDynamicAssembly(new AssemblyName("KafkaKsqlLinq.DerivedTumbling"), AssemblyBuilderAccess.Run)
-        .DefineDynamicModule("Main");
     public static async Task RunAsync(
         TumblingQao qao,
         EntityModel baseModel,
@@ -41,9 +37,9 @@ internal static class DerivedTumblingPipeline
         foreach (var m in models)
         {
             var role = Enum.Parse<Role>((string)m.AdditionalSettings["role"]);
-        var (ddl, dt, ns) = BuildDdlAndRegister(baseName, queryModel, m, role, resolveType);
-        logger.LogInformation("KSQL DDL (derived {Entity}): {Sql}", m.TopicName, ddl);
-        await execute(ddl);
+            var (ddl, dt, ns) = BuildDdlAndRegister(baseName, queryModel, m, role, resolveType);
+            logger.LogInformation("KSQL DDL (derived {Entity}): {Sql}", m.TopicName, ddl);
+            await execute(ddl);
             mapping.RegisterEntityModel(m, genericValue: true, overrideNamespace: ns);
             registry[dt] = m;
         }
@@ -126,132 +122,5 @@ internal static class DerivedTumblingPipeline
         var bindings = props.Select(pr => Expression.Bind(pr, Expression.Property(p, pr)));
         var body = Expression.MemberInit(Expression.New(inputType), bindings);
         return Expression.Lambda(body, p);
-    }
-
-    private static (LambdaExpression select, LambdaExpression group) BuildFinalProjection(
-        EntityModel model,
-        LambdaExpression baseProjection)
-    {
-        var joinKeys = (string[])model.AdditionalSettings["basedOn/joinKeys"];
-        var keyNames = (string[])model.AdditionalSettings["keys"];
-        var keyTypes = (Type[])model.AdditionalSettings["keys/types"];
-        var projNames = (string[])model.AdditionalSettings["projection"];
-        var projTypes = (Type[])model.AdditionalSettings["projection/types"];
-
-        var methods = new Dictionary<string, MethodInfo>();
-        switch (baseProjection.Body)
-        {
-            case MemberInitExpression m:
-                foreach (var b in m.Bindings.OfType<MemberAssignment>())
-                    if (b.Expression is MethodCallExpression mc)
-                        methods[b.Member.Name] = mc.Method.GetGenericMethodDefinition();
-                break;
-            case UnaryExpression { Operand: MemberInitExpression m }:
-                foreach (var b in m.Bindings.OfType<MemberAssignment>())
-                    if (b.Expression is MethodCallExpression mc)
-                        methods[b.Member.Name] = mc.Method.GetGenericMethodDefinition();
-                break;
-            case NewExpression ne when ne.Members != null:
-                for (int i = 0; i < ne.Members.Count; i++)
-                    if (ne.Arguments[i] is MethodCallExpression mc)
-                        methods[ne.Members[i].Name] = mc.Method.GetGenericMethodDefinition();
-                break;
-            case UnaryExpression { Operand: NewExpression ne } when ne.Members != null:
-                for (int i = 0; i < ne.Members.Count; i++)
-                    if (ne.Arguments[i] is MethodCallExpression mc)
-                        methods[ne.Members[i].Name] = mc.Method.GetGenericMethodDefinition();
-                break;
-        }
-
-        Type FindType(string name)
-        {
-            var idx = Array.FindIndex(keyNames, k => string.Equals(k, name, StringComparison.OrdinalIgnoreCase));
-            if (idx >= 0) return keyTypes[idx];
-            idx = Array.FindIndex(projNames, k => string.Equals(k, name, StringComparison.OrdinalIgnoreCase));
-            if (idx >= 0) return projTypes[idx];
-            return typeof(object);
-        }
-
-        var bucket = keyNames.FirstOrDefault(k => string.Equals(k, "BucketStart", StringComparison.OrdinalIgnoreCase)) ?? "BucketStart";
-
-        var keyList = joinKeys.ToList();
-        if (!keyList.Any(k => string.Equals(k, bucket, StringComparison.OrdinalIgnoreCase)))
-            keyList.Add(bucket);
-
-        var keyProps = keyList.Select(k => (Name: k, Type: FindType(k))).ToArray();
-        var valueNames = projNames
-            .Where(p => !keyList.Any(k => string.Equals(k, p, StringComparison.OrdinalIgnoreCase)))
-            .Where(p => methods.ContainsKey(p))
-            .ToArray();
-        var valueProps = valueNames.Select(v => (Name: v, Type: FindType(v))).ToArray();
-        var resultProps = keyProps.Concat(valueProps).ToArray();
-
-        Type CreateType((string Name, Type Type)[] props)
-        {
-            var tb = _module.DefineType("T" + Guid.NewGuid().ToString("N"), TypeAttributes.Public);
-            foreach (var p in props)
-            {
-                var field = tb.DefineField("_" + p.Name, p.Type, FieldAttributes.Private);
-                var prop = tb.DefineProperty(p.Name, PropertyAttributes.None, p.Type, null);
-                var get = tb.DefineMethod("get_" + p.Name, MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig, p.Type, Type.EmptyTypes);
-                var il = get.GetILGenerator();
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldfld, field);
-                il.Emit(OpCodes.Ret);
-                var set = tb.DefineMethod("set_" + p.Name, MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig, null, new[] { p.Type });
-                var il2 = set.GetILGenerator();
-                il2.Emit(OpCodes.Ldarg_0);
-                il2.Emit(OpCodes.Ldarg_1);
-                il2.Emit(OpCodes.Stfld, field);
-                il2.Emit(OpCodes.Ret);
-                prop.SetGetMethod(get);
-                prop.SetSetMethod(set);
-            }
-            return tb.CreateType()!;
-        }
-
-        var elementType = CreateType(resultProps);
-        var keyType = CreateType(keyProps);
-        var gType = typeof(IGrouping<,>).MakeGenericType(keyType, elementType);
-        var g = Expression.Parameter(gType, "g");
-        var keyExpr = Expression.Property(g, "Key");
-        var bindings = new List<MemberBinding>();
-
-        foreach (var kp in keyProps)
-        {
-            var prop = elementType.GetProperty(kp.Name)!;
-            var val = Expression.Property(keyExpr, kp.Name);
-            bindings.Add(Expression.Bind(prop, val));
-        }
-
-        var x = Expression.Parameter(elementType, "x");
-
-        Expression Agg(MethodInfo method, string col, Type retType)
-        {
-            var selectorBody = Expression.Property(x, col);
-            var selector = Expression.Lambda(selectorBody, x);
-            MethodInfo mi;
-            if (method.DeclaringType == typeof(OffsetAggregateExtensions))
-                mi = method.MakeGenericMethod(elementType, keyType, retType);
-            else if (method.GetGenericArguments().Length == 2)
-                mi = method.MakeGenericMethod(elementType, retType);
-            else
-                mi = method.MakeGenericMethod(elementType);
-            return Expression.Call(mi, g, selector);
-        }
-
-        foreach (var vp in valueProps)
-        {
-            var method = methods[vp.Name];
-            bindings.Add(Expression.Bind(elementType.GetProperty(vp.Name)!, Agg(method, vp.Name, vp.Type)));
-        }
-
-        var selectBody = Expression.MemberInit(Expression.New(elementType), bindings);
-        var select = Expression.Lambda(selectBody, g);
-
-        var r = Expression.Parameter(elementType, "r");
-        var keyBindings = keyProps.Select(kp => Expression.Bind(keyType.GetProperty(kp.Name)!, Expression.Property(r, kp.Name)));
-        var group = Expression.Lambda(Expression.MemberInit(Expression.New(keyType), keyBindings), r);
-        return (select, group);
     }
 }


### PR DESCRIPTION
## Summary
- drop BuildFinalProjection and dynamic type helpers
- clean up unused ModuleBuilder field and reflection emit using

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c17b60d4308327ba0015f357a69b38