### PR TITLE
refactor: drop materialization hint

### DIFF
--- a/docs/diff_log/diff_materialization_hint_removal_20251209.md
+++ b/docs/diff_log/diff_materialization_hint_removal_20251209.md
@@ -1,0 +1,2 @@
+- remove MaterializationHint enum and property from DerivedEntity
+- stop assigning MaterializationHint in DerivationPlanner

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -106,7 +106,6 @@ internal static class DerivationPlanner
                     Timeframe = tf,
                     KeyShape = keyShapes,
                     ValueShape = Array.Empty<ColumnShape>(),
-                    MaterializationHint = MaterializationHint.Stream,
                     BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor,
                     GraceSeconds = graceMap[tfStr]
@@ -154,7 +153,6 @@ internal static class DerivationPlanner
                 Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = Array.Empty<ColumnShape>(),
-                MaterializationHint = MaterializationHint.Stream,
                 BasedOnSpec = basedOn,
                 WeekAnchor = qao.WeekAnchor,
                 GraceSeconds = graceMap[tfStr]
@@ -224,7 +222,6 @@ internal static class DerivationPlanner
                     Timeframe = new Timeframe(1, "m"),
                     KeyShape = keyShapes,
                     ValueShape = Array.Empty<ColumnShape>(),
-                    MaterializationHint = MaterializationHint.Stream,
                     BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor,
                     GraceSeconds = grace1m

--- a/src/Query/Analysis/DerivedEntity.cs
+++ b/src/Query/Analysis/DerivedEntity.cs
@@ -14,12 +14,6 @@ internal enum Role
     Fill
 }
 
-internal enum MaterializationHint
-{
-    Table,
-    Stream
-}
-
 internal record ColumnShape(string Name, Type Type, bool IsNullable);
 
 internal class DerivedEntity
@@ -29,11 +23,10 @@ internal class DerivedEntity
     public Timeframe Timeframe { get; init; } = default!;
     public IReadOnlyList<ColumnShape> KeyShape { get; init; } = Array.Empty<ColumnShape>();
     public IReadOnlyList<ColumnShape> ValueShape { get; init; } = Array.Empty<ColumnShape>();
-    public MaterializationHint MaterializationHint { get; init; } = MaterializationHint.Table;
     public string? TopicHint { get; init; }
     public string? InputHint { get; init; }
     public string? SyncHint { get; init; }
-      public BasedOnSpec BasedOnSpec { get; init; } = new(new List<string>(), string.Empty, string.Empty, string.Empty);
+    public BasedOnSpec BasedOnSpec { get; init; } = new(new List<string>(), string.Empty, string.Empty, string.Empty);
     public DayOfWeek WeekAnchor { get; init; } = DayOfWeek.Monday;
     public int GraceSeconds { get; init; }
 }


### PR DESCRIPTION
## Summary
- remove `MaterializationHint` enum and property from `DerivedEntity`
- stop setting `MaterializationHint` in `DerivationPlanner`
- document removal in diff log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c17c89dbf48327882c0c5efac0fafe