### PR TITLE
Remove fixed 1m hub mappings

### DIFF
--- a/docs/diff_log/diff_expressionanalysis_hubref_cleanup_20250910.md
+++ b/docs/diff_log/diff_expressionanalysis_hubref_cleanup_20250910.md
@@ -1,0 +1,5 @@
+# ExpressionAnalysis hub reference cleanup
+
+- Removed automatic addition of `sync/1mLive`, `sync/1mFinal`, and `prev/1mFinal`.
+- Dropped timeframe loops for `input/*Live`, `input/*Final`, and `prev/*Final`; only first window now maps to hub.
+- Updated windowed query builder tests to avoid fixed `1m` metadata keys.

--- a/src/Query/Pipeline/ExpressionAnalysisResult.cs
+++ b/src/Query/Pipeline/ExpressionAnalysisResult.cs
@@ -57,20 +57,14 @@ internal class ExpressionAnalysisResult
         foreach (var kv in GracePerTimeframe)
             md = md.WithProperty($"grace/{kv.Key}", kv.Value);
 
-        if (PocoType != null)
+        if (PocoType != null && Windows.Count > 0)
         {
             var topicAttr = PocoType.GetCustomAttribute<KsqlTopicAttribute>();
             var baseId = (topicAttr?.Name ?? PocoType.Name).ToLowerInvariant();
             var hub = $"{baseId}_1s_final_s";
-            md = md.WithProperty("sync/1mLive", hub);
-            md = md.WithProperty("sync/1mFinal", hub);
-            md = md.WithProperty("prev/1mFinal", hub);
-            foreach (var tf in Windows)
-            {
-                md = md.WithProperty($"input/{tf}Live", hub);
-                md = md.WithProperty($"input/{tf}Final", hub);
-                md = md.WithProperty($"prev/{tf}Final", hub);
-            }
+            var tf = Windows[0];
+            md = md.WithProperty($"input/{tf}Live", hub);
+            md = md.WithProperty($"input/{tf}Final", hub);
         }
         return md;
     }

--- a/tests/Query/Builders/RollupBuilderTests.cs
+++ b/tests/Query/Builders/RollupBuilderTests.cs
@@ -82,18 +82,19 @@ public class RollupBuilderTests
     }
 
     [Fact]
-    public void Live_1m_IsTable_EmitChanges_SyncsOn_HB1m()
+    public void Live_1m_IsTable_EmitChanges_NoSync()
     {
         var md = BuildMetadata();
         var sql = LiveBuilder.Build(md, "1m");
         Assert.Contains("TABLE trade_raw_filtered_1s_final_s WINDOW TUMBLING(1m)", sql);
-        Assert.Contains("SYNC trade_raw_filtered_1s_final_s", sql);
+        Assert.DoesNotContain("SYNC", sql);
     }
 
     [Fact]
     public void Live_5m_RollsUp_From_1mLive()
     {
-        var md = BuildMetadata();
+        var md = BuildMetadata()
+            .WithProperty("input/5mLive", "trade_raw_filtered_1s_final_s");
         var sql = LiveBuilder.Build(md, "5m");
         Assert.Contains("TABLE trade_raw_filtered_1s_final_s WINDOW TUMBLING(5m)", sql);
         Assert.DoesNotContain("SYNC", sql);
@@ -102,7 +103,8 @@ public class RollupBuilderTests
     [Fact]
     public void Final_Uses_Window_EmitFinal()
     {
-        var md = BuildMetadata();
+        var md = BuildMetadata()
+            .WithProperty("input/5mFinal", "trade_raw_filtered_1s_final_s");
         var sql = FinalBuilder.Build(md, "5m");
         Assert.Contains("TABLE trade_raw_filtered_1s_final_s WINDOW TUMBLING(5m)", sql);
         Assert.Contains("EMIT FINAL", sql);
@@ -110,7 +112,7 @@ public class RollupBuilderTests
         Assert.DoesNotContain("COMPOSE(", sql);
         var sql1 = FinalBuilder.Build(md, "1m");
         Assert.Contains("TABLE trade_raw_filtered_1s_final_s WINDOW TUMBLING(1m)", sql1);
-        Assert.Contains("SYNC trade_raw_filtered_1s_final_s", sql1);
+        Assert.DoesNotContain("SYNC", sql1);
         Assert.DoesNotContain("COMPOSE(", sql1);
     }
 

--- a/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
+++ b/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
@@ -16,14 +16,12 @@ public class WindowedQueryBuilderCoreTests
             .WithProperty("timeKey", "Ts");
 
     [Fact]
-    public void Core_Builds_Live_Table_EmitChanges_SyncsOnlyOn1m()
+    public void Core_Builds_Live_Table_EmitChanges_NoSync()
     {
-        var md1 = BaseMd()
-            .WithProperty("input/1mLive", "src1")
-            .WithProperty("sync/1mLive", "HB_1m");
+        var md1 = BaseMd().WithProperty("input/1mLive", "src1");
         var q1 = LiveBuilder.Build(md1, "1m");
         Assert.StartsWith("TABLE src1", q1);
-        Assert.Contains("SYNC HB_1m", q1);
+        Assert.DoesNotContain("SYNC", q1);
 
         var md5 = BaseMd().WithProperty("input/5mLive", "src5");
         var q5 = LiveBuilder.Build(md5, "5m");
@@ -31,18 +29,15 @@ public class WindowedQueryBuilderCoreTests
     }
 
     [Fact]
-    public void Core_Builds_Final_Window_EmitFinal_SyncsOnlyOn1m()
+    public void Core_Builds_Final_Window_EmitFinal_NoSyncOrPrev()
     {
-            var md1 = BaseMd()
-                .WithProperty("input/1mFinal", "src1")
-                .WithProperty("sync/1mFinal", "HB_1m")
-                .WithProperty("prev/1mFinal", "bar_1s_final_s");
+        var md1 = BaseMd().WithProperty("input/1mFinal", "src1");
         var q1 = FinalBuilder.Build(md1, "1m");
         Assert.StartsWith("TABLE src1", q1);
         Assert.Contains("WINDOW TUMBLING(1m)", q1);
         Assert.Contains("EMIT FINAL", q1);
-        Assert.Contains("SYNC HB_1m", q1);
-            Assert.Contains("PREV bar_1s_final_s", q1);
+        Assert.DoesNotContain("SYNC", q1);
+        Assert.DoesNotContain("PREV", q1);
         Assert.DoesNotContain("COMPOSE(", q1);
 
         var md5 = BaseMd().WithProperty("input/5mFinal", "src5");


### PR DESCRIPTION
## Summary
- prune automatic 1m hub metadata in ExpressionAnalysisResult
- adjust windowed query builder tests to no longer rely on sync/prev keys
- document hub reference cleanup

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c17e5e128883279d0352d40f91e51b