### PR TITLE
Emit Prev1m only when 1m window is specified

### DIFF
--- a/docs/diff_log/diff_derivationplanner_prev1m_explicit_20251208.md
+++ b/docs/diff_log/diff_derivationplanner_prev1m_explicit_20251208.md
@@ -1,0 +1,4 @@
+# diff: derivation planner Prev1m explicit (2025-12-08)
+- Remove automatic generation of Prev1m and hb_1m when 1m window is absent.
+- Emit Prev1m/hb_1m only when 1m timeframe is explicitly requested.
+- Update DerivationPlannerTests to expect Prev1m only with explicit 1m window.

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -195,40 +195,6 @@ internal static class DerivationPlanner
                 entities.Add(prev);
             }
         }
-        if (!entities.Any(e => e.Role == Role.Prev1m))
-        {
-            var hbId = $"{baseId}_hb_1m";
-            var grace1m = graceMap.TryGetValue("1m", out var g1) ? g1 : graceMap.Values.Last() + 1;
-            var prev = new DerivedEntity
-            {
-                Id = $"{baseId}_prev_1m",
-                Role = Role.Prev1m,
-                Timeframe = new Timeframe(1, "m"),
-                KeyShape = keyShapes,
-                ValueShape = valueShapes,
-                InputHint = hub,
-                SyncHint = hbId.ToUpperInvariant(),
-                BasedOnSpec = basedOn,
-                WeekAnchor = qao.WeekAnchor,
-                GraceSeconds = grace1m
-            };
-            entities.Add(prev);
-            if (!entities.Any(e => e.Id == hbId))
-            {
-                var hb = new DerivedEntity
-                {
-                    Id = hbId,
-                    Role = Role.Hb,
-                    Timeframe = new Timeframe(1, "m"),
-                    KeyShape = keyShapes,
-                    ValueShape = Array.Empty<ColumnShape>(),
-                    BasedOnSpec = basedOn,
-                    WeekAnchor = qao.WeekAnchor,
-                    GraceSeconds = grace1m
-                };
-                entities.Add(hb);
-            }
-        }
         return entities;
     }
 }

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -79,7 +79,7 @@ public class DerivationPlannerTests
         Assert.Equal("bar_1s_final_s", final.InputHint);
         Assert.Equal("BAR_HB_5M", final.SyncHint);
         Assert.Contains(entities, e => e.Id == "bar_hb_5m" && e.Role == Role.Hb);
-        Assert.Contains(entities, e => e.Id == "bar_prev_1m" && e.Role == Role.Prev1m);
+        Assert.DoesNotContain(entities, e => e.Role == Role.Prev1m);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- stop DerivationPlanner from creating Prev1m/hb_1m unless the query specifies a 1m window
- adjust DerivationPlannerTests to assert Prev1m is absent when only a 5m window is planned
- log the change in diff_log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c180221e58832785863c65633d85bb