### PR TITLE
test: align windowed query builder tests with hub structure

### DIFF
--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -46,7 +46,7 @@ public class DerivationPlannerTests
     };
 
     [Fact]
-    public void Plan_1m_Includes_Live_Final_Hb_Prev()
+    public void Plan_1m_Includes_Live_Final_Hb()
     {
         var model = new EntityModel { EntityType = typeof(Source) };
         var entities = DerivationPlanner.Plan(Create(new Timeframe(1, "m")), model);
@@ -58,9 +58,6 @@ public class DerivationPlannerTests
         var final = Assert.Single(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
         Assert.Equal("bar_1s_final_s", final.InputHint);
         Assert.Equal("BAR_HB_1M", final.SyncHint);
-        var prev = Assert.Single(entities, e => e.Id == "bar_prev_1m" && e.Role == Role.Prev1m);
-        Assert.Equal("bar_1s_final_s", prev.InputHint);
-        Assert.Equal("BAR_HB_1M", prev.SyncHint);
         Assert.Contains(entities, e => e.Id == "bar_hb_1m" && e.Role == Role.Hb);
         Assert.Contains(entities, e => e.Id == "bar_hb_1s" && e.Role == Role.Hb);
     }
@@ -79,7 +76,6 @@ public class DerivationPlannerTests
         Assert.Equal("bar_1s_final_s", final.InputHint);
         Assert.Equal("BAR_HB_5M", final.SyncHint);
         Assert.Contains(entities, e => e.Id == "bar_hb_5m" && e.Role == Role.Hb);
-        Assert.DoesNotContain(entities, e => e.Role == Role.Prev1m);
     }
 
     [Fact]

--- a/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
@@ -59,7 +59,7 @@ public class DerivedTumblingPipelineConcurrencyTests
 
         await DerivedTumblingPipeline.RunAsync(qao, baseModel, model, Exec, Resolver, mapping, registry, new LoggerFactory().CreateLogger("test"));
 
-        var expected = 10; // 1s hub + 1m: Live/Final/Hb/Prev + 5m: Live/Final/Hb
+        var expected = 10; // 1s hub + 1m: Live/Final/Hb + 5m: Live/Final/Hb
         Assert.Equal(expected, registry.Count);
         Assert.Equal(expected, ddls.Count);
         foreach (var ddl in ddls)

--- a/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
+++ b/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
@@ -18,31 +18,30 @@ public class WindowedQueryBuilderCoreTests
     [Fact]
     public void Core_Builds_Live_Table_EmitChanges_NoSync()
     {
-        var md1 = BaseMd().WithProperty("input/1mLive", "src1");
+        var md1 = BaseMd().WithProperty("input/1mLive", "bar_1s_final_s");
         var q1 = LiveBuilder.Build(md1, "1m");
-        Assert.StartsWith("TABLE src1", q1);
+        Assert.StartsWith("TABLE bar_1s_final_s", q1);
         Assert.DoesNotContain("SYNC", q1);
 
-        var md5 = BaseMd().WithProperty("input/5mLive", "src5");
+        var md5 = BaseMd().WithProperty("input/5mLive", "bar_1s_final_s");
         var q5 = LiveBuilder.Build(md5, "5m");
         Assert.DoesNotContain("SYNC", q5);
     }
 
     [Fact]
-    public void Core_Builds_Final_Window_EmitFinal_NoSyncOrPrev()
+    public void Core_Builds_Final_Window_EmitFinal_NoSync()
     {
-        var md1 = BaseMd().WithProperty("input/1mFinal", "src1");
+        var md1 = BaseMd().WithProperty("input/1mFinal", "bar_1s_final_s");
         var q1 = FinalBuilder.Build(md1, "1m");
-        Assert.StartsWith("TABLE src1", q1);
+        Assert.StartsWith("TABLE bar_1s_final_s", q1);
         Assert.Contains("WINDOW TUMBLING(1m)", q1);
         Assert.Contains("EMIT FINAL", q1);
         Assert.DoesNotContain("SYNC", q1);
-        Assert.DoesNotContain("PREV", q1);
         Assert.DoesNotContain("COMPOSE(", q1);
 
-        var md5 = BaseMd().WithProperty("input/5mFinal", "src5");
+        var md5 = BaseMd().WithProperty("input/5mFinal", "bar_1s_final_s");
         var q5 = FinalBuilder.Build(md5, "5m");
-        Assert.StartsWith("TABLE src5", q5);
+        Assert.StartsWith("TABLE bar_1s_final_s", q5);
         Assert.Contains("WINDOW TUMBLING(5m)", q5);
         Assert.DoesNotContain("SYNC", q5);
         Assert.DoesNotContain("COMPOSE(", q5);
@@ -52,7 +51,7 @@ public class WindowedQueryBuilderCoreTests
     public void FinalBuilder_Uses_PerTimeframe_Grace()
     {
         var md = BaseMd()
-            .WithProperty("input/1mFinal", "src")
+            .WithProperty("input/1mFinal", "bar_1s_final_s")
             .WithProperty("grace/1m", 4);
         var q = FinalBuilder.Build(md, "1m");
         Assert.Contains("WINDOW TUMBLING(1m GRACE PERIOD 4s)", q);
@@ -61,9 +60,9 @@ public class WindowedQueryBuilderCoreTests
     [Fact]
     public void Core_Applies_TimeFrame_Join_And_Boundary_To_Live_And_Final()
     {
-        var md = BaseMd().WithProperty("input/1mLive", "s");
+        var md = BaseMd().WithProperty("input/1mLive", "bar_1s_final_s");
         var live = LiveBuilder.Build(md, "1m");
-        var fin = FinalBuilder.Build(md.WithProperty("input/1mFinal", "a"), "1m");
+        var fin = FinalBuilder.Build(md.WithProperty("input/1mFinal", "bar_1s_final_s"), "1m");
         foreach (var q in new[] { live, fin })
             Assert.Contains("JOIN ON", q);
     }
@@ -71,9 +70,9 @@ public class WindowedQueryBuilderCoreTests
     [Fact]
     public void Builders_Expand_TimeFrame_Join_And_Boundary_For_Live_And_Final()
     {
-        var md = BaseMd().WithProperty("input/1mLive", "s");
+        var md = BaseMd().WithProperty("input/1mLive", "bar_1s_final_s");
         var live = LiveBuilder.Build(md, "1m");
-        var fin = FinalBuilder.Build(md.WithProperty("input/1mFinal", "a"), "1m");
+        var fin = FinalBuilder.Build(md.WithProperty("input/1mFinal", "bar_1s_final_s"), "1m");
         Assert.Contains("s.Open <= r.Ts", live);
         Assert.Contains("s.Open <= r.Ts", fin);
     }


### PR DESCRIPTION
## Summary
- update windowed query builder tests to use 1s final hub keys
- drop Prev entity expectations from derivation planner tests
- clarify concurrency test count for hub-based derivations

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68c1813f06dc83278f810270932e7732