### PR TITLE
Remove SyncHint and heartbeat sync handling

### DIFF
--- a/docs/diff_log/diff_remove_sync_hint_20251209.md
+++ b/docs/diff_log/diff_remove_sync_hint_20251209.md
@@ -1,0 +1,5 @@
+# Remove SyncHint and heartbeat sync
+
+- Dropped `SyncHint` from derived entities and adapters.
+- Removed `SyncHb1m` handling and prev/1m sync utilities from query builders.
+- Updated role traits to only track window and emit behavior.

--- a/src/Query/Adapters/EntityModelAdapter.cs
+++ b/src/Query/Adapters/EntityModelAdapter.cs
@@ -40,9 +40,8 @@ internal static class EntityModelAdapter
             model.AdditionalSettings["role"] = e.Role.ToString();
             model.AdditionalSettings["timeframe"] = $"{e.Timeframe.Value}{e.Timeframe.Unit}";
             model.AdditionalSettings["graceSeconds"] = e.GraceSeconds;
-            if (e.SyncHint != null) model.AdditionalSettings[$"sync"] = e.SyncHint;
             if (e.InputHint != null) model.AdditionalSettings[$"input"] = e.InputHint;
-              var nsSource = e.TopicHint ?? e.Id;
+            var nsSource = e.TopicHint ?? e.Id;
             if (!string.IsNullOrWhiteSpace(nsSource))
             {
                 var baseNs = e.TopicHint ?? e.Id;

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -77,7 +77,6 @@ internal static class DerivationPlanner
                     Timeframe = tf,
                     KeyShape = keyShapes,
                     ValueShape = valueShapes,
-                    SyncHint = hbId.ToUpperInvariant(),
                     BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor,
                     GraceSeconds = graceMap[tfStr]
@@ -92,7 +91,6 @@ internal static class DerivationPlanner
                     KeyShape = keyShapes,
                     ValueShape = valueShapes,
                     InputHint = $"{baseId}_1s_final",
-                    SyncHint = hbId.ToUpperInvariant(),
                     BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor,
                     GraceSeconds = graceMap[tfStr]
@@ -124,7 +122,6 @@ internal static class DerivationPlanner
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
                 InputHint = hub,
-                SyncHint = hbId.ToUpperInvariant(),
                 BasedOnSpec = basedOn,
                 WeekAnchor = qao.WeekAnchor,
                 GraceSeconds = graceMap[tfStr]
@@ -139,7 +136,6 @@ internal static class DerivationPlanner
                 KeyShape = keyShapes,
                 ValueShape = valueShapes,
                 InputHint = hub,
-                SyncHint = hbId.ToUpperInvariant(),
                 BasedOnSpec = basedOn,
                 WeekAnchor = qao.WeekAnchor,
                 GraceSeconds = graceMap[tfStr]
@@ -169,7 +165,6 @@ internal static class DerivationPlanner
                     KeyShape = keyShapes,
                     ValueShape = valueShapes,
                     InputHint = hub,
-                    SyncHint = hbId.ToUpperInvariant(),
                     BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor,
                     GraceSeconds = graceMap[tfStr]
@@ -187,7 +182,6 @@ internal static class DerivationPlanner
                     KeyShape = keyShapes,
                     ValueShape = valueShapes,
                     InputHint = hub,
-                    SyncHint = hbId.ToUpperInvariant(),
                     BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor,
                     GraceSeconds = graceMap[tfStr]

--- a/src/Query/Analysis/DerivedEntity.cs
+++ b/src/Query/Analysis/DerivedEntity.cs
@@ -25,7 +25,6 @@ internal class DerivedEntity
     public IReadOnlyList<ColumnShape> ValueShape { get; init; } = Array.Empty<ColumnShape>();
     public string? TopicHint { get; init; }
     public string? InputHint { get; init; }
-    public string? SyncHint { get; init; }
     public BasedOnSpec BasedOnSpec { get; init; } = new(new List<string>(), string.Empty, string.Empty, string.Empty);
     public DayOfWeek WeekAnchor { get; init; } = DayOfWeek.Monday;
     public int GraceSeconds { get; init; }

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -70,14 +70,7 @@ internal static class DerivedTumblingPipeline
             qm.SelectProjection = BuildInputProjection(inputType);
         }
         var tf = (string)model.AdditionalSettings["timeframe"];
-        Timeframe tfObj;
-        if (tf.EndsWith("wk", StringComparison.OrdinalIgnoreCase))
-            tfObj = new Timeframe(int.Parse(tf[..^2]), "wk");
-        else if (tf.EndsWith("mo", StringComparison.OrdinalIgnoreCase))
-            tfObj = new Timeframe(int.Parse(tf[..^2]), "mo");
-        else
-            tfObj = new Timeframe(int.Parse(tf[..^1]), tf[^1].ToString());
-        var spec = RoleTraits.For(role, tfObj);
+        var spec = RoleTraits.For(role);
         var emit = spec.Emit != null ? $"EMIT {spec.Emit}" : null;
         var name = role switch
         {

--- a/src/Query/Builders/Core/OperationSpec.cs
+++ b/src/Query/Builders/Core/OperationSpec.cs
@@ -2,5 +2,4 @@ namespace Kafka.Ksql.Linq.Query.Builders.Core;
 
 internal readonly record struct OperationSpec(
     bool Window,
-    string? Emit,
-    bool SyncHb1m);
+    string? Emit);

--- a/src/Query/Builders/Core/RoleTraits.cs
+++ b/src/Query/Builders/Core/RoleTraits.cs
@@ -3,22 +3,22 @@ using Kafka.Ksql.Linq.Query.Analysis;
 namespace Kafka.Ksql.Linq.Query.Builders.Core;
 
 /// <summary>
-/// Describes window, emit and sync behavior for each query role.
+/// Describes window and emit behavior for each query role.
 /// Final roles never compose intermediate sources; they operate on physical or view tables
 /// and require windowing with <c>EMIT FINAL</c>.
 /// </summary>
 internal static class RoleTraits
 {
-    public static OperationSpec For(Role role, Timeframe tf)
+    public static OperationSpec For(Role role)
     {
         return role switch
         {
-            Role.Live => new(true, "CHANGES", true),
-            Role.Final => new(true, "FINAL", true),
-            Role.Final1s => new(true, "FINAL", true),
-            Role.Final1sStream => new(false, null, false),
-            Role.Prev1m => new(true, "FINAL", true),
-            _ => new(false, null, false)
+            Role.Live => new(true, "CHANGES"),
+            Role.Final => new(true, "FINAL"),
+            Role.Final1s => new(true, "FINAL"),
+            Role.Final1sStream => new(false, null),
+            Role.Prev1m => new(true, "FINAL"),
+            _ => new(false, null)
         };
     }
 }

--- a/src/Query/Builders/Core/WindowedQueryBuilder.cs
+++ b/src/Query/Builders/Core/WindowedQueryBuilder.cs
@@ -9,10 +9,8 @@ internal static class WindowedQueryBuilder
 {
     public static string Build(Role role, string timeframe, QueryMetadata md)
     {
-        var tf = Parse(timeframe);
         var tfStr = timeframe;
-        var spec = RoleTraits.For(role, tf);
-        var roleName = role switch { Role.Live => "Live", Role.Final => "Final", _ => string.Empty };
+        var spec = RoleTraits.For(role);
         var input = role switch
         {
             Role.Live => QueryBuilderUtils.ResolveInput(md.GetProperty<string>($"input/{tfStr}Live")),
@@ -29,31 +27,10 @@ internal static class WindowedQueryBuilder
         }
         if (spec.Emit != null)
             sb.Append(' ').Append($"EMIT {spec.Emit}");
-        if (spec.SyncHb1m)
-        {
-            var sync = md.GetProperty<string>($"sync/{tfStr}{roleName}");
-            if (sync != null)
-                sb.Append(' ').Append(QueryBuilderUtils.ApplySync_HB1m(sync));
-        }
-        if (role == Role.Final)
-        {
-            var prev = md.GetProperty<string>($"prev/{tfStr}{roleName}");
-            if (prev != null)
-                sb.Append(' ').Append(QueryBuilderUtils.ApplyPrev_1m(prev));
-        }
         sb.Append(' ').Append(QueryBuilderUtils.ApplyTimeFrame(md));
         var sql = sb.ToString().Trim();
         if (role == Role.Final && sql.Contains("COMPOSE(", System.StringComparison.OrdinalIgnoreCase))
             throw new System.InvalidOperationException("Final SQL should not include COMPOSE()");
         return sql;
-    }
-
-    private static Timeframe Parse(string tf)
-    {
-        if (tf.EndsWith("mo"))
-            return new Timeframe(int.Parse(tf[..^2]), "mo");
-        if (tf.EndsWith("wk"))
-            return new Timeframe(int.Parse(tf[..^2]), "wk");
-        return new Timeframe(int.Parse(tf[..^1]), tf[^1].ToString());
     }
 }

--- a/src/Query/Builders/Utils/QueryBuilderUtils.cs
+++ b/src/Query/Builders/Utils/QueryBuilderUtils.cs
@@ -27,8 +27,4 @@ internal static class QueryBuilderUtils
         var grace = graceSeconds.HasValue ? $" GRACE PERIOD {graceSeconds.Value}s" : string.Empty;
         return $"WINDOW TUMBLING({timeframe}{grace})";
     }
-
-    public static string ApplySync_HB1m(string sync) => $"SYNC {sync}";
-
-    public static string ApplyPrev_1m(string prev) => $"PREV {prev}";
 }

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -1,11 +1,8 @@
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Attributes;
 using Kafka.Ksql.Linq.Query.Analysis;
-using Kafka.Ksql.Linq.Query.Adapters;
 using Kafka.Ksql.Linq.Query.Dsl;
 using System;
-using System.Linq;
-using System.Reflection;
 using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Query.Analysis;
@@ -54,10 +51,8 @@ public class DerivationPlannerTests
         var final1sStream = Assert.Single(entities, e => e.Id == "bar_1s_final_s" && e.Role == Role.Final1sStream);
         var live = Assert.Single(entities, e => e.Id == "bar_1m_live" && e.Role == Role.Live);
         Assert.Equal("bar_1s_final_s", live.InputHint);
-        Assert.Equal("BAR_HB_1M", live.SyncHint);
         var final = Assert.Single(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
         Assert.Equal("bar_1s_final_s", final.InputHint);
-        Assert.Equal("BAR_HB_1M", final.SyncHint);
         Assert.Contains(entities, e => e.Id == "bar_hb_1m" && e.Role == Role.Hb);
         Assert.Contains(entities, e => e.Id == "bar_hb_1s" && e.Role == Role.Hb);
     }
@@ -71,10 +66,8 @@ public class DerivationPlannerTests
         var final1sStream = Assert.Single(entities, e => e.Id == "bar_1s_final_s" && e.Role == Role.Final1sStream);
         var live5 = Assert.Single(entities, e => e.Id == "bar_5m_live" && e.Role == Role.Live);
         Assert.Equal("bar_1s_final_s", live5.InputHint);
-        Assert.Equal("BAR_HB_5M", live5.SyncHint);
         var final = Assert.Single(entities, e => e.Id == "bar_5m_final" && e.Role == Role.Final);
         Assert.Equal("bar_1s_final_s", final.InputHint);
-        Assert.Equal("BAR_HB_5M", final.SyncHint);
         Assert.Contains(entities, e => e.Id == "bar_hb_5m" && e.Role == Role.Hb);
     }
 

--- a/tests/Query/Builders/RollupBuilderTests.cs
+++ b/tests/Query/Builders/RollupBuilderTests.cs
@@ -133,14 +133,12 @@ public class RollupBuilderTests
     [Fact]
     public void RoleSpec_Table()
     {
-        var specLive = RoleTraits.For(Role.Live, new Timeframe(1, "m"));
+        var specLive = RoleTraits.For(Role.Live);
         Assert.True(specLive.Window);
         Assert.Equal("CHANGES", specLive.Emit);
-        Assert.True(specLive.SyncHb1m);
 
-        var specFinal = RoleTraits.For(Role.Final, new Timeframe(5, "m"));
+        var specFinal = RoleTraits.For(Role.Final);
         Assert.True(specFinal.Window);
         Assert.Equal("FINAL", specFinal.Emit);
-        Assert.True(specFinal.SyncHb1m);
     }
 }


### PR DESCRIPTION
## Summary
- drop SyncHint from derived entities and adapter
- remove SyncHb1m/prev handling from query builders and role traits
- update tests and add diff log entry

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -c Release`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68c1862bb8a483278979156000e47240