### PR TITLE
Skip final tables for non-1s tumbling windows

### DIFF
--- a/docs/diff_log/diff_derived_tumbling_pipeline_final_condition_20250910.md
+++ b/docs/diff_log/diff_derived_tumbling_pipeline_final_condition_20250910.md
@@ -1,0 +1,2 @@
+- Derived tumbling pipeline now skips creation of final tables for non-1s timeframes.
+- Only *_1s_final and *_1s_final_s are generated; other timeframes produce *_X_live only.

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -37,6 +37,9 @@ internal static class DerivedTumblingPipeline
         foreach (var m in models)
         {
             var role = Enum.Parse<Role>((string)m.AdditionalSettings["role"]);
+            var tf = (string)m.AdditionalSettings["timeframe"];
+            if (tf != "1s" && role != Role.Live)
+                continue;
             var (ddl, dt, ns) = BuildDdlAndRegister(baseName, queryModel, m, role, resolveType);
             logger.LogInformation("KSQL DDL (derived {Entity}): {Sql}", m.TopicName, ddl);
             await execute(ddl);

--- a/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineConcurrencyTests.cs
@@ -6,6 +6,7 @@ using Kafka.Ksql.Linq.Mapping;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Threading.Tasks;
@@ -59,11 +60,11 @@ public class DerivedTumblingPipelineConcurrencyTests
 
         await DerivedTumblingPipeline.RunAsync(qao, baseModel, model, Exec, Resolver, mapping, registry, new LoggerFactory().CreateLogger("test"));
 
-        var expected = 10; // 1s hub + 1m: Live/Final/Hb + 5m: Live/Final/Hb
+        var expected = 5; // 1s hub + 1m: Live + 5m: Live
         Assert.Equal(expected, registry.Count);
         Assert.Equal(expected, ddls.Count);
-        foreach (var ddl in ddls)
-            if (ddl.Contains("_final") && !ddl.Contains("_final_s"))
-                Assert.Contains("EMIT FINAL", ddl);
+        var finals = ddls.Where(d => d.Contains("_final") && !d.Contains("_final_s")).ToList();
+        Assert.Single(finals);
+        Assert.Contains("EMIT FINAL", finals[0]);
     }
 }

--- a/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineTests.cs
@@ -65,10 +65,8 @@ public class DerivedTumblingPipelineTests
 
         Assert.Contains(ddls, s => s.StartsWith("CREATE TABLE bar_1s_final"));
         Assert.Contains(ddls, s => s.StartsWith("CREATE STREAM bar_1s_final_s"));
-        var live = ddls.Single(s => s.StartsWith("CREATE TABLE bar_1m_live") || s.StartsWith("CREATE STREAM bar_1m_live"));
-        var final = ddls.Single(s => s.StartsWith("CREATE TABLE bar_1m_final") || s.StartsWith("CREATE STREAM bar_1m_final"));
-        Assert.Contains(ddls, s => s.Contains("_prev_1m"));
-        Assert.Contains("EMIT FINAL", final);
+        Assert.Contains(ddls, s => s.StartsWith("CREATE TABLE bar_1m_live") || s.StartsWith("CREATE STREAM bar_1m_live"));
+        Assert.DoesNotContain(ddls, s => s.Contains("_1m_final"));
     }
 
     [Fact]
@@ -111,9 +109,9 @@ public class DerivedTumblingPipelineTests
 
         await DerivedTumblingPipeline.RunAsync(qao, baseModel, model, Exec, Resolver, mapping, registry, new LoggerFactory().CreateLogger("test"));
 
-        var ddl5 = ddls.Single(s => s.Contains("_5m_final"));
+        var ddl5 = ddls.Single(s => s.Contains("_5m_live"));
         Assert.Contains("FROM bar_1s_final_s", ddl5);
-        Assert.Contains("EMIT FINAL", ddl5);
+        Assert.DoesNotContain("EMIT FINAL", ddl5);
     }
 
     [Fact]
@@ -171,9 +169,8 @@ public class DerivedTumblingPipelineTests
 
         await DerivedTumblingPipeline.RunAsync(qao, baseModel, model, Exec, Resolver, mapping, registry, new LoggerFactory().CreateLogger("test"));
 
-        var ddl = ddls.Single(s => s.StartsWith("CREATE TABLE bar_1m_final") || s.StartsWith("CREATE STREAM bar_1m_final"));
+        var ddl = ddls.Single(s => s.StartsWith("CREATE TABLE bar_1m_live") || s.StartsWith("CREATE STREAM bar_1m_live"));
         Assert.Contains("FROM bar_1s_final_s", ddl);
-        Assert.Contains("EMIT FINAL", ddl);
         Assert.DoesNotContain("BID", ddl, StringComparison.OrdinalIgnoreCase);
     }
 


### PR DESCRIPTION
## Summary
- avoid generating *_final tables for tumbling windows longer than 1 second
- adjust derived tumbling pipeline tests to expect only live tables for non-1s windows
- document final-table condition in diff log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj -v minimal`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68c18b043efc83278bac36c3e8c17238