### PR TITLE
Remove non-1s final windows and chain input hints

### DIFF
--- a/docs/diff_log/diff_derivationplanner_final_cleanup_20250910.md
+++ b/docs/diff_log/diff_derivationplanner_final_cleanup_20250910.md
@@ -1,0 +1,3 @@
+## diff_derivationplanner_final_cleanup_20250910
+- remove final windows beyond 1s
+- chain non-live InputHint through live entities

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -113,7 +113,6 @@ internal static class DerivationPlanner
             }
 
             var liveId = $"{baseId}_{tfStr}_live";
-            var finalId = $"{baseId}_{tfStr}_final";
             var live = new DerivedEntity
             {
                 Id = liveId,
@@ -127,20 +126,6 @@ internal static class DerivationPlanner
                 GraceSeconds = graceMap[tfStr]
             };
             entities.Add(live);
-
-            var final = new DerivedEntity
-            {
-                Id = finalId,
-                Role = Role.Final,
-                Timeframe = tf,
-                KeyShape = keyShapes,
-                ValueShape = valueShapes,
-                InputHint = hub,
-                BasedOnSpec = basedOn,
-                WeekAnchor = qao.WeekAnchor,
-                GraceSeconds = graceMap[tfStr]
-            };
-            entities.Add(final);
 
             var hb = new DerivedEntity
             {
@@ -164,7 +149,7 @@ internal static class DerivationPlanner
                     Timeframe = tf,
                     KeyShape = keyShapes,
                     ValueShape = valueShapes,
-                    InputHint = hub,
+                    InputHint = liveId,
                     BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor,
                     GraceSeconds = graceMap[tfStr]
@@ -181,7 +166,7 @@ internal static class DerivationPlanner
                     Timeframe = tf,
                     KeyShape = keyShapes,
                     ValueShape = valueShapes,
-                    InputHint = hub,
+                    InputHint = liveId,
                     BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor,
                     GraceSeconds = graceMap[tfStr]

--- a/tests/Query/Analysis/DerivationPlannerTests.cs
+++ b/tests/Query/Analysis/DerivationPlannerTests.cs
@@ -43,7 +43,7 @@ public class DerivationPlannerTests
     };
 
     [Fact]
-    public void Plan_1m_Includes_Live_Final_Hb()
+    public void Plan_1m_Includes_Live_Hb()
     {
         var model = new EntityModel { EntityType = typeof(Source) };
         var entities = DerivationPlanner.Plan(Create(new Timeframe(1, "m")), model);
@@ -51,8 +51,7 @@ public class DerivationPlannerTests
         var final1sStream = Assert.Single(entities, e => e.Id == "bar_1s_final_s" && e.Role == Role.Final1sStream);
         var live = Assert.Single(entities, e => e.Id == "bar_1m_live" && e.Role == Role.Live);
         Assert.Equal("bar_1s_final_s", live.InputHint);
-        var final = Assert.Single(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
-        Assert.Equal("bar_1s_final_s", final.InputHint);
+        Assert.DoesNotContain(entities, e => e.Id == "bar_1m_final");
         Assert.Contains(entities, e => e.Id == "bar_hb_1m" && e.Role == Role.Hb);
         Assert.Contains(entities, e => e.Id == "bar_hb_1s" && e.Role == Role.Hb);
     }
@@ -66,20 +65,20 @@ public class DerivationPlannerTests
         var final1sStream = Assert.Single(entities, e => e.Id == "bar_1s_final_s" && e.Role == Role.Final1sStream);
         var live5 = Assert.Single(entities, e => e.Id == "bar_5m_live" && e.Role == Role.Live);
         Assert.Equal("bar_1s_final_s", live5.InputHint);
-        var final = Assert.Single(entities, e => e.Id == "bar_5m_final" && e.Role == Role.Final);
-        Assert.Equal("bar_1s_final_s", final.InputHint);
+        Assert.DoesNotContain(entities, e => e.Id == "bar_5m_final");
         Assert.Contains(entities, e => e.Id == "bar_hb_5m" && e.Role == Role.Hb);
     }
 
     [Fact]
-    public void Plan_Windows_Use_Hub_Input()
+    public void Plan_Windows_Live_Use_Hub_Input()
     {
         var model = new EntityModel { EntityType = typeof(Source) };
         var entities = DerivationPlanner.Plan(Create(new Timeframe(1, "m"), new Timeframe(5, "m")), model);
-        var final1 = Assert.Single(entities, e => e.Id == "bar_1m_final" && e.Role == Role.Final);
-        Assert.Equal("bar_1s_final_s", final1.InputHint);
-        var final5 = Assert.Single(entities, e => e.Id == "bar_5m_final" && e.Role == Role.Final);
-        Assert.Equal("bar_1s_final_s", final5.InputHint);
+        var live1 = Assert.Single(entities, e => e.Id == "bar_1m_live" && e.Role == Role.Live);
+        Assert.Equal("bar_1s_final_s", live1.InputHint);
+        var live5 = Assert.Single(entities, e => e.Id == "bar_5m_live" && e.Role == Role.Live);
+        Assert.Equal("bar_1s_final_s", live5.InputHint);
+        Assert.DoesNotContain(entities, e => e.Id == "bar_1m_final" || e.Id == "bar_5m_final");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- drop final window generation for timeframes other than 1s
- route fill/prev input hints through their live window
- update derivation planner tests to assert new live-only behavior

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c18cdaa9ac8327bd458fe607fb508a