### PR TITLE
test: use live tables for non 1s windows

### DIFF
--- a/docs/diff_log/diff_query_final_live_tests_20250910.md
+++ b/docs/diff_log/diff_query_final_live_tests_20250910.md
@@ -1,0 +1,8 @@
+# diff_query_final_live_tests_20250910
+
+## Summary
+- tests under Query/Builders updated to expect live tables instead of final for windows >1s
+- ensure 1s final stream acts as source for live tables
+
+## Testing
+- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

--- a/tests/Query/Builders/RollupBuilderTests.cs
+++ b/tests/Query/Builders/RollupBuilderTests.cs
@@ -100,32 +100,29 @@ public class RollupBuilderTests
     }
 
     [Fact]
-    public void Final_Uses_Window_EmitFinal()
+    public void Live_Uses_Window_NoFinal()
     {
         var md = BuildMetadata();
-        var sql = FinalBuilder.Build(md, "5m");
+        var sql = LiveBuilder.Build(md, "5m");
         Assert.Contains("TABLE trade_raw_filtered_1s_final_s WINDOW TUMBLING(5m)", sql);
-        Assert.Contains("EMIT FINAL", sql);
+        Assert.DoesNotContain("EMIT FINAL", sql);
         Assert.DoesNotContain("SYNC", sql);
         Assert.DoesNotContain("COMPOSE(", sql);
-        var sql1 = FinalBuilder.Build(md, "1m");
+        var sql1 = LiveBuilder.Build(md, "1m");
         Assert.Contains("TABLE trade_raw_filtered_1s_final_s WINDOW TUMBLING(1m)", sql1);
+        Assert.DoesNotContain("EMIT FINAL", sql1);
         Assert.DoesNotContain("SYNC", sql1);
         Assert.DoesNotContain("COMPOSE(", sql1);
     }
 
     [Fact]
-    public void Builders_Expand_TimeFrame_Join_And_Boundary_For_Live_And_Final()
+    public void Builders_Expand_TimeFrame_Join_And_Boundary_For_Live()
     {
         var md = BuildMetadata();
         var live = LiveBuilder.Build(md, "1m");
-        var fin = FinalBuilder.Build(md, "1m");
-        foreach (var sql in new[] { live, fin })
-        {
-            Assert.Contains("JOIN", sql);
-            Assert.Contains("<=", sql);
-            Assert.Contains("<", sql);
-        }
+        Assert.Contains("JOIN", live);
+        Assert.Contains("<=", live);
+        Assert.Contains("<", live);
     }
 
     [Fact]

--- a/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
+++ b/tests/Query/Builders/WindowedQueryBuilderCoreTests.cs
@@ -40,49 +40,47 @@ public class WindowedQueryBuilderCoreTests
     }
 
     [Fact]
-    public void Core_Builds_Final_Window_EmitFinal_NoSync()
+    public void Core_Builds_Live_Window_NoFinal_NoSync()
     {
-        var q1 = FinalBuilder.Build(Md("1m"), "1m");
+        var q1 = LiveBuilder.Build(Md("1m"), "1m");
         Assert.StartsWith("TABLE bar_1s_final_s", q1);
         Assert.Contains("WINDOW TUMBLING(1m)", q1);
-        Assert.Contains("EMIT FINAL", q1);
+        Assert.DoesNotContain("EMIT FINAL", q1);
         Assert.DoesNotContain("SYNC", q1);
         Assert.DoesNotContain("COMPOSE(", q1);
 
-        var q5 = FinalBuilder.Build(Md("5m"), "5m");
+        var q5 = LiveBuilder.Build(Md("5m"), "5m");
         Assert.StartsWith("TABLE bar_1s_final_s", q5);
         Assert.Contains("WINDOW TUMBLING(5m)", q5);
+        Assert.DoesNotContain("EMIT FINAL", q5);
         Assert.DoesNotContain("SYNC", q5);
         Assert.DoesNotContain("COMPOSE(", q5);
     }
 
     [Fact]
-    public void FinalBuilder_Uses_PerTimeframe_Grace()
+    public void LiveBuilder_Uses_PerTimeframe_Grace()
     {
         var res = BaseRes("1m");
         res.GracePerTimeframe["1m"] = 4;
-        var q = FinalBuilder.Build(res.ToMetadata(), "1m");
+        var q = LiveBuilder.Build(res.ToMetadata(), "1m");
         Assert.Contains("WINDOW TUMBLING(1m GRACE PERIOD 4s)", q);
+        Assert.DoesNotContain("EMIT FINAL", q);
     }
 
     [Fact]
-    public void Core_Applies_TimeFrame_Join_And_Boundary_To_Live_And_Final()
+    public void Core_Applies_TimeFrame_Join_And_Boundary_To_Live()
     {
         var md = Md("1m");
         var live = LiveBuilder.Build(md, "1m");
-        var fin = FinalBuilder.Build(md, "1m");
-        foreach (var q in new[] { live, fin })
-            Assert.Contains("JOIN ON", q);
+        Assert.Contains("JOIN ON", live);
     }
 
     [Fact]
-    public void Builders_Expand_TimeFrame_Join_And_Boundary_For_Live_And_Final()
+    public void Builders_Expand_TimeFrame_Join_And_Boundary_For_Live()
     {
         var md = Md("1m");
         var live = LiveBuilder.Build(md, "1m");
-        var fin = FinalBuilder.Build(md, "1m");
         Assert.Contains("s.Open <= r.Ts", live);
-        Assert.Contains("s.Open <= r.Ts", fin);
     }
 }
 


### PR DESCRIPTION
## Summary
- verify live windows avoid EMIT FINAL for all non-1s timeframes
- add diff log for query final/live test updates

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c18e26b8f08327b705b357360e8c86