### PR TITLE
Use final stream hub for derivations

### DIFF
--- a/docs/diff_log/diff_final1s_hub_input_20251210.md
+++ b/docs/diff_log/diff_final1s_hub_input_20251210.md
@@ -1,0 +1,5 @@
+# Diff: final1s hub input
+
+- DerivedTumblingPipeline ignores `input` for `*_1s_final_s` so stream derives from base topic.
+- DerivationPlanner assigns `<base>_1s_final_s` as `InputHint` for all derived entities.
+- KsqlCreateWindowedStatementBuilder tests expect `*_1s_final_s` as the source topic.

--- a/src/Query/Analysis/DerivationPlanner.cs
+++ b/src/Query/Analysis/DerivationPlanner.cs
@@ -77,6 +77,7 @@ internal static class DerivationPlanner
                     Timeframe = tf,
                     KeyShape = keyShapes,
                     ValueShape = valueShapes,
+                    InputHint = hub,
                     BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor,
                     GraceSeconds = graceMap[tfStr]
@@ -90,7 +91,7 @@ internal static class DerivationPlanner
                     Timeframe = tf,
                     KeyShape = keyShapes,
                     ValueShape = valueShapes,
-                    InputHint = $"{baseId}_1s_final",
+                    InputHint = hub,
                     BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor,
                     GraceSeconds = graceMap[tfStr]
@@ -104,6 +105,7 @@ internal static class DerivationPlanner
                     Timeframe = tf,
                     KeyShape = keyShapes,
                     ValueShape = Array.Empty<ColumnShape>(),
+                    InputHint = hub,
                     BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor,
                     GraceSeconds = graceMap[tfStr]
@@ -134,6 +136,7 @@ internal static class DerivationPlanner
                 Timeframe = tf,
                 KeyShape = keyShapes,
                 ValueShape = Array.Empty<ColumnShape>(),
+                InputHint = hub,
                 BasedOnSpec = basedOn,
                 WeekAnchor = qao.WeekAnchor,
                 GraceSeconds = graceMap[tfStr]
@@ -149,7 +152,7 @@ internal static class DerivationPlanner
                     Timeframe = tf,
                     KeyShape = keyShapes,
                     ValueShape = valueShapes,
-                    InputHint = liveId,
+                    InputHint = hub,
                     BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor,
                     GraceSeconds = graceMap[tfStr]
@@ -166,7 +169,7 @@ internal static class DerivationPlanner
                     Timeframe = tf,
                     KeyShape = keyShapes,
                     ValueShape = valueShapes,
-                    InputHint = liveId,
+                    InputHint = hub,
                     BasedOnSpec = basedOn,
                     WeekAnchor = qao.WeekAnchor,
                     GraceSeconds = graceMap[tfStr]

--- a/src/Query/Analysis/DerivedTumblingPipeline.cs
+++ b/src/Query/Analysis/DerivedTumblingPipeline.cs
@@ -63,7 +63,7 @@ internal static class DerivedTumblingPipeline
     {
         var qm = queryModel.Clone();
         var inputOverride = baseName;
-        if (model.AdditionalSettings.TryGetValue("input", out var inputObj))
+        if (role != Role.Final1sStream && model.AdditionalSettings.TryGetValue("input", out var inputObj))
             inputOverride = inputObj?.ToString() ?? baseName;
         if (role == Role.Prev1m || role == Role.Final1sStream)
         {

--- a/tests/Query/Builders/KsqlCreateWindowedStatementBuilderTests.cs
+++ b/tests/Query/Builders/KsqlCreateWindowedStatementBuilderTests.cs
@@ -60,8 +60,13 @@ public class KsqlCreateWindowedStatementBuilderTests
             .Select(g => new { g.Key.Broker, g.Key.Symbol, BucketStart = g.WindowStart(), Open = g.EarliestByOffset(x => x.Bid) })
             .Build();
 
-        var sql = Kafka.Ksql.Linq.Query.Builders.KsqlCreateWindowedStatementBuilder.Build("bar_1m_live", model, "1m");
-        Assert.Contains("FROM DEDUPRATES o WINDOW TUMBLING", sql);
+        var sql = Kafka.Ksql.Linq.Query.Builders.KsqlCreateWindowedStatementBuilder.Build(
+            "bar_1m_live",
+            model,
+            "1m",
+            null,
+            "deduprates_1s_final_s");
+        Assert.Contains("FROM deduprates_1s_final_s o WINDOW TUMBLING", sql);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Ensure final stream hub reads from base topic by ignoring overridden input for `_1s_final_s`.
- Route all derived entities through `<base>_1s_final_s` and update builder tests accordingly.
- Document hub-based input hint in diff log.

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c1930cf1d48327a45defac45cb27dd