### PR TITLE
Ensure deterministic DDL order for derived tumbling pipeline

### DIFF
--- a/docs/diff_log/diff_derived_tumbling_pipeline_order_20250910.md
+++ b/docs/diff_log/diff_derived_tumbling_pipeline_order_20250910.md
@@ -1,0 +1,2 @@
+- Added test verifying DerivedTumblingPipeline emits DDL in deterministic order.
+- Renamed test topic attribute from `bar` to `foo`.

--- a/tests/Query/Analysis/DerivedTumblingPipelineOrderTests.cs
+++ b/tests/Query/Analysis/DerivedTumblingPipelineOrderTests.cs
@@ -1,0 +1,56 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Attributes;
+using Kafka.Ksql.Linq.Query.Analysis;
+using Kafka.Ksql.Linq.Query.Dsl;
+using Kafka.Ksql.Linq.Mapping;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Analysis;
+
+public class DerivedTumblingPipelineOrderTests
+{
+    [KsqlTopic("foo")]
+    public class TestSource
+    {
+        public int Id { get; set; }
+    }
+
+    [Fact]
+    public async Task Emits_DDL_in_expected_order()
+    {
+        var qao = new TumblingQao {
+            TimeKey = "Timestamp",
+            Windows = new[] { new Timeframe(1,"m"), new Timeframe(5,"m") },
+            Keys = new[] { "Id", "BucketStart" },
+            Projection = new[] { "Id", "BucketStart", "KsqlTimeFrameClose" },
+            PocoShape = new[] {
+                new ColumnShape("Id", typeof(int), false),
+                new ColumnShape("BucketStart", typeof(long), false),
+                new ColumnShape("KsqlTimeFrameClose", typeof(double), false)
+            },
+            BasedOn = new BasedOnSpec(new[] { "Id", "BucketStart" }, string.Empty, "KsqlTimeFrameClose", string.Empty),
+            WeekAnchor = DayOfWeek.Monday
+        };
+        var baseModel = new EntityModel { EntityType = typeof(TestSource) };
+        var model = new KsqlQueryModel { SourceTypes = new[] { typeof(TestSource) }, Windows = { "1m", "5m" } };
+
+        var order = new List<string>();
+        Task Exec(string sql) { order.Add(sql); return Task.CompletedTask; }
+
+        await DerivedTumblingPipeline.RunAsync(qao, baseModel, model, Exec,
+            _ => typeof(object), new MappingRegistry(), new(), NullLoggerFactory.Instance.CreateLogger("test"));
+
+        Assert.Collection(order,
+            ddl => Assert.StartsWith("CREATE TABLE foo_1s_final", ddl),
+            ddl => Assert.StartsWith("CREATE STREAM foo_1s_final_s", ddl),
+            ddl => Assert.StartsWith("CREATE TABLE foo_hb_1s", ddl),
+            ddl => Assert.StartsWith("CREATE TABLE foo_1m_live", ddl),
+            ddl => Assert.StartsWith("CREATE TABLE foo_5m_live", ddl)
+        );
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit test covering DDL emission ordering in DerivedTumblingPipeline
- rename test topic attribute to `foo` per review

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c1a82c8fe48327816bb51940d93390