### PR TITLE
chore: remove dead code

### DIFF
--- a/docs/diff_log/diff_deadcode_cleanup_20250911.md
+++ b/docs/diff_log/diff_deadcode_cleanup_20250911.md
@@ -1,0 +1,9 @@
+# diff_deadcode_cleanup_20250911
+
+## Summary
+- remove unused internal tracking property from GroupByClauseBuilder
+- delete commented-out cache helper methods
+
+## Testing
+- `dotnet build src/Kafka.Ksql.Linq.csproj`
+- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`

--- a/src/Cache/Extensions/KsqlContextCacheExtensions.cs
+++ b/src/Cache/Extensions/KsqlContextCacheExtensions.cs
@@ -201,21 +201,6 @@ internal static class KsqlContextCacheExtensions
         public string Apply(TKeyLocal key, TValueLocal value, IRecordContext context) => _f(key);
     }
 
-    //private static Lazy<object> CreateStoreLazyGeneric(Type keyType, Type valueType, IKafkaStreams streams, string storeName)
-    //{
-    //    var method = typeof(KsqlContextCacheExtensions).GetMethod(nameof(CreateStoreLazy), BindingFlags.NonPublic | BindingFlags.Static)!;
-    //    return (Lazy<object>)method.MakeGenericMethod(keyType, valueType).Invoke(null, new object[] { streams, storeName })!;
-    //}
-
-    //private static Lazy<object> CreateStoreLazy<TKey, TValue>(IKafkaStreams streams, string storeName)
-    //{
-    //    return new Lazy<object>(() =>
-    //    {
-    //        var parameters = StoreQueryParameters.FromNameAndType(storeName, QueryableStoreTypes.KeyValueStore<TKey, TValue>());
-    //        return streams.Store<TKey, TValue>(storeName, parameters);
-    //    });
-    //}
-
     private static object CreateTableCacheGeneric(Type entityType, MappingRegistry mapping,
         string storeName, Func<TimeSpan?, Task> wait,
         Lazy<Func<IEnumerable<(object key, object val)>>> enumerateLazy)

--- a/src/Query/Builders/GroupByClauseBuilder.cs
+++ b/src/Query/Builders/GroupByClauseBuilder.cs
@@ -13,7 +13,6 @@ namespace Kafka.Ksql.Linq.Query.Builders;
 /// </summary>
 internal class GroupByClauseBuilder : BuilderBase
 {
-    private static readonly AsyncLocal<Expression?> _lastGroupByExpression = new();
     private static readonly AsyncLocal<string?> _lastBuiltKeys = new();
     private readonly System.Collections.Generic.IDictionary<string, string>? _paramToSource;
 
@@ -21,12 +20,6 @@ internal class GroupByClauseBuilder : BuilderBase
     public GroupByClauseBuilder(System.Collections.Generic.IDictionary<string, string> paramToSource)
     {
         _paramToSource = paramToSource;
-    }
-
-    internal static Expression? LastGroupByExpression
-    {
-        get => _lastGroupByExpression.Value;
-        private set => _lastGroupByExpression.Value = value;
     }
 
     internal static string? LastBuiltKeys
@@ -44,7 +37,6 @@ internal class GroupByClauseBuilder : BuilderBase
 
     protected override string BuildInternal(Expression expression)
     {
-        LastGroupByExpression = expression;
         var visitor = _paramToSource == null
             ? new GroupByExpressionVisitor()
             : new GroupByExpressionVisitor(_paramToSource);


### PR DESCRIPTION
## Summary
- remove unused GroupByClauseBuilder tracking property
- delete commented-out cache helper methods

## Testing
- `dotnet build src/Kafka.Ksql.Linq.csproj`
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c2cb9bb050832780ee2f27ae166bb1