### PR TITLE
docs: clarify rollup and stream bullets

### DIFF
--- a/docs/chart_quickstart_user.md
+++ b/docs/chart_quickstart_user.md
@@ -82,9 +82,9 @@ var list = await ctx.Set<Bar>().ToListAsync();
 以下は利用者が実装時に意識しておくと迷わない要点です。
 - Select の投影に `g.WindowStart()` を一度だけ含めて、ウィンドウ開始時刻の列を出力してください。列名は自由です（例: `BucketStart = g.WindowStart()`）。複数回入れるとエラーになります。
 - 日足以上を作る場合は、dayKey（例: MarketDate）を付けてください。
-- 多段ロールアップは行わないでください（5m→15m ではなく、1s_final から派生させます）。
-- 確定系列に Hopping を混在させないでください（速報用途は別 DAG に分けます）。
-- 取得方式は、Table は `ToListAsync()`、Stream は Push（`ForEachAsync`）です。
+- すべての足は基底の1秒足から直接生成します（例: 5分足や15分足も1秒足から作ります）。
+- 確定値と速報値は処理を分けてください。
+- 取得方式は、Table は `ToListAsync()`、Stream は `ForEachAsync` で購読します。
 - 伝達時間は環境により変動します。通常は 50〜200ms、起動直後は 0.5〜3 秒が目安です。
 
 自動チェックと対処のコツ（困ったら見る）

--- a/docs/diff_log/diff_chart_quickstart_user_doc_update_20250912_v2.md
+++ b/docs/diff_log/diff_chart_quickstart_user_doc_update_20250912_v2.md
@@ -1,0 +1,15 @@
+# diff: refine quickstart rollup and stream bullets
+
+- Date: 2025-09-12
+- Authors: 葉月(編集), くすのき(記録), assistant(実装)
+
+## Summary
+- 明示的に1秒足から派生させることを説明
+- 確定値と速報値の処理を分ける指針を追加
+- Stream の購読方法を `ForEachAsync` に統一
+
+## Rationale
+- 初心者でも誤解しないよう専門語を避け、手順を簡潔に示すため。
+
+## Impact
+- ドキュメントのみの更新で、コードへの影響はありません。


### PR DESCRIPTION
## Summary
- explain rollup generation from 1-second base
- separate processing for finalized and preliminary values
- describe stream consumption via `ForEachAsync`

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` *(fails: MaxLengthAttribute not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c40b655bb083279cb25906e50a97d0