### PR TITLE
docs: tidy quickstart error handling

### DIFF
--- a/docs/chart_quickstart_user.md
+++ b/docs/chart_quickstart_user.md
@@ -86,6 +86,7 @@ var list = await ctx.Set<Bar>().ToListAsync();
 - 確定値と速報値は処理を分けてください。
 - 取得方式は、Table は `ToListAsync()`、Stream は `ForEachAsync` で購読します。
 - 伝達時間は環境により変動します。通常は 50〜200ms、起動直後は 0.5〜3 秒が目安です。
+上記を押さえたら、典型的な検証エラーと対処法も把握しておくとスムーズです。
 
 自動チェックと対処のコツ（困ったら見る）
 内部ルールの多くは自動で検証します。エラーが出たら次を確認してください。
@@ -95,7 +96,7 @@ var list = await ctx.Set<Bar>().ToListAsync();
   - 対処: 1 分以上の窓サイズは 1 分単位の整数倍にしてください（例: 1m, 5m, 15m）。
 - 「Windows must be multiples of the base unit」などの窓サイズ系エラー
   - 対処: 秒台の微妙なサイズ指定を避け、一般的なサイズ（1m/5m/15m/1h/1d など）を選んでください。
-※ BaseUnit や grace の詳細は内部で調整されます。通常は利用者が設定・調整する必要はありません。
+これで基礎的な検証エラーは解消できます。続いて命名規約も確認してください。
 
 命名規約（代表）
 - `<entity>_<timeframe>_(live|final)` の形式を使います（例: `bar_1m_live`, `bar_1d_live`）。

--- a/docs/diff_log/diff_chart_quickstart_user_doc_update_20250912_v3.md
+++ b/docs/diff_log/diff_chart_quickstart_user_doc_update_20250912_v3.md
@@ -1,0 +1,14 @@
+# diff: tidy quickstart error handling section
+
+- Date: 2025-09-12
+- Authors: 葉月(編集), くすのき(記録), assistant(実装)
+
+## Summary
+- Removed BaseUnit/grace note from "自動チェックと対処のコツ" section.
+- Added transition sentences before and after the section.
+
+## Rationale
+- Internal parameters are irrelevant to end users, and smoother prose aids comprehension.
+
+## Impact
+- Documentation only; no code changes.


### PR DESCRIPTION
## Summary
- remove internal BaseUnit/grace note from quickstart
- add transitions around "自動チェックと対処のコツ" section
- record change in diff log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` *(fails: MaxLengthAttribute not found)*
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c40c50452083279ec458a5d215e35d