### PR TITLE
docs: clarify chart quickstart step headings

### DIFF
--- a/docs/chart_quickstart_user.md
+++ b/docs/chart_quickstart_user.md
@@ -13,14 +13,14 @@
   `ToListAsync()` で高速に取得できます。
 
 すぐ試す（最短 5 ステップ）
-1) 事前準備をします
+1) 接続先を設定する（事前準備）
 - Kafka / ksqlDB / Schema Registry を起動しておきます。
 - `appsettings.json` に最低限の接続先を設定します。
   - `KsqlDsl:Common:BootstrapServers`
   - `KsqlDsl:SchemaRegistry:Url`
   - `KsqlDsl:KsqlDbUrl`
 
-2) コンテキストを作成します
+2) 接続できる状態を作る（Context 作成）
 ```csharp
 var cfg = new ConfigurationBuilder()
   .AddJsonFile("appsettings.json") // 接続先設定を読み込む
@@ -30,7 +30,7 @@ var ctx = KsqlContextBuilder.Create()
   .BuildContext<MyAppContext>();
 ```
 
-3) モデルを登録します（使う型にトピックを結びつけます）
+3) Rate をトピック "rates" に関連づける（モデル登録）
 ```csharp
 [KsqlTopic("rates")]
 public class Rate
@@ -42,7 +42,7 @@ public class Rate
 }
 ```
 
-4) クエリを定義します（日/週の境界 + 複数足 + OHLC）
+4) 日/週の境界を含む複数足を定義する（クエリ）
 ```csharp
 modelBuilder.Entity<Bar>().ToQuery(q => q
   .From<Rate>()
@@ -64,7 +64,7 @@ modelBuilder.Entity<Bar>().ToQuery(q => q
   }));
 ```
 
-5) 動作を確認します
+5) 送受信を確かめる（動作確認）
 - 送信します（Stream / Table 共通）。
 ```csharp
 await ctx.Set<Rate>().AddAsync(new Rate {

--- a/docs/diff_log/diff_chart_quickstart_user_doc_update_20250912_v6.md
+++ b/docs/diff_log/diff_chart_quickstart_user_doc_update_20250912_v6.md
@@ -1,0 +1,13 @@
+# diff: refine step headings in chart quickstart
+
+- Date: 2025-09-12
+- Authors: 葉月(編集), くすのき(記録), assistant(実装)
+
+## Summary
+- Adjusted five step headings in `docs/chart_quickstart_user.md` to clarify actions.
+
+## Rationale
+- Makes each step explicit about connection setup, context creation, model registration, query definition, and end-to-end verification.
+
+## Impact
+- Documentation only; no code changes.


### PR DESCRIPTION
## Summary
- clarify five quickstart steps for connection setup, context, model registration, query, and verification
- log chart quickstart step heading update

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` *(fails: MaxLengthAttribute missing)*
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c41043a1788327ae37ef8efdf0ba8d