### PR TITLE
docs: annotate push/pull and DAG in chart quickstart

### DIFF
--- a/docs/chart_quickstart_user.md
+++ b/docs/chart_quickstart_user.md
@@ -71,11 +71,11 @@ await ctx.Set<Rate>().AddAsync(new Rate {
   Broker = "B1", Symbol = "S1", Timestamp = DateTime.UtcNow, Bid = 100
 });
 ```
-- 受信します（Stream は Push 購読）。
+- 受信します（Stream は Push（購読方式））。
 ```csharp
 await ctx.Set<Bar>().ForEachAsync(b => { Console.WriteLine(b.Symbol); return Task.CompletedTask; });
 ```
-- 取得します（Table は RocksDB から Pull します）。
+- 取得します（Table は RocksDB から Pull（取得方式）します）。
 ```csharp
 var list = await ctx.Set<Bar>().ToListAsync();
 ```
@@ -85,7 +85,7 @@ var list = await ctx.Set<Bar>().ToListAsync();
 - Select には g.WindowStart() を 1 回だけ入れます（重複はエラー）。
 - 日足以上を作る場合は dayKey（同一営業日を識別するキー列）を付けます。
 - すべての足は基底の1秒足から直接生成します（例: 5分足や15分足も1秒足から作ります）。
-- 確定値（final）と速報値（live）は別DAG にします。
+- 確定値（final）と速報値（live）は別DAG（処理の流れ＝依存グラフ）にします。
 - 取得方式は、Table は `ToListAsync()`、Stream は `ForEachAsync` で購読します。
 - 伝達時間は環境により変動します。通常は 50〜200ms、起動直後は 0.5〜3 秒が目安です。
 上記を押さえたら、典型的な検証エラーと対処法も把握しておくとスムーズです。

--- a/docs/diff_log/diff_chart_quickstart_user_doc_update_20250912_v8.md
+++ b/docs/diff_log/diff_chart_quickstart_user_doc_update_20250912_v8.md
@@ -1,0 +1,13 @@
+# diff: annotate push/pull and DAG in quickstart
+
+- Date: 2025-09-12
+- Authors: 葉月(編集), くすのき(記録), assistant(実装)
+
+## Summary
+- Added brief parentheses explanations for Push/Pull and clarified DAG meaning in `docs/chart_quickstart_user.md`.
+
+## Rationale
+- Help users understand subscription versus retrieval methods and what a DAG represents in the chart context.
+
+## Impact
+- Documentation only; no code changes.


### PR DESCRIPTION
## Summary
- explain push and pull approaches in chart quickstart
- clarify DAG meaning

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` (fails: MaxLengthAttribute not found)
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c41243cef08327abeaa82bebf5124b