### PR TITLE
docs: highlight push pull terminology

### DIFF
--- a/docs/chart_quickstart_user.md
+++ b/docs/chart_quickstart_user.md
@@ -71,11 +71,11 @@ await ctx.Set<Rate>().AddAsync(new Rate {
   Broker = "B1", Symbol = "S1", Timestamp = DateTime.UtcNow, Bid = 100
 });
 ```
-- 受信します（Stream は Push（購読方式））。
+- 受信します（Stream は `Push（購読方式）`）。
 ```csharp
 await ctx.Set<Bar>().ForEachAsync(b => { Console.WriteLine(b.Symbol); return Task.CompletedTask; });
 ```
-- 取得します（Table は RocksDB から Pull（取得方式）します）。
+- 取得します（Table は RocksDB から `Pull（取得方式）` します）。
 ```csharp
 var list = await ctx.Set<Bar>().ToListAsync();
 ```

--- a/docs/diff_log/diff_chart_quickstart_user_doc_update_20250912_v9.md
+++ b/docs/diff_log/diff_chart_quickstart_user_doc_update_20250912_v9.md
@@ -1,0 +1,13 @@
+# diff: inline-code for Push/Pull clarification
+
+- Date: 2025-09-12
+- Authors: 葉月(編集), くすのき(記録), assistant(実装)
+
+## Summary
+- Wrapped "Push（購読方式）" and "Pull（取得方式）" in backticks in `docs/chart_quickstart_user.md`.
+
+## Rationale
+- Highlight the methods as technical terms for better readability.
+
+## Impact
+- Documentation only; no code changes.


### PR DESCRIPTION
## Summary
- wrap push and pull descriptions with inline code tags for clarity
- record documentation update in diff log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --filter 'FullyQualifiedName!~Integration'` *(fails: CS0246 MaxLengthAttribute not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c414006be88327a92a45d5af49d29e