### PR TITLE
docs: clarify chart quickstart stream/table retrieval

### DIFF
--- a/docs/chart_quickstart_user.md
+++ b/docs/chart_quickstart_user.md
@@ -71,11 +71,11 @@ await ctx.Set<Rate>().AddAsync(new Rate {
   Broker = "B1", Symbol = "S1", Timestamp = DateTime.UtcNow, Bid = 100
 });
 ```
-- 受信します（Stream は `Push（購読方式）`）。
+- 受信します（Stream は `ForEachAsync` で購読）。
 ```csharp
 await ctx.Set<Bar>().ForEachAsync(b => { Console.WriteLine(b.Symbol); return Task.CompletedTask; });
 ```
-- 取得します（Table は RocksDB から `Pull（取得方式）` します）。
+- 取得します（Table は RocksDB から `ToListAsync()` で取得）。
 ```csharp
 var list = await ctx.Set<Bar>().ToListAsync();
 ```


### PR DESCRIPTION
## Summary
- clarify that streams are received via `ForEachAsync`
- note table records are retrieved from RocksDB with `ToListAsync()`

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` *(fails: Duplicate 'System.Reflection' attributes)*
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c418b4e7d483278f06a9c56e211608