### PR TITLE
docs: clarify parent table in chart quickstart

### DIFF
--- a/docs/chart_quickstart_user.md
+++ b/docs/chart_quickstart_user.md
@@ -103,7 +103,7 @@ var list = await ctx.Set<Bar>().ToListAsync();
 命名規約（代表）
 - `<entity>_<timeframe>_(live|final)` の形式を使います（例: `bar_1m_live`, `bar_1d_live`）。
 - timeframe は `s`=秒, `m`=分, `h`=時間, `d`=日, `mo`=月 です。
-- 1s_final / 1s_final_s は上位足の唯一の親です。
+- `1s_final` テーブルが上位足の親になります。
 
 トラブル対策（抜粋）
 - 反映が遅い場合は、起動直後に数秒待機し、短いポーリングで再試行してください。

--- a/docs/diff_log/diff_chart_quickstart_user_line106_update_20250912.md
+++ b/docs/diff_log/diff_chart_quickstart_user_line106_update_20250912.md
@@ -1,0 +1,13 @@
+# diff: clarify parent table line in chart quickstart
+
+- Date: 2025-09-12
+- Authors: 葉月(編集), くすのき(記録), assistant(実装)
+
+## Summary
+- Rephrased naming convention note to say `1s_final` table is the parent for higher timeframes.
+
+## Rationale
+- Original wording `1s_final / 1s_final_s` was unclear; single-table phrasing aids comprehension.
+
+## Impact
+- Documentation only; no code changes.


### PR DESCRIPTION
## Summary
- clarify that `1s_final` table is parent for higher timeframes in chart quickstart doc
- log the change in diff_log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` *(fails: MaxLengthAttribute not found)*
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c419c38b748327bb2af7d6852f48d8