### PR TITLE
docs: clarify chart quickstart step heading

### DIFF
--- a/docs/chart_quickstart_user.md
+++ b/docs/chart_quickstart_user.md
@@ -12,7 +12,7 @@
 - Table を RocksDB（内部ストレージ）にマテリアライズし、
   `ToListAsync()` で高速に取得できます。
 
-最短5ステップで試す
+5ステップで動作を確認する
 1) 接続先を設定する
 - Kafka / ksqlDB / Schema Registry を起動しておきます。
 - `appsettings.json` に最低限の接続先を設定します。

--- a/docs/diff_log/diff_chart_quickstart_user_line15_update_20250912.md
+++ b/docs/diff_log/diff_chart_quickstart_user_line15_update_20250912.md
@@ -1,0 +1,13 @@
+# diff: clarify step heading in chart quickstart
+
+- Date: 2025-09-12
+- Authors: 葉月(編集), くすのき(記録), assistant(実装)
+
+## Summary
+- Update line 15 heading to "5ステップで動作を確認する" for clearer action-oriented phrasing.
+
+## Rationale
+- Emphasizes verifying behavior in five steps to guide readers toward confirmation rather than mere trial.
+
+## Impact
+- Documentation only; no code changes.


### PR DESCRIPTION
## Summary
- rephrase step heading for clearer action focus
- record change in diff log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` *(fails: duplicate `TargetFrameworkAttribute` and others)*
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c426c60ac483279e8531bb27eaa38b