### PR TITLE
fix: repair example README links

### DIFF
--- a/docs/diff_log/diff_examples_link_fix_20250915.md
+++ b/docs/diff_log/diff_examples_link_fix_20250915.md
@@ -1,0 +1,8 @@
+# diff_examples_link_fix_20250915
+
+## Summary
+- Fixed broken documentation links in example README files.
+
+## Testing
+- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj`
+- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`

--- a/examples/configuration-mapping/README.md
+++ b/examples/configuration-mapping/README.md
@@ -24,6 +24,5 @@ The default `appsettings.json` is tuned for debugging with `LogLevel:Debug`.
 
 ## Design Document Reference
 
-- [Logging and query visibility](../../docs/oss_design_combined.md#8-logging-and-query-visibility)
-
-This sample corresponds to [docs_configuration_reference.md](../../docs/docs_configuration_reference.md).
+- [Kafka.Ksql.Linq user guide](../../docs/kafka_ksql_linq_user_guide.md)
+- [configuration_reference.md](../../docs/configuration_reference.md)

--- a/examples/configuration/README.md
+++ b/examples/configuration/README.md
@@ -23,5 +23,5 @@ cd examples/configuration
 - `examples/schema-attributes`: `[KsqlKey]` / `[KsqlDecimal]` / `[KsqlTimestamp]`
 
 ## References
-- Function/type mapping: `docs/ksql-function-type-mapping.md`
-- SQLServer → ksqlDB guide: `docs/sqlserver-to-kafka-guide.md`
+- Function/type mapping: `../../docs/ksql-function-type-mapping.md`
+- SQLServer → ksqlDB guide: `../../docs/sqlserver-to-kafka-guide.md`

--- a/examples/daily-comparison/README.md
+++ b/examples/daily-comparison/README.md
@@ -2,7 +2,7 @@
 
 This example demonstrates a simple rate ingestion and daily aggregation using **Kafka.Ksql.Linq** only.
 All settings including logging and Schema Registry configuration are read from
-`appsettings.json` following `docs/docs_configuration_reference.md`.
+`appsettings.json` following `../../docs/configuration_reference.md`.
 `MyKsqlContext.FromAppSettings()` builds the context directly from this file.
 Bar and window definitions (1, 5, 60 minute bars and daily bars) are declared in `KafkaKsqlContext.OnModelCreating`.
 

--- a/examples/error-handling-dlq/README.md
+++ b/examples/error-handling-dlq/README.md
@@ -5,7 +5,7 @@ and `.WithRetry(3)`. Records that fail processing are forwarded to the configure
 Dead Letter Queue after retries.
 
 This sample maps to
-[docs_advanced_rules.md](../../docs/docs_advanced_rules.md) section about
+[advanced_rules.md](../../docs/advanced_rules.md) section about
 `OnError` and retry strategies.
 
 ## Prerequisites

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -24,8 +24,4 @@ stream is ready using `WaitForEntityReadyAsync`, and then consumes it with
 
 ## Design Document References
 
-- [POCO structure and attributes](../../docs/oss_design_combined.md#3-poco-attribute-based-dsl-design-rules-fluent-api-elimination-policy)
-- [Schema registration](../../docs/oss_design_combined.md#4-schema-building-and-initialization-procedures-onmodelcreating)
-- [Produce operations](../../docs/oss_design_combined.md#5-produce-operations)
-- [Consume operations](../../docs/oss_design_combined.md#6-consume-operations-retry-error-dlq-commit-misconceptions)
-- [Logging and query visibility](../../docs/oss_design_combined.md#8-logging-and-query-visibility)
+- [Kafka.Ksql.Linq user guide](../../docs/kafka_ksql_linq_user_guide.md)

--- a/examples/index.md
+++ b/examples/index.md
@@ -55,6 +55,6 @@ dotnet run --project examples/basic-produce-consume
 ---
 
 ## Reference Docs (click to open)
-- OnModelCreating samples: `docs/onmodelcreating_samples.md`
-- Function/type mapping: `docs/ksql-function-type-mapping.md`
-- SQLServer → ksqlDB guide: `docs/sqlserver-to-kafka-guide.md`
+- OnModelCreating samples: `../docs/onmodelcreating_samples.md`
+- Function/type mapping: `../docs/ksql-function-type-mapping.md`
+- SQLServer → ksqlDB guide: `../docs/sqlserver-to-kafka-guide.md`

--- a/examples/manual-commit/README.md
+++ b/examples/manual-commit/README.md
@@ -23,8 +23,5 @@ Call `context.Orders.Commit(entity)` after successful processing to record the o
 
 ## Design Document References
 
-- [Manual commit operation](../../docs/manual_commit.md)
-- [POCO attribute design](../../docs/oss_design_combined.md#3-poco-attribute-based-dsl-design-rules-fluent-api-elimination-policy)
-- [Schema initialization](../../docs/oss_design_combined.md#4-schema-building-and-initialization-procedures-onmodelcreating)
-
-See the manual commit API in [api_reference.md](../../docs/api_reference.md).
+- [Kafka.Ksql.Linq user guide](../../docs/kafka_ksql_linq_user_guide.md)
+- [API reference](../../docs/api_reference.md)

--- a/examples/windowing/README.md
+++ b/examples/windowing/README.md
@@ -14,11 +14,11 @@ Prerequisites
 - Start Kafka + Schema Registry + ksqlDB (`docker-compose -f tools/docker-compose.kafka.yml up -d`)
 
 Minimal steps
-1) Define windows and aggregates in OnModelCreating (see `docs/onmodelcreating_samples.md#7-time-window-tumbling-1min-push`).
+1) Define windows and aggregates in OnModelCreating (see `../../docs/onmodelcreating_samples.md#7-time-window-tumbling-1min-push`).
 2) Feed sample data (any Producer is fine, `examples/basic-produce-consume` works).
 3) Use a Push query (EMIT CHANGES) to watch live results.
 4) Layer a 5-minute roll-up on top of the 1-minute aggregation and confirm the numbers align.
 
 Notes
-- For diagrams of Streams/Tables and Pull/Push, see `docs/sqlserver-to-kafka-guide.md`.
-- ksqlDB function/type mapping: `docs/ksql-function-type-mapping.md`
+- For diagrams of Streams/Tables and Pull/Push, see `../../docs/sqlserver-to-kafka-guide.md`.
+- ksqlDB function/type mapping: `../../docs/ksql-function-type-mapping.md`


### PR DESCRIPTION
## Summary
- fix broken documentation links across example READMEs
- record link fixes in diff log

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj` *(fails: 25 failed, 524 passed, 30 skipped)*
- `dotnet test tests/Kafka.Ksql.Linq.Cache.Tests/Kafka.Ksql.Linq.Cache.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c7957b423883328c0d1ce826f05a60